### PR TITLE
fix name mixup that caused image button/menu to be broken

### DIFF
--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -380,12 +380,12 @@ define([
       };
       if(self.options.pasteImages){
         tinyOptions.paste_data_images = 'true';
-        tinyOptions.addImageClicked = function() {
-          self.addImageClicked.apply(self, []);
+        tinyOptions.addImagePasted = function() {
+          self.addImagePasted.apply(self, []);
         };
       }
-      tinyOptions.addImagePasted = function(file) {
-        self.addImagePasted.apply(self, [file] );
+      tinyOptions.addImageClicked = function(file) {
+        self.addImageClicked.apply(self, [file] );
       };
       // XXX: disabled skin means it wont load css files which we already
       // include in widgets.min.css


### PR DESCRIPTION
I made a little mistake in pull request #491