### PR TITLE
WIP: fixes for IE9

### DIFF
--- a/js/patterns/dropzone.js
+++ b/js/patterns/dropzone.js
@@ -167,7 +167,7 @@ define([
 
 
       if (autoClean) {
-        self.dropzone.on('complete', function(file) {
+        self.$dropzone.on('complete', function(file) {
           setTimeout(function() {
             $(file.previewElement).fadeOut();
           }, 3000);
@@ -225,7 +225,7 @@ define([
           setTimeout(process, 100);
         }
       }
-      self.dropzone.on('addedfile', function() {
+      self.$dropzone.on('addedfile', function() {
         self.$dropzone.addClass(fileaddedClassName);
         setTimeout(function() {
           if (!processing) {

--- a/js/patterns/structure/views/app.js
+++ b/js/patterns/structure/views/app.js
@@ -492,7 +492,7 @@ define([
             self.collection.pager();
           }
         }).dropzone;
-        self.dropzone.on('drop', function() {
+        $(self.dropzone).on('drop', function() {
           // because this can change depending on the folder we're in
           self.dropzone.options.url = self.getAjaxUrl(self.options.uploadUrl);
         });


### PR DESCRIPTION
Some fixes to avoid failures in IE9.
- patterns/structure/views/app: Explicitly wrap self.dropzone in jQuery. This prevents the following error in IE9:
  Object doesn't support property or method 'on'
- patterns/dropzone: use self.$dropzone (=wrapped in jQuery), not self.dropzone, to call "on" on. Fixes same error as above

NOTE: the dropzone pattern is currently being refactored! Merging these changes need to wait for those changes.
