### PR TITLE
Make patterns more generic by loading the i18n catalog in a separate step.

### DIFF
--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -44,6 +44,7 @@
       'jquery.event.drag': 'lib/jquery.event.drag',
       'jquery.event.drop': 'lib/jquery.event.drop',
       'jquery.form': 'bower_components/jquery-form/jquery.form',
+      'translate': 'js/i18n-wrapper',
       'marked': 'bower_components/marked/lib/marked',
       'mockup-bundles-docs': 'js/bundles/docs',
       'mockup-bundles-filemanager': 'js/bundles/filemanager',

--- a/mockup/js/i18n-wrapper.js
+++ b/mockup/js/i18n-wrapper.js
@@ -1,0 +1,16 @@
+/* i18n integration.
+ *
+ * This is a singleton.
+ * Configuration is done on the body tag data-i18ncatalogurl attribute
+ *     <body data-i18ncatalogurl="/jsi18n">
+ *
+ *  Or, it'll default to "/jsi18n"
+ */
+
+define([
+  'mockup-i18n'
+], function(i18n) {
+  'use strict';
+  i18n.loadCatalog('widgets');
+  return i18n.MessageFactory('widgets');
+});

--- a/mockup/patterns/formunloadalert/pattern.js
+++ b/mockup/patterns/formunloadalert/pattern.js
@@ -30,12 +30,9 @@
 define([
   'jquery',
   'mockup-patterns-base',
-  'mockup-i18n'
-], function ($, Base, i18n) {
+  'translate'
+], function ($, Base, _t) {
   'use strict';
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var FormUnloadAlert = Base.extend({
     name: 'formunloadalert',

--- a/mockup/patterns/pickadate/pattern.js
+++ b/mockup/patterns/pickadate/pattern.js
@@ -89,12 +89,9 @@ define([
   'picker.date',
   'picker.time',
   'mockup-patterns-select2',
-  'mockup-i18n'
-], function($, Base, Picker, PickerDate, PickerTime, Select2, i18n) {
+  'translate'
+], function($, Base, Picker, PickerDate, PickerTime, Select2, _t) {
   'use strict';
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var PickADate = Base.extend({
     name: 'pickadate',

--- a/mockup/patterns/preventdoublesubmit/pattern.js
+++ b/mockup/patterns/preventdoublesubmit/pattern.js
@@ -23,12 +23,9 @@
 define([
   'jquery',
   'mockup-patterns-base',
-  'mockup-i18n'
-], function($, Base, i18n) {
+  'translate'
+], function($, Base, _t) {
   'use strict';
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var PreventDoubleSubmit = Base.extend({
     name: 'preventdoublesubmit',

--- a/mockup/patterns/querystring/pattern.js
+++ b/mockup/patterns/querystring/pattern.js
@@ -49,12 +49,9 @@ define([
   'mockup-patterns-select2',
   'mockup-patterns-pickadate',
   'select2',
-  'mockup-i18n'
-], function($, Base, Select2, PickADate, undefined, i18n) {
+  'translate'
+], function($, Base, Select2, PickADate, undefined, _t) {
   'use strict';
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var Criteria = function() { this.init.apply(this, arguments); };
   Criteria.prototype = {

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -77,12 +77,9 @@ define([
   'mockup-patterns-select2',
   'mockup-utils',
   'mockup-patterns-tree',
-  'mockup-i18n'
-], function($, _, Base, Select2, utils, Tree, i18n) {
+  'translate'
+], function($, _, Base, Select2, utils, Tree, _t) {
   'use strict';
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var RelatedItems = Base.extend({
     name: 'relateditems',

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -32,17 +32,14 @@ define([
   'mockup-patterns-base',
   'mockup-utils',
   'mockup-patterns-structure-url/js/views/app',
-  'mockup-i18n',
+  'translate',
   'text!mockup-patterns-structure-url/templates/paging.xml',
   'text!mockup-patterns-structure-url/templates/selection_item.xml',
   'text!mockup-patterns-structure-url/templates/tablerow.xml',
   'text!mockup-patterns-structure-url/templates/table.xml',
   'text!mockup-ui-url/templates/popover.xml',
-], function($, Base, utils, AppView, i18n) {
+], function($, Base, utils, AppView, _t) {
   'use strict';
-
-  i18n.loadCatalog('widgets');
-  var _ = i18n.MessageFactory('widgets');
 
   var Structure = Base.extend({
     name: 'structure',
@@ -66,26 +63,26 @@ define([
         'review_state'
       ],
       availableColumns: {
-        'ModificationDate': _('Last modified'),
-        'EffectiveDate': _('Published'),
-        'CreationDate': _('Created'),
-        'review_state': _('Review state'),
-        'Subject': _('Tags'),
-        'Type': _('Type'),
-        'is_folderish': _('Folder'),
-        'exclude_from_nav': _('Excluded from nav'),
-        'getObjSize': _('Object Size'),
-        'last_comment_date': _('Last comment date'),
-        'total_comments': _('Total comments')
+        'ModificationDate': _t('Last modified'),
+        'EffectiveDate': _t('Published'),
+        'CreationDate': _t('Created'),
+        'review_state': _t('Review state'),
+        'Subject': _t('Tags'),
+        'Type': _t('Type'),
+        'is_folderish': _t('Folder'),
+        'exclude_from_nav': _t('Excluded from nav'),
+        'getObjSize': _t('Object Size'),
+        'last_comment_date': _t('Last comment date'),
+        'total_comments': _t('Total comments')
       },
       rearrange: {
         properties: {
-          'id': _('ID'),
-          'sortable_title': _('Title'),
-          'modified': _('Last Modified'),
-          'created': _('Created on'),
-          'effective': _('Publication Date'),
-          'Type': _('Type')
+          'id': _t('ID'),
+          'sortable_title': _t('Title'),
+          'modified': _t('Last Modified'),
+          'created': _t('Created on'),
+          'effective': _t('Publication Date'),
+          'Type': _t('Type')
         },
         url: '/rearrange'
       },
@@ -96,31 +93,31 @@ define([
        */
       buttonGroups: {
         primary: [{
-          title: _('Cut'),
+          title: _t('Cut'),
           url: '/cut'
         },{
-          title: _('Copy'),
+          title: _t('Copy'),
           url: '/copy'
         },{
-          title: _('Paste'),
+          title: _t('Paste'),
           url: '/paste'
         },{
-          title: _('Delete'),
+          title: _t('Delete'),
           url: '/delete',
           context: 'danger',
           icon: 'trash'
         }],
         secondary: [{
-          title: _('Workflow'),
+          title: _t('Workflow'),
           url: '/workflow'
         },{
-          title: _('Tags'),
+          title: _t('Tags'),
           url: '/tags'
         },{
-          title: _('Properties'),
+          title: _t('Properties'),
           url: '/properties'
         },{
-          title: _('Rename'),
+          title: _t('Rename'),
           url: '/rename'
         }]
       },

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -58,7 +58,7 @@ define([
   'text!mockup-patterns-tinymce-url/templates/selection.xml',
   'mockup-utils',
   'mockup-patterns-tinymce-url/js/links',
-  'mockup-i18n',
+  'translate',
   'tinymce-modern-theme', 'tinymce-advlist', 'tinymce-anchor', 'tinymce-autolink',
   'tinymce-autoresize', 'tinymce-autosave', 'tinymce-bbcode', 'tinymce-charmap',
   'tinymce-code', 'tinymce-colorpicker', 'tinymce-contextmenu', 'tinymce-directionality',
@@ -73,13 +73,8 @@ define([
 ], function($, _,
             Base, RelatedItems, Modal, tinymce,
             AutoTOC, ResultTemplate, SelectionTemplate,
-            utils, LinkModal, i18n) {
+            utils, LinkModal, _t) {
   'use strict';
-
-
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var TinyMCE = Base.extend({
     name: 'tinymce',

--- a/mockup/patterns/upload/pattern.js
+++ b/mockup/patterns/upload/pattern.js
@@ -48,16 +48,13 @@ define([
   'dropzone',
   'text!mockup-patterns-upload-url/templates/upload.xml',
   'text!mockup-patterns-upload-url/templates/preview.xml',
-  'mockup-i18n'
+  'translate'
 ], function($, _, Base, RelatedItems, Dropzone,
-            UploadTemplate, PreviewTemplate, i18n) {
+            UploadTemplate, PreviewTemplate, _t) {
   'use strict';
 
   /* we do not want this plugin to auto discover */
   Dropzone.autoDiscover = false;
-
-  i18n.loadCatalog('widgets');
-  var _t = i18n.MessageFactory('widgets');
 
   var UploadPattern = Base.extend({
     name: 'upload',


### PR DESCRIPTION
Hi mockers

This pull request makes the Mockup patterns more generic by refactoring the loading of the i18n catalog out of the patterns themselves.

By having that step out of the patterns themselves, one could conceivably use a different i18n library (such as Jed.js), merely by changing the require.js paths config and without having the modify the pattern itself.

This is important considering the goal of eventually getting Mockup and Patternslib back together.

We want to have the ability to write patterns that are usable outside of Plone as well as to use patterns that were written by people from outside of the Plone community. So making our own patterns generic is a very important step towards that goal.

The changes here require an additional entry to the Plone resource registries, for which I'll make a Plone request soon. (EDIT: Please see https://github.com/plone/Products.CMFPlone/pull/336 )

Feedback/thoughts are appreciated.
