### PR TITLE
Fix to use TinyMCE init callback for storing the editor object

### DIFF
--- a/js/patterns/tinymce/pattern.js
+++ b/js/patterns/tinymce/pattern.js
@@ -262,6 +262,12 @@ define([
         return self.generateImageUrl.apply(self, [data, scale]);
       };
 
+      tinyOptions.init_instance_callback = function(editor) {
+        if (self.tiny === undefined) {
+          self.tiny = editor;
+        }
+      };
+
       tinymce.init(tinyOptions);
 
       self.tiny = tinymce.get(id);


### PR DESCRIPTION
Fixes #395 but fails jscs-check because of the naming conventions in used TinyMCE API.
