### PR TITLE
Improve tinymce links/images modals + improved autotoc docs

### DIFF
--- a/js/patterns/autotoc.js
+++ b/js/patterns/autotoc.js
@@ -12,9 +12,11 @@
  *    section(string): Tag type to use for TOC. ('section')
  *
  * Documentation:
- *    # Set custom levels
- *
+ *    # TOC
  *    {{ example-1 }}
+ *
+ *    # Tabs
+ *    {{ example-2-tabs }}
  *
  * Example: example-1
  *    <div class="pat-autotoc"
@@ -32,6 +34,36 @@
  *      <p>You boys know how to shovel coal? Don't worry, these young
  *      beauties have been nowhere near the bananas. I thought the two of
  *      us could talk man-on-man.</p>
+ *    </div>
+ *
+ * Example: example-2-tabs
+ *    <div class="pat-autotoc autotabs"
+ *          data-pat-autotoc="section:fieldset;levels:legend;">
+ *        <fieldset>
+ *          <legend>Tab 1</legend>
+ *          <div>
+ *            Lorem ipsum dolor sit amet, ex nam odio ceteros fastidii,
+ *            id porro lorem pro, homero facilisis in cum.
+ *            At doming voluptua indoctum mel, natum noster similique ne mel.
+ *          </div>
+ *        </fieldset>
+ *        <fieldset>
+ *          <legend>Tab 2</legend>
+ *          <div>
+ *            Reque repudiare eum et. Prompta expetendis percipitur eu eam,
+ *            et graece mandamus pro, eu vim harum audire tractatos.
+ *            Ad perpetua salutandi mea, soluta delicata aliquando eam ne.
+ *            Qui nostrum lucilius perpetua ut, eum suas stet oblique ut.
+ *          </div>
+ *        </fieldset>
+ *        <fieldset>
+ *          <legend>Tab 3</legend>
+ *          <div>
+ *            Vis mazim harum deterruisset ex, duo nemore nostro civibus ad,
+ *            eros vituperata id cum. Vim at erat solet soleat,
+ *            eum et iuvaret luptatum, pro an esse dolorum maiestatis.
+ *          </div>
+ *        </fieldset>
  *    </div>
  *
  * License:
@@ -56,10 +88,10 @@ define([
   'jquery',
   'mockup-patterns-base'
 ], function($, Base) {
-  "use strict";
+  'use strict';
 
   var AutoTOC = Base.extend({
-    name: "autotoc",
+    name: 'autotoc',
     defaults: {
       section: 'section',
       levels: 'h1,h2,h3',
@@ -92,6 +124,8 @@ define([
 
       $(self.options.section, self.$el).addClass(self.options.classSectionName);
 
+      var as_tabs = self.$el.hasClass('autotabs');
+
       $(self.options.levels, self.$el).each(function(i) {
         var $level = $(this),
             id = $level.prop('id') ? '#' + $level.prop('id') :
@@ -115,7 +149,10 @@ define([
             $(e.target).addClass(self.options.classActiveName);
             $level.parents(self.options.section)
                 .addClass(self.options.classActiveName);
-            if (doScroll !== false && self.options.scrollDuration && $level) {
+            if (doScroll !== false &&
+                self.options.scrollDuration &&
+                $level &&
+                !as_tabs) {
               $('body,html').animate({
                 scrollTop: $level.offset().top
               }, self.options.scrollDuration, self.options.scrollEasing);

--- a/js/patterns/tinymce/links.js
+++ b/js/patterns/tinymce/links.js
@@ -32,8 +32,10 @@ define([
   'mockup-patterns-modal',
   'tinymce',
   'mockup-patterns-dropzone',
-  'text!js/patterns/tinymce/templates/link.xml'
-], function($, _, Base, RelatedItems, Modal, tinymce, DropZone, LinkTemplate) {
+  'text!js/patterns/tinymce/templates/link.xml',
+  'text!js/patterns/tinymce/templates/image.xml'
+], function($, _, Base, RelatedItems, Modal, tinymce, DropZone,
+            LinkTemplate, ImageTemplate) {
   "use strict";
 
   var LinkType = Base.extend({
@@ -314,7 +316,21 @@ define([
         'externalImage': LinkType
       }
     },
-    template: _.template(LinkTemplate),
+    // XXX: this is a temporary work around for having separated templates.
+    // Image modal is going to have its own modal class, funcs and template.
+    linkTypeTemplateMapping: {
+      'internal': LinkTemplate,
+      'external': LinkTemplate,
+      'email': LinkTemplate,
+      'anchor': LinkTemplate,
+      'image': ImageTemplate,
+      'externalImage': ImageTemplate
+    },
+
+    template: function(data){
+      return  _.template(this.linkTypeTemplateMapping[this.linkType])(data);
+    },
+
     init: function(){
       var self = this;
       self.tinypattern = self.options.tinypattern;
@@ -370,7 +386,7 @@ define([
 
       /* load up all the link types */
       _.each(self.options.linkTypes, function(type){
-        var $container = $('.linkType.main.' + type, self.modal.$modal);
+        var $container = $('.linkType.' + type + ' .main', self.modal.$modal);
         self.linkTypes[type] = new self.options.linkTypeClassMapping[type]($container, {
           linkModal: self,
           tinypattern: self.tinypattern
@@ -383,13 +399,6 @@ define([
       if($linkType.length > 0){
         $linkType[0].checked = true;
       }
-      self.activateLinkTypeElements();
-    },
-    activateLinkTypeElements: function(){
-      /* handle specify url types */
-      var self = this;
-      $('.linkType', self.modal.$modal).hide();
-      $('.' + self.linkType).show();
     },
     getLinkUrl: function(){
       // get the url, only get one uid
@@ -478,10 +487,6 @@ define([
       $('.modal-footer input[name="cancel"]', self.modal.$modal).click(function(e){
         e.preventDefault();
         self.hide();
-      });
-      $('.linkTypes input:radio', self.modal.$modal).change(function(){
-        self.linkType = $(this).val();
-        self.activateLinkTypeElements();
       });
       self.setupDropzone();
     },

--- a/js/patterns/tinymce/pattern.js
+++ b/js/patterns/tinymce/pattern.js
@@ -67,6 +67,7 @@ define([
   'mockup-patterns-relateditems',
   'mockup-patterns-modal',
   'tinymce',
+  'mockup-patterns-autotoc',
   'mockup-patterns-dropzone',
   'dropzone',
   'text!js/patterns/tinymce/templates/result.xml',
@@ -74,8 +75,11 @@ define([
   'mockup-utils',
   'js/patterns/tinymce/links',
   'js/patterns/tinymce/upload'
-], function($, _, Base, RelatedItems, Modal, tinymce, DropZone, dropzone,
-            ResultTemplate, SelectionTemplate, utils, LinkModal, UploadModal) {
+], function($, _,
+            Base, RelatedItems, Modal, tinymce,
+            AutoTOC, DropZone, dropzone,
+            ResultTemplate, SelectionTemplate,
+            utils, LinkModal, UploadModal) {
   "use strict";
 
   var TinyMCE = Base.extend({
@@ -312,7 +316,7 @@ define([
       tinyOptions.skin = false;
 
       self.options.relatedItems.generateImageUrl = function(data, scale){
-        // this is so, in our result and selection template, we can 
+        // this is so, in our result and selection template, we can
         // access getting actual urls from related items
         return self.generateImageUrl.apply(self, [data, scale]);
       };

--- a/js/patterns/tinymce/templates/image.xml
+++ b/js/patterns/tinymce/templates/image.xml
@@ -1,0 +1,67 @@
+<div>
+  <div class="linkModal">
+    <h1><%- insertHeading %></h1>
+    <p class="info">Drag and drop files from your desktop onto dialog to upload</p>
+
+    <div class="linkTypes pat-autotoc autotabs"
+         data-pat-autotoc="section:fieldset;levels:legend;">
+
+      <fieldset class="linkType image">
+        <legend>Image</legend>
+        <div class="form-inline">
+          <div class="form-group main">
+            <input type="text" name="image" />
+          </div>
+          <div class="form-group scale">
+            <label><%- scaleText %></label>
+            <select name="scale">
+              <option value="">Original</option>
+                <% _.each(scales.split(','), function(scale){ %>
+                  <% var scale = scale.split(':'); %>
+                  <option value="<%- scale[1] %>">
+                    <%- scale[0] %>
+                  </option>
+                <% }); %>
+            </select>
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset class="linkType externalImage">
+        <legend>External image</legend>
+        <div>
+          <div class="form-group main">
+            <label><%- externalImageText %></label>
+            <input type="text" name="externalImage" />
+          </div>
+        </div>
+      </fieldset>
+
+    </div><!-- / tabs -->
+
+    <div class="common-controls">
+      <div class="form-group title">
+        <label><%- titleText %></label>
+        <input type="text" name="title" />
+      </div>
+      <div class="form-group text">
+        <label><%- altText %></label>
+        <input type="text" name="alt" />
+      </div>
+      <div class="form-group align">
+        <label><%- imageAlignText %></label>
+        <select name="align">
+          <% _.each(['inline', 'right', 'left'], function(align){ %>
+              <option value="<%- align %>">
+              <%- align.charAt(0).toUpperCase() + align.slice(1) %>
+              </option>
+          <% }); %>
+        <select>
+      </div>
+    </div>
+
+    <input type="submit" class="btn" name="cancel" value="<%- cancelBtn %>" />
+    <input type="submit" class="btn btn-primary" name="insert" value="<%- insertBtn %>" />
+
+  </div>
+</div>

--- a/js/patterns/tinymce/templates/link.xml
+++ b/js/patterns/tinymce/templates/link.xml
@@ -3,99 +3,69 @@
     <h1><%- insertHeading %></h1>
     <p class="info">Drag and drop files from your desktop onto dialog to upload</p>
 
-    <div class="linkTypes">
-      <% _.each(linkTypes, function(type){ %>
-        <label>
-          <input name="linktype" type="radio"
-                 value="<%- type %>" />
-            <%- text[type] %>
-        </label>
-      <% }); %>
-    <div>
-    <hr style="clear:both" />
-    <div class="internal linkType main">
-      <input type="text" name="internal" />
-    </div>
-    <div class="image linkType main">
-      <input type="text" name="image" />
-    </div>
-    <div class="control-group external linkType main">
-      <label><%- externalText %></label>
-      <div class="controls">
-        <input type="text" name="external" />
-      </div>
-    </div>
-    <div class="control-group email linkType main">
-      <label><%- emailText %></label>
-      <div class="controls">
-        <input type="text" name="email" />
-      </div>
-    </div>
-    <div class="control-group email linkType">
-      <label><%- subjectText %></label>
-      <div class="controls">
-        <input type="text" name="subject" />
-      </div>
-    </div>
-    <div class="control-group anchor linkType main">
-      <label>Select an anchor</label>
-      <div class="controls">
-        <select name="anchor" class="pat-select2" data-pat-select2="width:500px" />
-      </div>
-    </div>
-    <div class="control-group linkType anchor email external internal">
-      <div class="controls">
+    <div class="linkTypes pat-autotoc autotabs"
+         data-pat-autotoc="section:fieldset;levels:legend;">
+
+      <fieldset class="linkType internal">
+        <legend>Internal</legend>
+        <div>
+          <div class="form-group main">
+            <input type="text" name="internal" />
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset class="linkType external">
+        <legend>External</legend>
+        <div class="form-group main">
+          <label for="external"><%- externalText %></label>
+          <input type="text" name="external" />
+        </div>
+      </fieldset>
+
+      <fieldset class="linkType email">
+        <legend>Email</legend>
+        <div class="form-inline">
+          <div class="form-group main">
+            <label><%- emailText %></label>
+            <input type="text" name="email" />
+          </div>
+          <div class="form-group">
+            <label><%- subjectText %></label>
+            <input type="text" name="subject" />
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset class="linkType anchor">
+        <legend>Anchor</legend>
+        <div>
+          <div class="form-group main">
+            <label>Select an anchor</label>
+            <div class="input-wrapper">
+              <select name="anchor" class="pat-select2" data-pat-select2="width:500px" />
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+    </div><!-- / tabs -->
+
+    <div class="common-controls">
+      <div class="form-group">
+        <label>Target</label>
         <select name="target">
           <% _.each(targetList, function(target){ %>
             <option value="<%- target.value %>"><%- target.text %></option>
           <% }); %>
         </select>
       </div>
-    </div>
-    <div class="control-group linkType anchor email external internal">
-      <label><%- titleText %></label>
-      <div class="controls">
+      <div class="form-group">
+        <label><%- titleText %></label>
         <input type="text" name="title" />
       </div>
     </div>
-    <div class="control-group linkType externalImage main">
-      <label><%- externalImageText %></label>
-      <div class="controls">
-        <input type="text" name="externalImage" />
-      </div>
-    </div>
-    <div class="control-group linkType image externalImage">
-      <label><%- altText %></label>
-      <div class="controls">
-        <input type="text" name="alt" />
-      </div>
-    </div>
-    <div class="control-group linkType image externalImage">
-      <label><%- imageAlignText %></label>
-      <div class="controls">
-        <select name="align">
-          <% _.each(['inline', 'right', 'left'], function(align){ %>
-              <option value="<%- align %>">
-              <%- align.charAt(0).toUpperCase() + align.slice(1) %>
-              </option>
-          <% }); %>
-        <select>
-      </div>
-    </div>
-    <div class="control-group linkType image">
-      <label><%- scaleText %></label>
-      <div class="controls">
-        <select name="scale">
-          <option value="">Original</option>
-            <% _.each(scales.split(','), function(scale){ %>
-              <% var scale = scale.split(':'); %>
-              <option value="<%- scale[1] %>">
-                <%- scale[0] %>
-              </option>
-            <% }); %>
-        </select>
-      </div>
-    </div>
+
     <input type="submit" class="btn" name="cancel" value="<%- cancelBtn %>" />
     <input type="submit" class="btn btn-primary" name="insert" value="<%- insertBtn %>" />
   </div>

--- a/less/pattern.tinymce.less
+++ b/less/pattern.tinymce.less
@@ -9,6 +9,7 @@
 .importCSS();
 
 @import "pattern.modal.less";
+@import "pattern.autotoc.less";
 @import "../bower_components/bootstrap/less/buttons.less";
 @import "../bower_components/bootstrap/less/button-groups.less";
 @import "../bower_components/bootstrap/less/close.less";
@@ -18,6 +19,7 @@
 div.linkModal {
     .pattern-relateditems-container{
         padding-top: 0;
+        margin-right: 20px;
     }
     hr {
         margin: 5px 0;
@@ -27,15 +29,18 @@ div.linkModal {
         input{
             margin: 5px 5px 9px 9px;
         }
-        label{
-            float: left;
-        }
-    }
-    .linkType{
-        display: none;
     }
     input[name="external"],input[name="externalImage"]{
-        width: 95%;
+        width: 80%;
+    }
+    fieldset{
+        padding-top: 10px;
+        min-height: 90px;
+    }
+    fieldset .input-wrapper{ display: inline-flex; }
+    .common-controls{
+        padding-top: 10px;
+        border-top: 1px solid #ccc;
     }
 }
 
@@ -105,3 +110,4 @@ div.linkModal {
     max-height: 30px;
     max-width: 80px;
 }
+


### PR DESCRIPTION
## AutoTOC
- Include example on how to render tabs
- Improve tabs setup using "autotabs" class on pattern element
## TinyMCE
- Improve markup and styles for link modal and image modal
- Use AutoTOC to display main options as tabs
- Splitted link and image js upload template
- Fix less/css loading (include autotoc styles)
