### PR TITLE
Integrated Font Awesome

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ CSSMIN = ./node_modules/.bin/cssmin
 UGLIFYJS = ./node_modules/.bin/uglifyjs
 TESTEM = ./node_modules/.bin/testem
 
-DOCS = docs/index.html docs/index.js docs/index.css docs/jquery.js docs/img docs/widgets.html docs/widgets.js docs/widgets.css docs/widgets.png docs/widgets-spinner.gif docs/toolbar.html docs/toolbar_init.js docs/toolbar_init.css docs/toolbar.js docs/toolbar.css docs/toolbar.png docs/patterns.html docs/patterns.css docs/patterns.js docs/patterns.png docs/patterns-spinner.gif
+DOCS = docs/index.html docs/index.js docs/index.css docs/jquery.js docs/img docs/widgets.html docs/widgets.js docs/widgets.css docs/widgets.png docs/widgets-spinner.gif docs/toolbar.html docs/toolbar_init.js docs/toolbar_init.css docs/toolbar.js docs/toolbar.css docs/patterns.html docs/patterns.css docs/patterns.js docs/patterns.png docs/patterns-spinner.gif docs/font
 WIDGETS = build/widgets.js build/widgets.min.js build/widgets.css build/widgets.png build/widgets-spinner.gif
-TOOLBAR = build/toolbar_init.js build/toolbar_init.min.js build/toolbar_init.css build/toolbar.js build/toolbar.min.js build/toolbar.css build/toolbar.png
+TOOLBAR = build/toolbar_init.js build/toolbar_init.min.js build/toolbar_init.css build/toolbar.js build/toolbar.min.js build/toolbar.css build/toolbar-webfont.eot build/toolbar-webfont.ttf build/toolbar-webfont.woff build/toolbar-webfont.otf
 
 all:: widgets toolbar
 
@@ -56,6 +56,7 @@ docs/index.css:
 	$(CSSMIN) jam/SyntaxHighlighter/styles/shCore.css > $@
 	$(CSSMIN) less/shThemeGitHub.css >> $@
 	$(LESSC) less/mockup.less | $(CSSMIN) >> $@
+	sed -i -e 's@../jam/font-awesome/@@g' $@
 
 docs/jquery.js:
 	$(UGLIFYJS) jam/jquery/dist/jquery.js > $@
@@ -63,7 +64,10 @@ docs/jquery.js:
 docs/img:
 	mkdir $@
 	cp img/* $@
-	cp jam/bootstrap/img/glyphicons-halflings.png $@
+
+docs/font:
+	mkdir $@
+	cp jam/font-awesome/font/* $@
 
 docs/widgets.html:
 	cp widgets.html $@
@@ -92,7 +96,7 @@ docs/widgets.css:
 	$(LESSC) less/mockup.less | $(CSSMIN) >> $@
 	sed -i -e 's@select2.png@widgets.png@g' $@
 	sed -i -e 's@select2-spinner.gif@widgets-spinner.gif@g' $@
-	sed -i -e 's@jam/bootstrap/img/glyphicons-halflings.png@img/glyphicons-halflings.png@g' $@
+	sed -i -e 's@../jam/font-awesome/@@g' $@
 
 docs/widgets.png:
 	cp jam/select2/select2.png $@
@@ -118,6 +122,7 @@ docs/toolbar_init.js:
 
 docs/toolbar_init.css:
 	$(LESSC) less/mockup.less | $(CSSMIN) > $@
+	sed -i -e 's@../jam/font-awesome/@@g' $@
 
 docs/toolbar.js:
 	$(JAM) compile -i js/demo/toolbar -e jquery --no-minify --almond $@
@@ -128,10 +133,7 @@ docs/toolbar.css:
 	$(CSSMIN) jam/select2/select2.css > $@
 	$(CSSMIN) jam/pickadate/themes/pickadate.02.classic.css >> $@
 	$(LESSC) less/toolbar.less | $(CSSMIN) >> $@
-	sed -i -e 's@../img/glyphicons-halflings.png@toolbar.png@g' $@
-
-docs/toolbar.png:
-	cp jam/bootstrap/img/glyphicons-halflings.png $@
+	sed -i -e 's@../jam/font-awesome/@@g' $@
 
 docs/patterns.html:
 	cp patterns.html $@
@@ -158,11 +160,11 @@ docs/patterns.css:
 	$(CSSMIN) less/shThemeGitHub.css >> $@
 	$(CSSMIN) jam/select2/select2.css >> $@
 	$(CSSMIN) jam/pickadate/themes/pickadate.02.classic.css >> $@
-	$(LESSC) less/mockup.less | $(CSSMIN) >> $@
 	$(LESSC) less/widgets.less | $(CSSMIN) >> $@
+	$(LESSC) less/mockup.less | $(CSSMIN) >> $@
 	sed -i -e 's@select2.png@patterns.png@g' $@
 	sed -i -e 's@select2-spinner.gif@patterns-spinner.gif@g' $@
-	sed -i -e 's@jam/bootstrap/img/glyphicons-halflings.png@img/glyphicons-halflings.png@g' $@
+	sed -i -e 's@../jam/font-awesome/@@g' $@
 
 docs/patterns.js:
 	$(UGLIFYJS) jam/less/dist/less-1.3.3.js > $@
@@ -218,7 +220,7 @@ build/toolbar_init.min.js:
 	$(UGLIFYJS) js/iframe.js > $@
 
 build/toolbar_init.css:
-	$(LESSC) less/toolbar_init.less | $(CSSMIN) >> $@                           
+	$(LESSC) less/toolbar_init.less | $(CSSMIN) >> $@
 
 build/toolbar.js:
 	$(JAM) compile -i js/bundles/toolbar -e jquery --no-minify --almond $@
@@ -227,13 +229,26 @@ build/toolbar.js:
 build/toolbar.min.js: build/toolbar.js
 	$(UGLIFYJS) build/toolbar.js > $@
 
+build/toolbar-webfont.eot:
+	cp jam/font-awesome/font/fontawesome-webfont.eot $@
+
+build/toolbar-webfont.ttf:
+	cp jam/font-awesome/font/fontawesome-webfont.ttf $@
+
+build/toolbar-webfont.woff:
+	cp jam/font-awesome/font/fontawesome-webfont.woff $@
+
+build/toolbar-webfont.otf:
+	cp jam/font-awesome/font/FontAwesome.otf $@
+
 build/toolbar.css: build/widgets.css
 	cat build/widgets.css > $@
-	$(LESSC) less/toolbar.less | $(CSSMIN) >> $@                                
-	sed -i -e 's@../img/glyphicons-halflings.png@++resource++plone.app.toolbar.png@g' $@
+	$(LESSC) less/toolbar.less | $(CSSMIN) >> $@
+	sed -i -e 's@../jam/font-awesome/font/fontawesome-webfont.eot@++resource++plone.app.toolbar.eot@g' $@
+	sed -i -e 's@../jam/font-awesome/font/fontawesome-webfont.ttf@++resource++plone.app.toolbar.ttf@g' $@
+	sed -i -e 's@../jam/font-awesome/font/fontawesome-webfont.woff@++resource++plone.app.toolbar.woff@g' $@
+	sed -i -e 's@../jam/font-awesome/font/fontawesome-webfont.otf@++resource++plone.app.toolbar.otf@g' $@
 
-build/toolbar.png:
-	cp jam/bootstrap/img/glyphicons-halflings.png $@
 
 
-.PHONY: all clean bootstrap test test-ci docs publish-demo widgets toolbar 
+.PHONY: all clean bootstrap test test-ci docs publish-demo widgets toolbar

--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -1,0 +1,65 @@
+/*!
+ * Bootstrap v2.2.2
+ *
+ * Copyright 2012 Twitter, Inc
+ * Licensed under the Apache License v2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Designed and built with all the love in the world @twitter by @mdo and @fat.
+ */
+
+// CSS Reset
+@import "../jam/bootstrap/less/reset.less";
+
+// Core variables and mixins
+@import "../jam/bootstrap/less/variables.less"; // Modify this for custom colors, font-sizes, etc
+@import "../jam/bootstrap/less/mixins.less";
+
+// Grid system and page structure
+@import "../jam/bootstrap/less/scaffolding.less";
+@import "../jam/bootstrap/less/grid.less";
+@import "../jam/bootstrap/less/layouts.less";
+
+// Base CSS
+@import "../jam/bootstrap/less/type.less";
+@import "../jam/bootstrap/less/code.less";
+@import "../jam/bootstrap/less/forms.less";
+@import "../jam/bootstrap/less/tables.less";
+
+// Components: common
+// @import "../jam/bootstrap/less/sprites.less";
+@import "../jam/font-awesome/less/font-awesome.less";
+@FontAwesomePath: "../jam/font-awesome/font";
+@import "../jam/bootstrap/less/dropdowns.less";
+@import "../jam/bootstrap/less/wells.less";
+@import "../jam/bootstrap/less/component-animations.less";
+@import "../jam/bootstrap/less/close.less";
+
+// Components: Buttons & Alerts
+@import "../jam/bootstrap/less/buttons.less";
+@import "../jam/bootstrap/less/button-groups.less";
+@import "../jam/bootstrap/less/alerts.less"; // Note: alerts share common CSS with buttons and thus have styles in buttons.less
+
+// Components: Nav
+@import "../jam/bootstrap/less/navs.less";
+@import "../jam/bootstrap/less/navbar.less";
+@import "../jam/bootstrap/less/breadcrumbs.less";
+@import "../jam/bootstrap/less/pagination.less";
+@import "../jam/bootstrap/less/pager.less";
+
+// Components: Popovers
+@import "../jam/bootstrap/less/modals.less";
+@import "../jam/bootstrap/less/tooltip.less";
+@import "../jam/bootstrap/less/popovers.less";
+
+// Components: Misc
+@import "../jam/bootstrap/less/thumbnails.less";
+@import "../jam/bootstrap/less/media.less";
+@import "../jam/bootstrap/less/labels-badges.less";
+@import "../jam/bootstrap/less/progress-bars.less";
+@import "../jam/bootstrap/less/accordion.less";
+@import "../jam/bootstrap/less/carousel.less";
+@import "../jam/bootstrap/less/hero-unit.less";
+
+// Utility classes
+@import "../jam/bootstrap/less/utilities.less"; // Has to be last to override when necessary

--- a/less/mockup.less
+++ b/less/mockup.less
@@ -1,6 +1,6 @@
 @import url(http://fonts.googleapis.com/css?family=Inconsolata:400,700);
 
-@import "../jam/bootstrap/less/bootstrap.less";
+@import "bootstrap.less";
 @import "../jam/bootstrap/less/responsive.less";
 
 @import "plonelogo.less";
@@ -33,8 +33,23 @@ footer {
 }
 .pat-datetime-wrapper {
   .pat-datetime-icon {
-    background-image: url("jam/bootstrap/img/glyphicons-halflings.png");
-    .icon-calendar();
+    font-family: FontAwesome;
+    font-weight: normal;
+    font-style: normal;
+    text-decoration: inherit;
+    display: inline;
+    width: auto;
+    height: auto;
+    line-height: normal;
+    vertical-align: super;
+    background: none;
+    background-image: none;
+    background-position: 0% 0%;
+    background-repeat: repeat;
+    margin: 0 0.4em;
+  }
+  .pat-datetime-icon:before {
+    content: "\f073";
   }
 }
 .syntaxhighlighter {

--- a/less/toolbar.less
+++ b/less/toolbar.less
@@ -1,4 +1,5 @@
 @import "widgets.less";
+@import "bootstrap.less";
 @import "plonetoolbar.less";
 
 
@@ -39,7 +40,7 @@ body {
   .modal-body {
     max-height: none;
     overflow-y: visible;
-    padding: 0 15px;   
+    padding: 0 15px;
   }
 
   .backdrop {
@@ -94,17 +95,24 @@ body {
       margin: 0 0.2em;
     }
     .pat-datetime-icon {
-      background-image: url("++resource++plone.app.toolbar.png");
-      background-position: 14px 14px;
-      background-repeat: no-repeat;
-      display: inline-block;
-      height: 14px;
-      line-height: 14px;
-      margin-top: 1px;
-      margin-bottom: 0.5em;
-      vertical-align: middle;
-      width: 14px;
-      .icon-calendar();
+      margin: 0 0.4em;
+      cursor: pointer;
+      font-family: FontAwesome;
+      font-weight: normal;
+      font-style: normal;
+      text-decoration: inherit;
+      display: inline;
+      width: auto;
+      height: auto;
+      line-height: normal;
+      vertical-align: super;
+      background: none;
+      background-image: none;
+      background-position: 0% 0%;
+      background-repeat: repeat;
+    }
+    .pat-datetime-icon:before {
+      content: "\f073";
     }
   }
   input.destructive[type='submit'] {
@@ -133,7 +141,7 @@ body {
       }
     }
     dd {
-      margin-left: 2em;      
+      margin-left: 2em;
     }
   }
   dl.portalMessage {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "pickadate": ">=2.0.6",
       "jquery-form": ">=3.25.0",
       "bootstrap": ">=2.2.2",
+      "font-awesome": ">=3.0.0",
       "logging": ">=1.0.0-jam.1"
     }
   },

--- a/patterns.html
+++ b/patterns.html
@@ -13,8 +13,8 @@
   <link href="less/shThemeGitHub.css" rel="stylesheet" type="text/css" />
   <link rel="stylesheet" type="text/css" href="jam/select2/select2.css" />
   <link rel="stylesheet" type="text/css" href="jam/pickadate/themes/pickadate.02.classic.css" />
-  <link rel="stylesheet/less" type="text/css" href="less/mockup.less" />
   <link rel="stylesheet/less" type="text/css" href="less/widgets.less" />
+  <link rel="stylesheet/less" type="text/css" href="less/mockup.less" />
   <script src="jam/less/dist/less-1.3.3.js"></script>
   <script src="jam/jquery/dist/jquery.js"></script>
   <script src="jam/require.js"></script>

--- a/widgets.html
+++ b/widgets.html
@@ -13,8 +13,8 @@
   <link href="less/shThemeGitHub.css" rel="stylesheet" type="text/css" />
   <link rel="stylesheet" type="text/css" href="jam/select2/select2.css" />
   <link rel="stylesheet" type="text/css" href="jam/pickadate/themes/pickadate.02.classic.css" />
-  <link rel="stylesheet/less" type="text/css" href="less/mockup.less" />
   <link rel="stylesheet/less" type="text/css" href="less/widgets.less" />
+  <link rel="stylesheet/less" type="text/css" href="less/mockup.less" />
   <script src="jam/less/dist/less-1.3.3.js"></script>
   <script src="jam/jquery/dist/jquery.js"></script>
   <script src="jam/require.js"></script>


### PR DESCRIPTION
Added Font Awesome to mockup.
- Added new package dependency
- Created new bootstrap.less (required for awesome)
- plone.app.widgets does not build with font-awesome
- mockup builds with font awesome
- plone.app.toolbar builds with font-awesome

Font Awesome files are copied to build/toolbar-webfont.\* , I chose this naming so that the same copy command could be used to update plone.app.toolbar. plone.app.toolbar also needs some modification:
- Remove resource plone.app.toolbar.png
- Add resources for fonts:
      plone.app.toolbar.ttf, plone.app.toolbar.woff etc.

I have the changes required on plone.app.toolbar available locally, can supply those also.
