### PR TITLE
remove dep on tinymce-builded, newer tinymce

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,10 @@
+Changelog
+=========
+
+v1.8.0 (unreleased)
+-------------------
+
+- Remove bower dependency on ``tinymce-builded``, since the ``tinymce``
+  dependency already points to the official builded ``tinymce-dist``
+  reposotory. Raise TinyMCE version to 4.1.6.
+  [thet]

--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,7 @@
     "requirejs-text": "2.0.12",
     "respond": "1.4.2",
     "select2": "3.5.1",
-    "tinymce": "4.1.3",
-    "tinymce-builded": "4.1.0"
+    "tinymce": "4.1.6"
   },
   "devDependencies": {
     "expect": "0.3.1",

--- a/js/config.js
+++ b/js/config.js
@@ -99,7 +99,7 @@
       'sinon': 'bower_components/sinonjs/sinon',
       'text': 'bower_components/requirejs-text/text',
       'tinymce-modern-theme': 'bower_components/tinymce/themes/modern/theme',
-      'tinymce': 'bower_components/tinymce-builded/js/tinymce/tinymce',
+      'tinymce': 'bower_components/tinymce/tinymce',
       'underscore': 'bower_components/lodash/dist/lodash.underscore'
     },
     shim: {

--- a/patterns/tinymce/pattern.js
+++ b/patterns/tinymce/pattern.js
@@ -131,7 +131,7 @@ define([
         externalImage: _t('External Image URI')
       },
       // URL generation options
-      loadingBaseUrl: '../../../bower_components/tinymce-builded/js/tinymce/',
+      loadingBaseUrl: '../../../bower_components/tinymce/',
       prependToUrl: '',
       appendToUrl: '',
       linkAttribute: 'path', // attribute to get link value from data


### PR DESCRIPTION
Remove bower dependency on `tinymce-builded`, since the `tinymce` dependency already points to the official builded `tinymce-dist` reposotory. Raise TinyMCE version to 4.1.6.
- add a CHANGES.rst file to maintain changelogs. i _like_ changelogs. we might update it with previous changes at a later point...
