### PR TITLE
include widget patterns explicitly rather than via the widgets bundle

### DIFF
--- a/js/bundles/plone.js
+++ b/js/bundles/plone.js
@@ -25,7 +25,13 @@ define([
   'jquery',
   'mockup-registry',
   'mockup-patterns-base',
-  'mockup-bundles-widgets',
+
+  'mockup-patterns-select2',
+  'mockup-patterns-pickadate',
+  'mockup-patterns-relateditems',
+  'mockup-patterns-querystring',
+  'mockup-patterns-tinymce',
+
   'mockup-patterns-livesearch',
   'mockup-patterns-accessibility',
   'mockup-patterns-autotoc',


### PR DESCRIPTION
Including the widgets bundle was causing Registry.scan to get called on the body twice, which caused problems such as breaking the related items widget.
