### PR TITLE
MimeType selector pattern for textareas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
+- Add mimetype selector pattern for textareas.
+  [thet]
+
 - Fix broken HTML tag on structure pattern's ``actionmenu.xml``.
   [datakurre]
 

--- a/mockup/js/bundles/docs.js
+++ b/mockup/js/bundles/docs.js
@@ -117,6 +117,11 @@ require([
             description: 'A pattern you can apply to a table so it can have its items rearranged when clicking the header',
             url: 'patterns/tablesorter/pattern.js'
           },
+          { id: 'textareamimetypeselector',
+            title: 'Textarea MimeType Selector',
+            description: 'Selects the MimeType for a textarea and changes the widget according to the MimeType',
+            url: 'patterns/textareamimetypeselector/pattern.js'
+          },
           { id: 'tinymce',
             title: 'TinyMCE',
             description: 'Rich text editor',

--- a/mockup/js/bundles/plone.js
+++ b/mockup/js/bundles/plone.js
@@ -16,6 +16,7 @@ define([
   'mockup-patterns-formautofocus',
   'mockup-patterns-modal',
   'mockup-patterns-structure',
+  'mockup-patterns-textareamimetypeselector',
   'bootstrap-dropdown',
   'bootstrap-collapse',
   'bootstrap-tooltip'

--- a/mockup/js/bundles/widgets.js
+++ b/mockup/js/bundles/widgets.js
@@ -7,6 +7,7 @@ define([
   'mockup-patterns-pickadate',
   'mockup-patterns-relateditems',
   'mockup-patterns-querystring',
+  'mockup-patterns-textareamimetypeselector',
   'mockup-patterns-tinymce'
 ], function($, Registry, Base) {
   'use strict';

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -83,6 +83,7 @@
       'mockup-patterns-structure': 'patterns/structure/pattern',
       'mockup-patterns-structure-url': 'patterns/structure',
       'mockup-patterns-tablesorter': 'patterns/tablesorter/pattern',
+      'mockup-patterns-textareamimetypeselector': 'patterns/textareamimetypeselector/pattern',
       'mockup-patterns-texteditor': 'patterns/texteditor/pattern',
       'mockup-patterns-thememapper': 'patterns/thememapper/pattern',
       'mockup-patterns-thememapper-url': 'patterns/thememapper',

--- a/mockup/patterns/textareamimetypeselector/pattern.js
+++ b/mockup/patterns/textareamimetypeselector/pattern.js
@@ -1,0 +1,108 @@
+/* TextareaMimetypeSelector pattern.
+ *
+ *
+ * Options:
+ *    textareaName(string): Value of name attribute of the textarea ('')
+ *    widgets(object): MimeType/PatternConfig pairs ({'text/html': {pattern: 'tinymce', patternOptions: {}}})
+ *
+ *
+ * Documentation:
+ *   # General
+ *
+ *   This pattern displays a mimetype selection widget for textareas. It
+ *   switches the widget according to the selected mimetype.
+ *
+ *   ## widgets option Structure
+ *
+ *   Complex Object/JSON structure with MimeType/PatternConfig pairs. The
+ *   MimeType is a string like "text/html". The PatternConfig is a object with
+ *   a "pattern" and an optional "patternOptions" attribute. The "pattern"
+ *   attribute's value is a string with the patterns name and the
+ *   "patternOptions" attribute is a object with whatever options the pattern
+ *   needs. For example, to use the TinyMCE pattern for the HTML mimetype, use
+ *   "text/html": {"pattern": "tinymce"}
+ *
+ *   # Mimetype selection on textarea including text/html mimetype with TinyMCE editor.
+ *
+ *   {{ example-1 }}
+ *
+ * Example: example-1
+ *
+ *    <textarea name="text">
+ *      <h1>hello world</h1>
+ *    </textarea>
+ *    <select
+ *        name="text.mimeType"
+ *        class="pat-textareamimetypeselector"
+ *        data-pat-textareamimetypeselector='{
+ *          "textareaName": "text",
+ *          "widgets": {
+ *            "text/html": {
+ *              "pattern": "tinymce",
+ *              "patternOptions": {
+ *                "tiny": {
+ *                  "plugins": [],
+ *                  "menubar": "edit format tools",
+ *                  "toolbar": " "
+ *                }
+ *              }
+ *            }
+ *          }
+ *        }'
+ *      >
+ *      <option value="text/html">text/html</option>
+ *      <option value="text/plain" selected="selected">text/plain</option>
+ *    </select>
+ *
+ */
+
+define([
+  'jquery',
+  'mockup-patterns-base',
+  'mockup-registry',
+  'mockup-patterns-tinymce'
+], function ($, Base, registry, tinymce) {
+  'use strict';
+
+  var TextareaMimetypeSelector = Base.extend({
+    name: 'textareamimetypeselector',
+    textarea: undefined,
+    currentWidget: undefined,
+    defaults: {
+      textareaName: '',
+      widgets: {'text/html': {pattern: 'tinymce', patternOptions: {}}}
+    },
+    init: function () {
+      var self = this,
+          $el = self.$el,
+          current;
+      self.textarea = $('[name="' + self.options.textareaName + '"]');
+      $el.change(function (e) {
+        self.initTextarea(e.target.value);
+      });
+      self.initTextarea($el.val());
+
+    },
+    initTextarea: function (mimetype) {
+      var self = this,
+          patternConfig = self.options.widgets[mimetype],
+          pattern;
+      // First, destroy current
+      if (self.currentWidget) {
+        // The pattern must implement the destroy method.
+        self.currentWidget.destroy();
+      }
+      // Then, setup new
+      if (patternConfig) {
+          pattern = new registry.patterns[patternConfig.pattern](
+            self.textarea,
+            patternConfig.patternOptions || {}
+          );
+          self.currentWidget = pattern;
+      }
+    }
+
+  });
+
+  return TextareaMimetypeSelector;
+});

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -284,6 +284,9 @@ define([
       $form.on('submit', function() {
         self.tiny.save();
       });
+    },
+    destroy: function() {
+      this.tiny.destroy();
     }
   });
 

--- a/mockup/tests/pattern-textareamimetypeselector-test.js
+++ b/mockup/tests/pattern-textareamimetypeselector-test.js
@@ -1,0 +1,82 @@
+define([
+  'expect',
+  'jquery',
+  'mockup-registry',
+  'mockup-patterns-textareamimetypeselector',
+  'mockup-patterns-tinymce'
+], function(expect, $, registry, textareamimetypeselector, tinymce) {
+  'use strict';
+
+  window.mocha.setup('bdd');
+  $.fx.off = true;
+
+/* ================================
+   TEST: Textarea MimeType Selector
+  ================================= */
+
+  describe('Textarea MimeType Selector', function () {
+
+    afterEach(function() {
+      $('body').empty();
+    });
+
+    it('Switching changes widget', function() {
+
+      var dom_structure =
+        '<textarea name="text">hello world</textarea>' +
+        '<select' +
+        '    name="text.mimeType"' +
+        '    class="pat-textareamimetypeselector"' +
+        '    data-pat-textareamimetypeselector=\'{' +
+        '      "textareaName": "text",' +
+        '      "widgets": {' +
+        '        "text/html": {' +
+        '          "pattern": "tinymce",' +
+        '          "patternOptions": {' +
+        '            "tiny": {' +
+        '              "plugins": [],' +
+        '              "menubar": "edit format tools",' +
+        '              "toolbar": " "' +
+        '            }' +
+        '          }' +
+        '        }' +
+        '      }' +
+        '    }\'' +
+        '  >' +
+        '  <option value="text/html">text/html</option>' +
+        '  <option value="text/plain" selected="selected">text/plain</option>' +
+        '</select>';
+
+      var $doc = $(dom_structure).appendTo('body');
+      registry.scan($doc);
+
+      var $el = $("[name='text.mimeType']");
+      var $textarea = $("[name='text']");
+
+      // Initially, text/plain is selected and textarea should be visible.
+      expect($textarea.is(":visible")).to.be.ok();
+      // But TinyMCE shouldn't be there
+      expect($(".mce-tinymce").length).to.be(0);
+      // Value should be at it's initial state
+      expect($textarea.val()).to.be.equal("hello world");
+
+      // Now, select text/html
+      $el.val("text/html").change();
+
+      // Textarea should be hidden
+      expect($textarea.is(":hidden")).to.be.ok();
+      // And TinyMCE should be shown
+      expect($(".mce-tinymce").is(":visible")).to.be.ok();
+
+      // Switching back to text/plain should destroy TinyMCE
+      $el.val("text/plain").change();
+      expect($textarea.is(":visible")).to.be.ok();
+      expect($(".mce-tinymce").length).to.be(0);
+      // Unfortunately, TinyMCE changes the value just by loading TinyMCE.
+      expect($textarea.val()).to.be.equal("<p>hello world</p>");
+
+    });
+
+  });
+});
+


### PR DESCRIPTION
Add mimetype selector pattern for textareas.

The mimetype selection box pattern config options allow to switch between different textarea widgets when changing the mimetype.

Textarea patterns must implement a destroy method, so that the previous widget can be removed when switching mimetypes. This pull-req includes this method for the TinyMCE widget.

Unfortunately, there can only be one mimetype entry per mimetype, so it's not possible to switch between "text/html (TinyMCE)" and "text/html (CKEditor)" or the like.

After merging this, I'll create pull-requests on plone.app.widgets and Products.CMFPlone.
