### PR TITLE
TinyMCE link/image upload fix + dropzone update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
+- TinyMCE and upload pattern: Re-add triggering of the ``uploadAllCompleted``
+  event and pass the server's response and path uid to it. TinyMCE's link
+  plugin is listening to it and uses the information to create a URL out of the
+  uploaded files. Fixes #471.
+  [thet]
+
 - Update Dropzone.js to it's latest 4.0.1 version.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
+- Update Dropzone.js to it's latest 4.0.1 version.
+  [thet]
+
 - hide some fields from plone-legacy bundle interface since that bundle
   is a special case
   [vangheem]

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "backbone.paginator": "0.8.1",
     "bootstrap": "3.2.0",
     "console-polyfill": "0.1.2",
-    "dropzone": "3.10.2",
+    "dropzone": "4.0.1",
     "es5-shim": "4.0.3",
     "jqtree": "0.22.0",
     "jquery": "1.11.1",

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -36,7 +36,7 @@
       'docs-contribute': 'CONTRIBUTE.md',
       'docs-getting-started': 'GETTING_STARTED.md',
       'docs-learn': 'LEARN.md',
-      'dropzone': 'bower_components/dropzone/downloads/dropzone-amd-module',
+      'dropzone': 'bower_components/dropzone/dist/dropzone-amd-module',
       'expect': 'bower_components/expect/index',
       'jqtree': 'bower_components/jqtree/tree.jquery',
       'jquery': 'bower_components/jquery/dist/jquery',

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -106,13 +106,9 @@ define([
 
   var UploadLink = InternalLink.extend({
     toUrl: function() {
-      var filename = $('.pat-upload').data('filename');
-      var path = $('.pat-upload').data('path');
-      var paths = [path, filename];
-      if (path){
-        paths.unshift(''); // add root node
-      }
-      return paths.join('/');
+      // Make a URL from the servers uuid of the uploaded file.
+      var upload_data = $('.pat-upload').data('uploaddata');
+      return 'resolveuid/' + upload_data.UID;
     }
   });
 
@@ -507,9 +503,10 @@ define([
         self.options.upload.relatedItems = self.options.relatedItems;
         self.$upload.addClass('pat-upload').patternUpload(self.options.upload);
         self.$upload.on('uploadAllCompleted', function(evt, data) {
+          // Add upload data and path_uid to the upload node's data attributes.
           self.$upload.attr({
-            'data-filename': data.files ? data.files[0].name : '',
-            'data-path': data.path
+            'data-uploaddata': data.data,
+            'data-path': data.path_uid
           });
         });
       }

--- a/mockup/patterns/upload/less/pattern.upload.less
+++ b/mockup/patterns/upload/less/pattern.upload.less
@@ -1,4 +1,4 @@
-@import (less) "@{bowerPath}/dropzone/downloads/css/dropzone.css";
+@import (less) "@{bowerPath}/dropzone/dist/dropzone.css";
 
 .upload-container {
     .upload-area {

--- a/mockup/patterns/upload/pattern.js
+++ b/mockup/patterns/upload/pattern.js
@@ -169,6 +169,16 @@ define([
         }
       });
 
+      self.dropzone.on('success', function(e, response){
+        // Trigger event 'uploadAllCompleted' and pass the server's reponse and
+        // the path uid. This event can be listened to by patterns using the
+        // upload pattern, e.g. the TinyMCE pattern's link plugin.
+        self.$el.trigger('uploadAllCompleted', {
+          'data': response,
+          'path_uid': self.$pathInput.val()
+        });
+      });
+
       if (self.options.autoCleanResults) {
         self.dropzone.on('complete', function(file) {
           setTimeout(function() {


### PR DESCRIPTION
TinyMCE and upload pattern: Re-add triggering of the ``uploadAllCompleted`` event and pass the server's response and path uid to it. TinyMCE's link plugin is listening to it and uses the information to create a URL out of the uploaded files. Fixes #471.

Update Dropzone.js to it's latest 4.0.1 version.
