### PR TITLE
Change index references from Type to portal_type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2.0.3 (unreleased)
+------------------
+
+- Change all index references from ``Type`` to ``portal_type``. E.g. the
+  TinyMCE configuration option ``containsobjects`` expects portal_type values,
+  not Type.
+  [thet]
+
+
 2.0.2 (2015-04-01)
 ------------------
 

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -19,7 +19,7 @@ define([
       pattern: null, // must be passed in
       vocabularyUrl: null,
       searchParam: 'SearchableText', // query string param to pass to search url
-      attributes: ['UID','Title', 'Description', 'getURL', 'Type'],
+      attributes: ['UID', 'Title', 'Description', 'getURL', 'portal_type'],
       batchSize: 10, // number of results to retrive
       baseCriteria: [],
       pathDepth: 1

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -2,7 +2,7 @@
  *
  * Options:
  *    vocabularyUrl(string): This is a URL to a JSON-formatted file used to populate the list (null)
- *    attributes(array): This list is passed to the server during an AJAX request to specify the attributes which should be included on each item. (['UID', 'Title', 'Type', 'path'])
+ *    attributes(array): This list is passed to the server during an AJAX request to specify the attributes which should be included on each item. (['UID', 'Title', 'portal_type', 'path'])
  *    basePath(string): If this is set the widget will start in "Browse" mode and will pass the path to the server to filter the results. ('/')
  *    mode(string): Possible values: 'search', 'browse'. If set to 'search', the catalog is searched for a searchterm. If set to 'browse', browsing starts at basePath. Default: 'search'.
  *    breadCrumbTemplate(string): Template to use for a single item in the breadcrumbs. ('/<a href="<%= path %>"><%= text %></a>')
@@ -103,12 +103,12 @@ define([
       homeText: _t('home'),
       folderTypes: ['Folder'],
       selectableTypes: null, // null means everything is selectable, otherwise a list of strings to match types that are selectable
-      attributes: ['UID', 'Title', 'Type', 'path', 'getIcon'],
+      attributes: ['UID', 'Title', 'portal_type', 'path', 'getIcon'],
       dropdownCssClass: 'pattern-relateditems-dropdown',
       maximumSelectionSize: -1,
       resultTemplate: '' +
-        '<div class="pattern-relateditems-result pattern-relateditems-type-<%= Type %> <% if (selected) { %>pattern-relateditems-active<% } %>">' +
-        '  <a href="#" class="pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %> contenttype-<%= Type.toLowerCase() %>">' +
+        '<div class="pattern-relateditems-result pattern-relateditems-type-<%= portal_type %> <% if (selected) { %>pattern-relateditems-active<% } %>">' +
+        '  <a href="#" class="pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %> contenttype-<%= portal_type.toLowerCase() %>">' +
         '    <% if (getIcon) { %><span class="pattern-relateditems-result-icon"><img src="<%= getIcon %>" /></span><% } %>' +
         '    <span class="pattern-relateditems-result-title"><%= Title %></span>' +
         '    <span class="pattern-relateditems-result-path"><%= path %></span>' +
@@ -121,7 +121,7 @@ define([
         '</div>',
       resultTemplateSelector: null,
       selectionTemplate: '' +
-        '<span class="pattern-relateditems-item pattern-relateditems-type-<%= Type %>">' +
+        '<span class="pattern-relateditems-item pattern-relateditems-type-<%= portal_type %>">' +
         ' <% if (getIcon) { %><span class="pattern-relateditems-result-icon"><img src="<%= getIcon %>" /></span><% } %>' +
         ' <span class="pattern-relateditems-item-title"><%= Title %></span>' +
         ' <span class="pattern-relateditems-item-path"><%= path %></span>' +
@@ -244,7 +244,7 @@ define([
               label: item.Title,
               id: item.UID,
               path: item.path,
-              folder: self.options.folderTypes.indexOf(item.Type) !== -1
+              folder: self.options.folderTypes.indexOf(item.portal_type) !== -1
             };
             nodes.push(node);
           });
@@ -326,7 +326,7 @@ define([
       if (self.options.selectableTypes === null) {
         return true;
       } else {
-        return _.indexOf(self.options.selectableTypes, item.Type) > -1;
+        return _.indexOf(self.options.selectableTypes, item.portal_type) > -1;
       }
     },
     init: function() {
@@ -339,7 +339,7 @@ define([
         $.extend(true, {}, self.options, {
           pattern: self,
           baseCriteria: [{
-            i: 'Type',
+            i: 'portal_type',
             o: 'plone.app.querystring.operation.list.contains',
             v: self.options.folderTypes
           }]
@@ -362,7 +362,7 @@ define([
       Select2.prototype.initializeOrdering.call(self);
 
       self.options.formatResult = function(item) {
-        if (!item.Type || _.indexOf(self.options.folderTypes, item.Type) === -1) {
+        if (!item.portal_type || _.indexOf(self.options.folderTypes, item.portal_type) === -1) {
           item.folderish = false;
         } else {
           item.folderish = true;

--- a/mockup/patterns/structure/js/views/tablerow.js
+++ b/mockup/patterns/structure/js/views/tablerow.js
@@ -33,14 +33,14 @@ define([
       data.availableColumns = self.app.availableColumns;
       self.$el.html(self.template(data));
       var attrs = self.model.attributes;
-      self.$el.addClass('state-' + attrs['review_state']).addClass('type-' + attrs.Type); // jshint ignore:line
+      self.$el.addClass('state-' + attrs['review_state']).addClass('type-' + attrs.portal_type); // jshint ignore:line
       if (attrs['is_folderish']) { // jshint ignore:line
         self.$el.addClass('folder');
       }
       self.$el.attr('data-path', data.path);
       self.$el.attr('data-UID', data.UID);
       self.$el.attr('data-id', data.id);
-      self.$el.attr('data-type', data.Type);
+      self.$el.attr('data-type', data.portal_type);
       self.$el.attr('data-folderish', data['is_folderish']); // jshint ignore:line
 
       self.el.model = this.model;

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -56,7 +56,7 @@ define([
       setDefaultPageUrl: null,
       backdropSelector: '.plone-modal', // Element upon which to apply backdrops used for popovers
       attributes: [
-        'UID', 'Title', 'Type', 'path', 'review_state',
+        'UID', 'Title', 'portal_type', 'path', 'review_state',
         'ModificationDate', 'EffectiveDate', 'CreationDate',
         'is_folderish', 'Subject', 'getURL', 'id', 'exclude_from_nav',
         'getObjSize', 'last_comment_date', 'total_comments'
@@ -75,7 +75,7 @@ define([
         'CreationDate': _t('Created'),
         'review_state': _t('Review state'),
         'Subject': _t('Tags'),
-        'Type': _t('Type'),
+        'portal_type': _t('Type'),
         'is_folderish': _t('Folder'),
         'exclude_from_nav': _t('Excluded from nav'),
         'getObjSize': _t('Object Size'),
@@ -89,7 +89,7 @@ define([
           'modified': _t('Last Modified'),
           'created': _t('Created on'),
           'effective': _t('Publication Date'),
-          'Type': _t('Type')
+          'portal_type': _t('Type')
         },
         url: '/rearrange'
       },

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -1,6 +1,6 @@
 <td class="selection"><input type="checkbox" <% if(selected){ %> checked="checked" <% } %>/></td>
 <td class="title">
-  <a href="<%- getURL %>" class="state-<%- review_state %> contenttype-<%- Type.toLowerCase() %>"><%- Title %></a>
+  <a href="<%- getURL %>" class="state-<%- review_state %> contenttype-<%- portal_type.toLowerCase() %>"><%- Title %></a>
 </td>
 <% _.each(activeColumns, function(column){ %>
   <% if(_.has(availableColumns, column)) { %>

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -1,7 +1,7 @@
 /* TinyMCE pattern.
  *
  * Options:
- *    relatedItems(object): Related items pattern options. ({ attributes: ["UID", "Title", "Description", "getURL", "Type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
+ *    relatedItems(object): Related items pattern options. ({ attributes: ["UID", "Title", "Description", "getURL", "portal_type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
  *    upload(object): Upload pattern options. ({ attributes: look at upload pattern for getting the options list })
  *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", externalImage: "External Image URI"})
  *    scales(string): TODO: is this even used ('Listing (16x16):listing,Icon (32x32):icon,Tile (64x64):tile,Thumb (128x128):thumb,Mini (200x200):mini,Preview (400x400):preview,Large (768x768):large')
@@ -118,7 +118,7 @@ define([
       },
       relatedItems: {
         // UID attribute is required here since we're working with related items
-        attributes: ['UID', 'Title', 'Description', 'getURL', 'Type', 'path', 'ModificationDate', 'getIcon'],
+        attributes: ['UID', 'Title', 'Description', 'getURL', 'portal_type', 'path', 'ModificationDate', 'getIcon'],
         batchSize: 20,
         basePath: '/',
         vocabularyUrl: null,
@@ -215,7 +215,7 @@ define([
           },
           relatedItems: {
             baseCriteria: [{
-              i: 'Type',
+              i: 'portal_type',
               o: 'plone.app.querystring.operation.list.contains',
               v: self.options.imageTypes.concat(self.options.folderTypes)
             }],

--- a/mockup/patterns/tinymce/templates/result.xml
+++ b/mockup/patterns/tinymce/templates/result.xml
@@ -1,4 +1,4 @@
-<div class="pattern-relateditems-result pattern-relateditems-type-<%= Type %> <% if (selected) { %>pattern-active<% } %>">
+<div class="pattern-relateditems-result pattern-relateditems-type-<%= portal_type %> <% if (selected) { %>pattern-active<% } %>">
   <a href="#" class="pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %>">
     <% if (!folderish) { %>
     <span class="pattern-relateditems-result-image">

--- a/mockup/patterns/tinymce/templates/selection.xml
+++ b/mockup/patterns/tinymce/templates/selection.xml
@@ -1,4 +1,4 @@
-<span class="pattern-relateditems-item pattern-relateditems-type-<%= Type %>">
+<span class="pattern-relateditems-item pattern-relateditems-type-<%= portal_type %>">
  <span class="pattern-relateditems-result-image">
    <img src="<%= generateImageUrl(_item, 'thumb') %>" />
  </span>

--- a/mockup/patterns/upload/pattern.js
+++ b/mockup/patterns/upload/pattern.js
@@ -17,7 +17,7 @@
  *    autoCleanResults(boolean): condition value for the file preview in div element to fadeout after file upload is completed. (true)
  *    previewsContainer(selector): JavaScript selector for file preview in div element. (.upload-previews)
  *    container(selector): JavaScript selector for where to put upload stuff into in case of form. If not provided it will be place before the first submit button. ('')
- *    relatedItems(object): Related items pattern options. Will only use only if relativePath is used to use correct upload destination ({ attributes: ["UID", "Title", "Description", "getURL", "Type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
+ *    relatedItems(object): Related items pattern options. Will only use only if relativePath is used to use correct upload destination ({ attributes: ["UID", "Title", "Description", "getURL", "portal_type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
  *
  * Documentation:
  *
@@ -81,7 +81,7 @@ define([
 
       relatedItems: {
         // UID attribute is required here since we're working with related items
-        attributes: ['UID', 'Title', 'Description', 'getURL', 'Type', 'path', 'ModificationDate'],
+        attributes: ['UID', 'Title', 'Description', 'getURL', 'portal_type', 'path', 'ModificationDate'],
         batchSize: 20,
         basePath: '/',
         vocabularyUrl: null,

--- a/mockup/tests/fakeserver.js
+++ b/mockup/tests/fakeserver.js
@@ -58,84 +58,84 @@ define([
       {
         UID: '123sdfasdf',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'News'
       },
       {
         UID: 'fooasdfasdf1123asZ',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'Another Item'
       },
       {
         UID: 'fooasdfasdf1231as',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'News'
       },
       {
         UID: 'fooasdfasdf12231451',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'Another Item'
       },
       {
         UID: 'fooasdfasdf1235dsd',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'News'
       },
       {
         UID: 'fooasdfasd345345f',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'Another Item'
       },
       {
         UID: 'fooasdfasdf465',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'News'
       },
       {
         UID: 'fooaewrwsdfasdf',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'Another Item'
       },
       {
         UID: 'fooasdfasd123f',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'News'
       },
       {
         UID: 'fooasdfasdas123f',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'Another Item'
       },
       {
         UID: 'fooasdfasdfsdf',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'News'
       },
       {
         UID: 'fooasdfasdf',
         getURL: 'http://localhost:8081/news/aggregator',
-        Type: 'Collection',
+        portal_type: 'Collection',
         Description: 'Site News',
         Title: 'Another Item'
       }
@@ -185,7 +185,7 @@ define([
   // these are all random items on the root of the site
   var randomItems = [];
   var basePaths = ['/', '/news/', '/projects/', '/about/'];
-  var possibleNames = ['Page', 'News Item', 'Info', 'Blog Item'];
+  var possibleNames = ['Document', 'News Item', 'Info', 'Blog Item'];
   var possibleTags = ['one', 'two', 'three', 'four'];
 
   function generateUID(size) {
@@ -207,29 +207,29 @@ define([
         UID: generateUID(),
         Title: possibleNames[Math.floor(Math.random() * possibleNames.length)] + ' ' + j,
         path: basePath + generateUID(8),
-        Type: 'Document'
+        portal_type: 'Document'
       });
     }
   }
 
   server.respondWith(/relateditems-test\.json/, function(xhr, id) {
     var searchables = [
-      {UID: 'jasdlfdlkdkjasdf', Title: 'Some Image', path: '/test.png', Type: 'Image'},
-      {UID: 'asdlfkjasdlfkjasdf', Title: 'News', path: '/news', Type: 'Folder'},
-      {UID: '124asdfasasdaf34', Title: 'About', path: '/about', Type: 'Folder'},
-      {UID: 'asdf1234', Title: 'Projects', path: '/projects', Type: 'Folder'},
-      {UID: 'asdf1234gsad', Title: 'Contact', path: '/contact', Type: 'Document'},
-      {UID: 'asdv34sdfs', Title: 'Privacy Policy', path: '/policy', Type: 'Document'},
-      {UID: 'asdfasdf234sdf', Title: 'Our Process', path: '/our-process', Type: 'Folder'},
-      {UID: 'asdhsfghyt45', Title: 'Donate', path: '/donate-now', Type: 'Document'},
+      {UID: 'jasdlfdlkdkjasdf', Title: 'Some Image', path: '/test.png', portal_type: 'Image'},
+      {UID: 'asdlfkjasdlfkjasdf', Title: 'News', path: '/news', portal_type: 'Folder'},
+      {UID: '124asdfasasdaf34', Title: 'About', path: '/about', portal_type: 'Folder'},
+      {UID: 'asdf1234', Title: 'Projects', path: '/projects', portal_type: 'Folder'},
+      {UID: 'asdf1234gsad', Title: 'Contact', path: '/contact', portal_type: 'Document'},
+      {UID: 'asdv34sdfs', Title: 'Privacy Policy', path: '/policy', portal_type: 'Document'},
+      {UID: 'asdfasdf234sdf', Title: 'Our Process', path: '/our-process', portal_type: 'Folder'},
+      {UID: 'asdhsfghyt45', Title: 'Donate', path: '/donate-now', portal_type: 'Document'},
       // about
-      {UID: 'gfn5634f', Title: 'About Us', path: '/about/about-us', Type: 'Document'},
-      {UID: '45dsfgsdcd', Title: 'Philosophy', path: '/about/philosophy', Type: 'Document'},
-      {UID: 'dfgsdfgj675', Title: 'Staff', path: '/about/staff', Type: 'Folder'},
-      {UID: 'sdfbsfdh345', Title: 'Board of Directors', path: '/about/board-of-directors', Type: 'Document'},
+      {UID: 'gfn5634f', Title: 'About Us', path: '/about/about-us', portal_type: 'Document'},
+      {UID: '45dsfgsdcd', Title: 'Philosophy', path: '/about/philosophy', portal_type: 'Document'},
+      {UID: 'dfgsdfgj675', Title: 'Staff', path: '/about/staff', portal_type: 'Folder'},
+      {UID: 'sdfbsfdh345', Title: 'Board of Directors', path: '/about/board-of-directors', portal_type: 'Document'},
       // staff
-      {UID: 'asdfasdf9sdf', Title: 'Mike', path: '/about/staff/mike', Type: 'Document'},
-      {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', Type: 'Document'}
+      {UID: 'asdfasdf9sdf', Title: 'Mike', path: '/about/staff/mike', portal_type: 'Document'},
+      {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', portal_type: 'Document'}
     ];
     searchables = searchables.concat(randomItems);
 
@@ -254,7 +254,7 @@ define([
           possibleTags[Math.floor(Math.random() * possibleTags.length)]
         ];
         data.id = data.Title.replace(' ', '-').toLowerCase();
-        if (data.Type === 'Folder') {
+        if (data.portal_type === 'Folder') {
           data['is_folderish'] = true;  // jshint ignore:line
         } else {
           data['is_folderish'] = false;  // jshint ignore:line
@@ -300,7 +300,7 @@ define([
       }
       _.each(items, function(item) {
         var q;
-        var keys = (item.UID + ' ' + item.Title + ' ' + item.path + ' ' + item.Type).toLowerCase();
+        var keys = (item.UID + ' ' + item.Title + ' ' + item.path + ' ' + item.portal_type).toLowerCase();
         if (typeof(term) === 'object') {
           for (var i = 0; i < term.length; i = i + 1) {
             q = term[i].toLowerCase();
@@ -427,7 +427,7 @@ define([
         uid: 'sldlfkjsldkjlskdjf',
         name: 'blah.png',
         filename: 'blah.png',
-        type: 'Image',
+        portal_type: 'Image',
         size: 239292
       })
     );
@@ -570,7 +570,7 @@ define([
           });
         }
       });
-      data.object = {UID: 'asdlfkjasdlfkjasdf', Title: 'News', path: '/news', Type: 'Folder'};
+      data.object = {UID: 'asdlfkjasdlfkjasdf', Title: 'News', path: '/news', portal_type: 'Folder'};
     }
     xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(data));
   });

--- a/mockup/tests/json/contextInfo.json
+++ b/mockup/tests/json/contextInfo.json
@@ -1,7 +1,7 @@
 {
   "addButtons": [{
-    "id": "page",
-    "title": "Page"
+    "id": "document",
+    "title": "Document"
   },{
     "id": "folder",
     "title": "Folder"

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -36,25 +36,25 @@ define([
       }
       this.server.respondWith(/relateditems-test.json/, function(xhr, id) {
         var root = [
-          {UID: 'jasdlfdlkdkjasdf', Title: 'Some Image', path: '/test.png', Type: 'Image', getIcon: "image.png"},
-          {UID: 'asdlfkjasdlfkjasdf', Title: 'News', path: '/news', Type: 'Folder', getIcon: ""},
-          {UID: '124asdfasasdaf34', Title: 'About', path: '/about', Type: 'Folder', getIcon: ""},
-          {UID: 'asdf1234', Title: 'Projects', path: '/projects', Type: 'Folder', getIcon: ""},
-          {UID: 'asdf1234gsad', Title: 'Contact', path: '/contact', Type: 'Document', getIcon: "document.png"},
-          {UID: 'asdv34sdfs', Title: 'Privacy Policy', path: '/policy', Type: 'Document', getIcon: ""},
-          {UID: 'asdfasdf234sdf', Title: 'Our Process', path: '/our-process', Type: 'Folder', getIcon: "folder.png"},
-          {UID: 'asdhsfghyt45', Title: 'Donate', path: '/donate-now', Type: 'Document', getIcon: ""},
+          {UID: 'jasdlfdlkdkjasdf', Title: 'Some Image', path: '/test.png', portal_type: 'Image', getIcon: "image.png"},
+          {UID: 'asdlfkjasdlfkjasdf', Title: 'News', path: '/news', portal_type: 'Folder', getIcon: ""},
+          {UID: '124asdfasasdaf34', Title: 'About', path: '/about', portal_type: 'Folder', getIcon: ""},
+          {UID: 'asdf1234', Title: 'Projects', path: '/projects', portal_type: 'Folder', getIcon: ""},
+          {UID: 'asdf1234gsad', Title: 'Contact', path: '/contact', portal_type: 'Document', getIcon: "document.png"},
+          {UID: 'asdv34sdfs', Title: 'Privacy Policy', path: '/policy', portal_type: 'Document', getIcon: ""},
+          {UID: 'asdfasdf234sdf', Title: 'Our Process', path: '/our-process', portal_type: 'Folder', getIcon: "folder.png"},
+          {UID: 'asdhsfghyt45', Title: 'Donate', path: '/donate-now', portal_type: 'Document', getIcon: ""},
         ];
         var about = [
-          {UID: 'gfn5634f', Title: 'About Us', path: '/about/about-us', Type: 'Document', getIcon: ""},
-          {UID: '45dsfgsdcd', Title: 'Philosophy', path: '/about/philosophy', Type: 'Document', getIcon: ""},
-          {UID: 'dfgsdfgj675', Title: 'Staff', path: '/about/staff', Type: 'Folder', getIcon: ""},
-          {UID: 'sdfbsfdh345', Title: 'Board of Directors', path: '/about/board-of-directors', Type: 'Document', getIcon: ""}
+          {UID: 'gfn5634f', Title: 'About Us', path: '/about/about-us', portal_type: 'Document', getIcon: ""},
+          {UID: '45dsfgsdcd', Title: 'Philosophy', path: '/about/philosophy', portal_type: 'Document', getIcon: ""},
+          {UID: 'dfgsdfgj675', Title: 'Staff', path: '/about/staff', portal_type: 'Folder', getIcon: ""},
+          {UID: 'sdfbsfdh345', Title: 'Board of Directors', path: '/about/board-of-directors', portal_type: 'Document', getIcon: ""}
         ];
 
         var staff = [
-          {UID: 'asdfasdf9sdf', Title: 'Mike', path: '/about/staff/mike', Type: 'Document', getIcon: ""},
-          {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', Type: 'Document', getIcon: ""}
+          {UID: 'asdfasdf9sdf', Title: 'Mike', path: '/about/staff/mike', portal_type: 'Document', getIcon: ""},
+          {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', portal_type: 'Document', getIcon: ""}
         ];
         var searchables = about.concat(root).concat(staff);
 
@@ -105,7 +105,7 @@ define([
           }
           _.each(items, function(item) {
             var q;
-            var keys = (item.UID + ' ' + item.Title + ' ' + item.path + ' ' + item.Type).toLowerCase();
+            var keys = (item.UID + ' ' + item.Title + ' ' + item.path + ' ' + item.portal_type).toLowerCase();
             if (typeof(term) === 'object') {
               for (var i = 0; i < term.length; i = i + 1) {
                 q = term[i].toLowerCase();

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -59,7 +59,7 @@ define([
           UID: '123sdfasdfFolder',
           getURL: 'http://localhost:8081/folder',
           path: '/folder',
-          Type: 'Folder',
+          portal_type: 'Folder',
           Description: 'folder',
           Title: 'Folder',
           'review_state': 'published',
@@ -72,9 +72,9 @@ define([
             UID: '123sdfasdf' + i,
             getURL: 'http://localhost:8081/item' + i,
             path: '/item' + i,
-            Type: 'Page ' + i,
-            Description: 'page',
-            Title: 'Page ' + i,
+            portal_type: 'Document ' + i,
+            Description: 'document',
+            Title: 'Document ' + i,
             'review_state': 'published',
             'is_folderish': false,
             Subject: [],
@@ -102,9 +102,9 @@ define([
       this.server.respondWith('GET', /contextInfo/, function (xhr, id) {
         var data = {
           addButtons: [{
-            id: 'page',
-            title: 'Page',
-            url: '/addpage'
+            id: 'document',
+            title: 'Document',
+            url: '/adddocument'
           },{
             id: 'folder',
             title: 'Folder'
@@ -115,7 +115,7 @@ define([
             UID: '123sdfasdfFolder',
             getURL: 'http://localhost:8081/folder',
             path: '/folder',
-            Type: 'Folder',
+            portal_type: 'Folder',
             Description: 'folder',
             Title: 'Folder',
             'review_state': 'published',

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -33,7 +33,7 @@ define([
             UID: '123sdfasdf',
             getURL: 'http://localhost:8081/news/aggregator',
             path: '/news/aggregator',
-            Type: 'Collection',
+            portal_type: 'Collection',
             Description: 'Site News',
             Title: 'News',
             getIcon: ''
@@ -42,7 +42,7 @@ define([
             UID: 'fooasdfasdf1123asZ',
             path: '/about',
             getURL: 'http://localhost:8081/about',
-            Type: 'Page',
+            portal_type: 'Document',
             Description: 'About',
             Title: 'About',
             getIcon: 'document.png'
@@ -199,7 +199,7 @@ define([
       pattern.addLinkClicked();
       pattern.linkModal.linkTypes.internal.$input.select2('data', {
         UID: 'foobar',
-        Type: 'Page',
+        portal_type: 'Document',
         Title: 'Foobar',
         path: '/foobar',
         getIcon: ''
@@ -231,7 +231,7 @@ define([
       pattern.addImageClicked();
       pattern.imageModal.linkTypes.image.$input.select2('data', {
         UID: 'foobar',
-        Type: 'Page',
+        portal_type: 'Document',
         Title: 'Foobar',
         path: '/foobar'
       });
@@ -247,7 +247,7 @@ define([
       pattern.addLinkClicked();
       pattern.linkModal.linkTypes.internal.$input.select2('data', {
         UID: 'foobar',
-        Type: 'Page',
+        portal_type: 'Document',
         Title: 'Foobar',
         path: '/foobar',
         getIcon: ''

--- a/mockup/tests/utils-test.js
+++ b/mockup/tests/utils-test.js
@@ -140,11 +140,11 @@ define([
 
       it('getUrl correct', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/'});
-        expect(qh.getUrl()).to.equal('http://foobar.com/?query=%7B%22criteria%22%3A%5B%5D%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22Type%22%5D');
+        expect(qh.getUrl()).to.equal('http://foobar.com/?query=%7B%22criteria%22%3A%5B%5D%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22portal_type%22%5D');
       });
       it('getUrl correct and url query params already present', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/?foo=bar'});
-        expect(qh.getUrl()).to.equal('http://foobar.com/?foo=bar&query=%7B%22criteria%22%3A%5B%5D%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22Type%22%5D');
+        expect(qh.getUrl()).to.equal('http://foobar.com/?foo=bar&query=%7B%22criteria%22%3A%5B%5D%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22portal_type%22%5D');
       });
 
 


### PR DESCRIPTION
Change all index references from Type to portal_type. E.g. the TinyMCE configuration option containsobjects expects portal_type values, not Type.

I had an issue with having 'Document' declared as folderish via an tinymce.xml 'containsobjects' entry, but the TinyMCE pattern wasn't respecting it (even with some necessary changes in plone.app.widgets.utils, for which i'll create a separate pull-request). It was due to mockup querying for the Type index, which is the title of the content type. In my case, the title is not Document, but Page.

IMO, we should remove the Type index at all and only use portal_type, but this is another discussion (or PLIP).

See https://github.com/plone/Products.TinyMCE/blob/master/Products/TinyMCE/profiles/default/tinymce.xml#L15 for tinymce declaring "Document" as "linkable" type, which is a proof that the TinyMCE config expects the content type id / portal_type and not the content types' title.