### PR TITLE
make sure list styles can be overridden easily

### DIFF
--- a/less/barceloneta.less
+++ b/less/barceloneta.less
@@ -315,7 +315,33 @@ html {
 
 ul, ol {
   list-style: none;
-  padding-left: none;
+  counter-reset: ol;
+  padding-left: 0;
+  li {
+    margin-bottom: .5em;
+    padding-left: 2em;
+    text-indent: -2em;
+  }
+}
+ul li:before {
+  content: "●";
+  color: @bullet-color;
+  padding-right: 1em;
+}
+ol li:before {
+  content: counter(ol) ".";
+  counter-increment: ol;
+  padding-right: 1em;
+  color: @gray-light;
+}
+// reset list styles in certain contexts
+.navbar, .breadcrumb, .navTree, .field, #portal-globalnav, .historyTools, .pagination, .select2-drop {
+  li:before, li:before { content: none; }
+  li {
+    margin-bottom: initial;
+    padding-left: initial;
+    text-indent: initial;
+  }
 }
 
 #content {
@@ -339,30 +365,6 @@ ul, ol {
     margin-bottom: 1.5em;
   }
 
-  ul, ol {
-    counter-reset: ol;
-    padding-left: 0;
-    li {
-      margin-bottom: .5em;
-      padding-left: 2em;
-      text-indent: -2em;
-    }
-  }
-  ul li:before {
-    content: "●";
-    color: @bullet-color;
-    padding-right: 1em;
-  }
-  ol li:before {
-    content: counter(ol) ".";
-    counter-increment: ol;
-    padding-right: 1em;
-    color: @gray-light;
-  }
-  .pagination, .dropdown-menu, .historyTools { //annulate the bullet from concrete lists
-    li {padding-left: 0; text-indent: 0;}
-    :before {content:""; padding-right: 0; display: none;}
-  }
   //added class for highlighted ordered lists
   .ol-primary li {
     margin-bottom: 1.5em;


### PR DESCRIPTION
This changes to specifying ordered and unordered list styles for `ul`, `ol`, `ul li` and `ol li`, instead of for `#content ul`, `#content ol`, `#content ul li` and `#content ol li`.

The old selectors tended to override class-based styles for lists in widgets (I was looking at select2 in particular) because id-based selectors take precedence over class-based selectors.

We still need to reset the styles for certain lists that are not meant to be displayed with bullets. This is done here but we'll probably need to add more classes.

Please take a look @bloodbare @albertcasado
