### PR TITLE
Resource registry: show bundle compilation metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@ New patterns:
 
 Fixes and enhancements:
 
+- In the resource registry bundle detail view, add the fields
+  ``last_compilation``, ``jscompilation`` and ``csscompilation`` for display.
+  This gives more insight about the state of each bundle.
+  [thet]
+
 - More jQuery 1.9 compatibility changes: Change ``attr`` to ``prop`` for
   setting / getting the state of ``multiple``, ``selected``, ``checked`` and
   ``disabled`` states.

--- a/mockup/patterns/resourceregistry/js/fields.js
+++ b/mockup/patterns/resourceregistry/js/fields.js
@@ -8,6 +8,32 @@ define([
   'use strict';
 
 
+  var ResourceDisplayFieldView = BaseView.extend({
+    tagName: 'div',
+    className: 'form-group',
+    template: _.template(
+      '<label class="col-sm-3 control-label"><%- title %></label>' +
+      '<div class="col-sm-9">' +
+        '<strong><%- value %></strong><br/>' +
+        '<%= description %>' +
+      '</div>'),
+    initialize: function(options) {
+      this.options = options;
+      for (var key in this.options) {
+        this[key] = this.options[key];
+      }
+      if (! this.value) {
+        this.template = _.template('');
+      }
+    },
+    serializedModel: function(){
+    },
+    afterRender: function(){
+      this.$el.addClass('field-' + this.options.name);
+    }
+
+  });
+
   var ResourceInputFieldView = BaseView.extend({
     tagName: 'div',
     className: 'form-group',
@@ -332,6 +358,7 @@ define([
   });
 
   return {
+    ResourceDisplayFieldView: ResourceDisplayFieldView,
     VariableFieldView: VariableFieldView,
     ResourceInputFieldView: ResourceInputFieldView,
     ResourceNameFieldView: ResourceNameFieldView,

--- a/mockup/patterns/resourceregistry/js/registry.js
+++ b/mockup/patterns/resourceregistry/js/registry.js
@@ -119,6 +119,21 @@ define([
       name: 'compile',
       title: 'Does your bundle contain any RequireJS or LESS files?',
       view: fields.ResourceBoolFieldView
+    }, {
+      name: 'last_compilation',
+      title: 'Last compilation',
+      description: 'Date/Time when your bundle was last compiled. Empty, if it was never compiled.',
+      view: fields.ResourceDisplayFieldView
+    }, {
+      name: 'jscompilation',
+      title: 'Compiled JavaScript',
+      description: 'Automatically generated path to the compiled JavaScript.',
+      view: fields.ResourceDisplayFieldView
+    }, {
+      name: 'csscompilation',
+      title: 'Compiled CSS',
+      description: 'Automatically generated path to the compiled CSS.',
+      view: fields.ResourceDisplayFieldView
     }]
   });
 
@@ -249,7 +264,7 @@ define([
     };
 
     self._buildCSSBundle = function(config){
-      var $iframe = $('<iframe><html><head></head><body></body></html></iframe').
+      var $iframe = $('<iframe><html><head></head><body></body></html></iframe>').
           appendTo('body').on('load', function(){
       });
       var iframe = $iframe[0];


### PR DESCRIPTION
I was wondering, how someone can find out if and when a bundle was compiled.

Therefore: In the resource registry bundle detail view, add the fields last_compilation, jscompilation and csscompilation for display.  This gives more insight about the state of each bundle.

plus a small fix in the ``_buildCSSBundle`` iframe template.