### PR TITLE
package metadata fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 v1.8.0 (unreleased)
 -------------------
 
+- Package metadata changes including removal of deprecated version specifier
+  from bower.json.
+  [thet]
+
 - Remove bower dependency on ``tinymce-builded``, since the ``tinymce``
   dependency already points to the official builded ``tinymce-dist``
   reposotory. Raise TinyMCE version to 4.1.6.

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,15 @@ Run tests with Chrome::
 
     $ make test-dev
 
+
+Credits
+-------
+
+Originally created by `Rok Garbas <http://garbas.si/>`_ using parts of `Patterns
+library <http://patternslib.com/>`_. Now maintained by the `Plone Foundation
+<http://plone.org/>`_.
+
+
 Status of builds
 ----------------
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "mockup",
-  "version": "1.7.0",
-  "description": "Plone core patterns",
+  "description": "A collection of client side patterns for faster and easier web development",
   "dependencies": {
     "ace-builds": "1.1.5",
     "backbone": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mockup",
-  "version": "1.7.0",
-  "description": "Collection of Plone CMS Core Patterns",
+  "version": "1.8.0-dev",
+  "description": "A collection of client side patterns for faster and easier web development",
   "homepage": "http://plone.github.io/mockup",
   "devDependencies": {
     "bower": "~1.3.2",
@@ -33,9 +33,9 @@
   },
   "maintainers": [
     {
-      "name": "Rok Garbas",
-      "email": "rok@garbas.si",
-      "url": "http://garbas.si"
+      "name": "Plone Foundation",
+      "email": "plone-developers@lists.sourceforge.net",
+      "url": "http://plone.org"
     }
   ],
   "repository": {
@@ -44,7 +44,7 @@
   },
   "bugs": {
     "url": "https://github.com/plone/mockup/issues",
-    "email": "rok@garbas.si"
+    "email": "plone-developers@lists.sourceforge.net"
   },
   "licenses": [
     {

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 from setuptools import setup, find_packages
+import json
 
-version = '0.1'
+package_json = json.load(open('package.json'))
+version = package_json['version']
 
 setup(
     name='mockup',
     version=version,
-    description="No sure how should this package be named so please don't "
-                "judge me just, yet",
+    description="A collection of client side patterns for faster and easier "
+                "web development",
     long_description=open("README.rst").read(),
     classifiers=[
         "Framework :: Plone",
@@ -14,8 +16,8 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords='plone mockup',
-    author='Rok Garbas',
-    author_email='rok@garbas.si',
+    author='Plone Foundation',
+    author_email='plone-developers@lists.sourceforge.net',
     url='https://github.com/plone/mockup',
     license='GPL',
     packages=find_packages(),


### PR DESCRIPTION
- Remove version specifier from bower.json. Bower discourages to use it: https://github.com/bower/bower.json-spec#version - Bower only uses the git tag.
- Get version specifier for setup.py from package.json, making package.json the only file to define the current version.
- Change package maintainer info from Rok Garbas to Plone Foundation.
