### PR TITLE
Make sure checked state of checkboxes gets cloned correctly in IE9 when loading modal

### DIFF
--- a/js/patterns/modal.js
+++ b/js/patterns/modal.js
@@ -313,6 +313,10 @@ define([
           return;
         }
         var $raw = self.$raw.clone();
+        // fix for IE9 bug (see http://bugs.jquery.com/ticket/10550)
+        $('input:checked', $raw).each(function() {
+          if (this.setAttribute) this.setAttribute('checked', 'checked');
+        });
 
         // Object that will be passed to the template
         var tpl_object = {


### PR DESCRIPTION
This fixes plone/mockup#238
