### PR TITLE
Fix #477 Fix #472 Restyled the theme mapper page, fixed referenced JS is...

### DIFF
--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -346,12 +346,23 @@ define([
       if (self.ace !== undefined){
         self.ace.editor.destroy();
       }
-      self.ace = new TextEditor(self.$editor, {
-        width: self.$editor.width()
-      });
-      self.ace.setSyntax(path);
-      self.ace.setText(self.fileData[path].contents);
-      self.ace.editor.clearSelection();
+      self.ace = new TextEditor(self.$editor);
+
+      self.resizeEditor();
+
+      if( typeof self.fileData[path].info !== 'undefined' )
+      {
+          var preview = self.fileData[path].info;
+          self.ace.editor.off();
+          $('.ace_editor').empty().append(preview);
+      }
+      else
+      {
+          self.ace.setText(self.fileData[path].contents);
+          self.ace.setSyntax(path);
+          self.ace.editor.clearSelection();
+      }
+
       self.ace.editor.on('change', function() {
         if (self.ace.editor.curOp && self.ace.editor.curOp.command.name) {
           $('[data-path="'+path+'"]').addClass("modified");
@@ -396,8 +407,25 @@ define([
         node = node.parent;
       }
       return '/' + parts.join('/');
-    }
+    },
 
+    resizeEditor: function() {
+        var self = this;
+        var tabBox = self.$tabs.parent();
+
+        //Contains both the tabs, and editor window
+        var container = tabBox.parent().parent();
+        var h = container.innerHeight();
+        h -= tabBox.outerHeight();
+
+        //accounts for the borders/margin
+        self.$editor.height(h);
+
+        var w = container.innerWidth();
+        w -= (container.outerWidth(true) - container.innerWidth());
+
+        self.$editor.width(w);
+    }
   });
 
   return FileManager;

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -481,7 +481,7 @@ define([
       self.showInspectorsButton.applyTemplate();
       $('html, body').animate({
         scrollTop: $parent.offset().top - 50
-      }, 1000); 
+      }, 1000);
     },
     hideInspectors: function(){
       var self = this;

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -4,7 +4,7 @@
 
 .pat-thememapper{
     font-family: Roboto, sans-serif;
-    
+
     iframe{
         width: 100%;
         height: 300px;
@@ -18,6 +18,7 @@
 
     .mockup-inspector {
         clear: both;
+        padding: 10px 0 10px 0;
     }
 
     .fullscreen {
@@ -92,4 +93,53 @@
         }
     }
 
+    .ace_editor {
+        border: 1px solid #999;
+    }
+
+    .navbar-nav {
+        a {
+            color: black;
+            text-decoration: none;
+            font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        }
+
+    }
+
+    .tree {
+        font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        border-color: #ddd;
+        border-style: solid;
+        border-right: 0;
+        padding: 10px;
+        overflow-y: scroll;
+        height: 80vh;
+        margin-top: 0;
+
+        .jqtree-tree {
+            margin-top: 0px;
+
+            li {
+                padding-bottom: 2px;
+            }
+        }
+
+        .jqtree-selected {
+            font-weight: bold;
+        }
+    }
+
+    .nav-and-editor {
+        background-color: #ccc;
+        width: 70vw;
+        height: 80vh;
+        padding-bottom: 20px;
+        border-color: #ddd;
+        border-style: solid;
+        border-left: 0;
+
+        .collapse {
+            padding-left: 0;
+        }
+    }
 }


### PR DESCRIPTION
Updated CSS to make thememapper now look much more presentable. Images are now shown in the ace editor window correctly. The editor will also now correctly expand to fit it's container.

@ebrehault @vangheem I realized after-the-fact that this should probably be in 3 separate commits. Hope that's not an issue.