### PR TITLE
use wrapShim flag to fix dependence of a shim (backbone.paginator) on an...

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -109,7 +109,8 @@
       'sinon': {exports: 'window.sinon'},
       'tinymce': { exports: 'window.tinyMCE', init: function () { this.tinyMCE.DOM.events.domLoaded = true; return this.tinyMCE; }},
       'underscore': { exports: 'window._' }
-    }
+    },
+    wrapShim: true
   };
 
   if (typeof exports !== 'undefined' && typeof module !== 'undefined') {


### PR DESCRIPTION
... AMD module (backbone)

See https://github.com/jrburke/r.js/issues/623 for more info

Without this we were getting "Uncaught ReferenceError: Backbone is not defined" errors in the plone bundle
