### PR TITLE
Bugfix. Prevent patterns from being loaded multiple times.

### DIFF
--- a/mockup/bower.json
+++ b/mockup/bower.json
@@ -15,7 +15,7 @@
     "jquery.cookie": "1.4.1",
     "lodash": "2.4.1",
     "logging": "",
-    "mockup-core": "2.1.1",
+    "mockup-core": "git@github.com:plone/mockup-core.git#registry-fix",
     "moment": "2.8.3",
     "pickadate": "3.4.0",
     "requirejs-text": "2.0.12",

--- a/mockup/js/bundles/filemanager.js
+++ b/mockup/js/bundles/filemanager.js
@@ -3,13 +3,12 @@ define([
   'pat-registry',
   'mockup-patterns-base',
   'mockup-patterns-filemanager'
-], function($, Registry, Base) {
+], function($, registry, Base) {
   'use strict';
-
   // initialize only if we are in top frame
   if (window.parent === window) {
-    $(document).ready(function() {
-      Registry.scan($('body'));
-    });
+    if (!registry.initialized) {
+      registry.init();
+    }
   }
 });

--- a/mockup/js/bundles/filemanager.js
+++ b/mockup/js/bundles/filemanager.js
@@ -1,6 +1,6 @@
 define([
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-base',
   'mockup-patterns-filemanager'
 ], function($, registry, Base) {

--- a/mockup/js/bundles/plone.js
+++ b/mockup/js/bundles/plone.js
@@ -1,6 +1,6 @@
 define([
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-base',
 
   'mockup-patterns-select2',

--- a/mockup/js/bundles/plone.js
+++ b/mockup/js/bundles/plone.js
@@ -20,7 +20,7 @@ define([
   'bootstrap-dropdown',
   'bootstrap-collapse',
   'bootstrap-tooltip'
-], function($, Registry, Base) {
+], function($, registry, Base) {
   'use strict';
 
   // BBB: we need to hook pattern to classes which plone was using until now
@@ -28,18 +28,17 @@ define([
     name: 'plone',
     init: function() {
       var self = this;
-
     }
-
   });
 
   // initialize only if we are in top frame
   if (window.parent === window) {
     $(document).ready(function() {
       $('body').addClass('pat-plone');
-      Registry.scan($('body'));
+      if (!registry.initialized) {
+        registry.init();
+      }
     });
   }
-
   return Plone;
 });

--- a/mockup/js/bundles/resourceregistry.js
+++ b/mockup/js/bundles/resourceregistry.js
@@ -1,6 +1,6 @@
 define([
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-resourceregistry',
 ], function($, registry, resource_registry) {
   'use strict';

--- a/mockup/js/bundles/resourceregistry.js
+++ b/mockup/js/bundles/resourceregistry.js
@@ -2,12 +2,9 @@ define([
   'jquery',
   'pat-registry',
   'mockup-patterns-resourceregistry',
-], function($, Registry) {
+], function($, registry, resource_registry) {
   'use strict';
-
-  $(document).ready(function() {
-    var $registry = $('.pat-resourceregistry');
-    Registry.scan($registry);
-  });
-
+  if (!registry.initialized) {
+    registry.init();
+  }
 });

--- a/mockup/js/bundles/structure.js
+++ b/mockup/js/bundles/structure.js
@@ -7,7 +7,7 @@ if (window.jQuery) {
 
 define([
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-base',
   'mockup-patterns-modal',
   'mockup-patterns-structure'

--- a/mockup/js/bundles/widgets.js
+++ b/mockup/js/bundles/widgets.js
@@ -1,6 +1,5 @@
 define([
   'jquery',
-  'pat-registry',
   'mockup-patterns-base',
   'mockup-patterns-select2',
   'mockup-patterns-passwordstrength',
@@ -9,7 +8,7 @@ define([
   'mockup-patterns-querystring',
   'mockup-patterns-textareamimetypeselector',
   'mockup-patterns-tinymce'
-], function($, Registry, Base) {
+], function($, registry, Base) {
   'use strict';
 
   var PloneWidgets = Base.extend({
@@ -23,9 +22,10 @@ define([
   if (window.parent === window) {
     $(document).ready(function() {
       $('body').addClass('pat-plone-widgets');
-      Registry.scan($('body'));
+      if (!registry.initialized) {
+        registry.init();
+      }
     });
   }
-
   return PloneWidgets;
 });

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -126,6 +126,7 @@
       'pat-compat': 'bower_components/patternslib/src/core/compat',
       'pat-jquery-ext': 'bower_components/patternslib/src/core/jquery-ext',
       'pat-logger': 'bower_components/patternslib/src/core/logger',
+      'pat-registry': 'bower_components/patternslib/src/core/registry',
       'pat-utils': 'bower_components/patternslib/src/core/utils',
       'logging': 'bower_components/logging/src/logging'
     },

--- a/mockup/patterns/contentloader/pattern.js
+++ b/mockup/patterns/contentloader/pattern.js
@@ -29,7 +29,7 @@ define([
   'jquery',
   'mockup-patterns-base',
   'pat-logger',
-  'mockup-registry',
+  'pat-registry',
   'mockup-utils'
 ], function($, Base, logger, Registry, utils) {
   'use strict';

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -74,7 +74,7 @@ define([
   'underscore',
   'mockup-patterns-base',
   'mockup-patterns-backdrop',
-  'mockup-registry',
+  'pat-registry',
   'mockup-router',
   'mockup-utils',
   'jquery.form'

--- a/mockup/patterns/textareamimetypeselector/pattern.js
+++ b/mockup/patterns/textareamimetypeselector/pattern.js
@@ -59,7 +59,7 @@
 define([
   'jquery',
   'mockup-patterns-base',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-tinymce'
 ], function ($, Base, registry, tinymce) {
   'use strict';

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -1,7 +1,7 @@
 define([
   'jquery',
   'underscore',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-base',
   'mockup-patterns-relateditems',
   'mockup-patterns-modal',

--- a/mockup/tests/fakeserver.js
+++ b/mockup/tests/fakeserver.js
@@ -675,7 +675,7 @@ define([
           'autotoc': 'patterns/autotoc/pattern',
           'mockup-patterns-base': 'bower_components/mockup-core/js/pattern',
           'jquery': 'bower_components/jquery/dist/jquery',
-          'mockup-registry': 'bower_components/mockup-core/js/registry',
+          'pat-registry': 'bower_components/patternslib/src/core/registry'
         },
         include: ['autotoc']
       };

--- a/mockup/tests/pattern-accessibility-test.js
+++ b/mockup/tests/pattern-accessibility-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-accessibility'
 ], function(expect, $, registry, Accessibility) {
   'use strict';

--- a/mockup/tests/pattern-autotoc-test.js
+++ b/mockup/tests/pattern-autotoc-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-autotoc'
 ], function(expect, $, Registry, AutoTOC) {
   'use strict';

--- a/mockup/tests/pattern-backdrop-test.js
+++ b/mockup/tests/pattern-backdrop-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-backdrop'
 ], function(expect, $, registry, Backdrop) {
   'use strict';

--- a/mockup/tests/pattern-contentloader-test.js
+++ b/mockup/tests/pattern-contentloader-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-contentloader'
 ], function(expect, $, sinon, registry, ContentLoader) {
   'use strict';

--- a/mockup/tests/pattern-cookietrigger-test.js
+++ b/mockup/tests/pattern-cookietrigger-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-cookietrigger'
 ], function(expect, $, sinon, registry, Pattern) {
   'use strict';

--- a/mockup/tests/pattern-eventedit-test.js
+++ b/mockup/tests/pattern-eventedit-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-eventedit'
 ], function(expect, $, registry, EventEdit) {
   'use strict';

--- a/mockup/tests/pattern-filemanager-test.js
+++ b/mockup/tests/pattern-filemanager-test.js
@@ -2,7 +2,7 @@ define([
   'sinon',
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-filemanager'
 ], function(sinon, expect, $, registry, Tree) {
   'use strict';

--- a/mockup/tests/pattern-formautofocus-test.js
+++ b/mockup/tests/pattern-formautofocus-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-formautofocus'
 ], function(expect, $, registry, FormAutoFocus) {
   'use strict';

--- a/mockup/tests/pattern-formunloadalert-test.js
+++ b/mockup/tests/pattern-formunloadalert-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-formunloadalert'
 ], function(expect, $, registry, FormUnloadAlert) {
   'use strict';

--- a/mockup/tests/pattern-inlinevalidation-test.js
+++ b/mockup/tests/pattern-inlinevalidation-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-inlinevalidation'
 ], function(expect, $, sinon, registry, Pattern) {
   'use strict';

--- a/mockup/tests/pattern-livesearch-test.js
+++ b/mockup/tests/pattern-livesearch-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-livesearch'
 ], function(expect, $, sinon, registry, Livesearch) {
   'use strict';

--- a/mockup/tests/pattern-markspeciallinks-test.js
+++ b/mockup/tests/pattern-markspeciallinks-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-markspeciallinks'
 ], function(expect, $, registry, MarkSpecialLinks) {
   'use strict';

--- a/mockup/tests/pattern-modal-test.js
+++ b/mockup/tests/pattern-modal-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-modal'
 ], function(expect, $, sinon, registry, Modal) {
   'use strict';

--- a/mockup/tests/pattern-moment-test.js
+++ b/mockup/tests/pattern-moment-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-moment'
 ], function(expect, $, registry, Moment) {
   'use strict';

--- a/mockup/tests/pattern-passwordstrength-test.js
+++ b/mockup/tests/pattern-passwordstrength-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-passwordstrength'
 ], function(expect, $, registry, PasswordStrength) {
   'use strict';

--- a/mockup/tests/pattern-pickadate-test.js
+++ b/mockup/tests/pattern-pickadate-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-pickadate',
   'mockup-patterns-select2'
 ], function(expect, $, sinon, registry, PickADate, Select2) {

--- a/mockup/tests/pattern-preventdoublesubmit-test.js
+++ b/mockup/tests/pattern-preventdoublesubmit-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-preventdoublesubmit'
 ], function(expect, $, registry, PreventDoubleSubmit) {
   'use strict';

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -3,7 +3,7 @@ define([
   'jquery',
   'underscore',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-relateditems'
 ], function(expect, $, _, sinon, registry, RelatedItems) {
   'use strict';

--- a/mockup/tests/pattern-resourceregistry-test.js
+++ b/mockup/tests/pattern-resourceregistry-test.js
@@ -2,7 +2,7 @@ define([
   'sinon',
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-resourceregistry'
 ], function(sinon, expect, $, registry) {
   'use strict';

--- a/mockup/tests/pattern-select2-test.js
+++ b/mockup/tests/pattern-select2-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-select2'
 ], function(expect, $, sinon, registry, Select2) {
   'use strict';

--- a/mockup/tests/pattern-sortable-test.js
+++ b/mockup/tests/pattern-sortable-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-sortable'
 ], function(expect, $, registry, Sortable) {
   'use strict';

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-structure',
   'sinon',
 ], function(expect, $, registry, Structure, sinon) {

--- a/mockup/tests/pattern-tablesorter-test.js
+++ b/mockup/tests/pattern-tablesorter-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-tablesorter'
 ], function(expect, $, registry, Tablesorter) {
   'use strict';

--- a/mockup/tests/pattern-textareamimetypeselector-test.js
+++ b/mockup/tests/pattern-textareamimetypeselector-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-textareamimetypeselector',
   'mockup-patterns-tinymce'
 ], function(expect, $, registry, textareamimetypeselector, tinymce) {

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -2,7 +2,7 @@ define([
   'expect',
   'jquery',
   'sinon',
-  'mockup-registry',
+  'pat-registry',
   'tinymce',
   'mockup-patterns-tinymce'
 ], function(expect, $, sinon, registry, tinymce, TinyMCE) {

--- a/mockup/tests/pattern-toggle-test.js
+++ b/mockup/tests/pattern-toggle-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-toggle'
 ], function(expect, $, registry, Toggle) {
   'use strict';

--- a/mockup/tests/pattern-tooltip-test.js
+++ b/mockup/tests/pattern-tooltip-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-tooltip'
 ], function(expect, $, registry, ToolTip) {
   'use strict';

--- a/mockup/tests/pattern-tree-test.js
+++ b/mockup/tests/pattern-tree-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-tree'
 ], function(expect, $, registry, Tree) {
   'use strict';

--- a/mockup/tests/pattern-upload-test.js
+++ b/mockup/tests/pattern-upload-test.js
@@ -1,7 +1,7 @@
 define([
   'expect',
   'jquery',
-  'mockup-registry',
+  'pat-registry',
   'mockup-patterns-upload'
 ], function(expect, $, registry, Upload) {
   'use strict';


### PR DESCRIPTION
For reference, see my comment here:
https://github.com/Patternslib/Patterns/issues/396#issuecomment-73722048

If we have multiple bundles that all pull in pat-registry and then call
registry.scan, then patterns will be scanned and initialized multiple times.

Instead, we need to call registry.init *if* it's not been called before. If
it's been called before, we don't need to do anything because the patterns will
automatically be registered as soon as they are loaded by require.js and evaluated
by the JS engine and then automatically scanned by the registry.

Note: this change relies on the Patternslib registry and won't work with the fork @vangheem made of pat-registry. Hopefully that fork can now be discarded.