### PR TITLE
feat(modal): Allow not to use ajax

### DIFF
--- a/js/patterns/modal.js
+++ b/js/patterns/modal.js
@@ -160,6 +160,7 @@ define([
         target: null,
         ajaxUrl: null, // string, or function($el, options) that returns a string
         modalFunction: null, // String, function name on self to call
+        formsUseAjax: true,
         isForm: false,
         timeout: 5000,
         displayInModal: true,
@@ -172,8 +173,13 @@ define([
         onTimeout: null,
         redirectOnResponse: false,
         redirectToUrl: function($action, response, options) {
-          var $base = $(/<base.*?(\/>|<\/base>)/im.exec(response)[0]);
-          return $base.attr('href');
+          var href = /<base.*?(\/>|<\/base>)/im.exec(response);
+          if (href !== null){
+            href = $(href[0]).attr('href');
+          } else {
+            href = $('body').data('base-url');
+          }
+          return href;
         }
       },
       routerOptions: {
@@ -248,6 +254,12 @@ define([
           url = $action.parents('form').attr('action');
         }
 
+
+        if (options.formsUseAjax !== true){
+          // EJECT EJECT!!
+          $action.unbind('click').click();
+          return;
+        }
         // We want to trigger the form submit event but NOT use the default
         $form.on('submit', function(e) {
           e.preventDefault();
@@ -434,7 +446,7 @@ define([
             .appendTo($('.pattern-modal-buttons', self.$modal))
             .off('click').on('click', function(e) {
               e.stopPropagation();
-              e.preventDefault();
+              //e.preventDefault();
               $button.trigger('click');
             });
           $button.hide();


### PR DESCRIPTION
This patch offers two things.
1. Allow not to use ajax for forms. Useful for the delete confirmation
   popup
2. If a page does not have a base tag, find the content url from
   $(body).data('base-url')
   The data attribute has been added in plone.app.layout 2.5.1.dev0

Background on the delete confirmation:
We wanted to just redirect on success, but this looses features with ajax.
There is no way to get the statusmessage. The statusmessage is set on the
302 reply, then jquery directly follows the redirect and receives the
information that it shall delete the cookie. Now the success handler has
no trace of the status message. After thinking of patching statusmessage
to maybe add the status message just once as a response header field, I
realized I could just not use ajax on form submit since it offers no
advantage for this use case.