### PR TITLE
Thememapper fullscreen

### DIFF
--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -224,8 +224,6 @@ define([
       self.$tree = self.$('.tree');
       self.$nav = self.$('nav');
       self.$tabs = $('ul.nav', self.$nav);
-      self.$editorContainer = $('.nav-and-editor');
-
       self.options.treeConfig.onLoad = function() {
         // on loading initial data, activate first node if available
         var node = self.$tree.tree('getNodeById', 1);
@@ -391,12 +389,12 @@ define([
 
     resizeEditor: function() {
         var self = this;
+
         var tabBox = self.$tabs.parent();
 
         //Contains both the tabs, and editor window
         var container = tabBox.parent().parent();
         var h = container.innerHeight();
-
         h -= tabBox.outerHeight();
 
         //+2 for the editor borders
@@ -404,11 +402,12 @@ define([
 
         //accounts for the borders/margin
         self.$editor.height(h);
-
         var w = container.innerWidth();
         w -= (container.outerWidth(true) - container.innerWidth());
 
         self.$editor.width(w);
+        //This forces ace to redraw if the container has changed size
+        self.ace.editor.resize();
     }
   });
 

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -224,6 +224,8 @@ define([
       self.$tree = self.$('.tree');
       self.$nav = self.$('nav');
       self.$tabs = $('ul.nav', self.$nav);
+      self.$editorContainer = $('.nav-and-editor');
+
       self.options.treeConfig.onLoad = function() {
         // on loading initial data, activate first node if available
         var node = self.$tree.tree('getNodeById', 1);
@@ -237,6 +239,10 @@ define([
         self.openFile(e);
       });
       self.$editor = self.$('.editor');
+
+      $(window).on('resize', function() {
+        self.resizeEditor();
+      });
     },
     openFile: function(event) {
       var self = this;
@@ -390,7 +396,11 @@ define([
         //Contains both the tabs, and editor window
         var container = tabBox.parent().parent();
         var h = container.innerHeight();
+
         h -= tabBox.outerHeight();
+
+        //+2 for the editor borders
+        h -= 2;
 
         //accounts for the borders/margin
         self.$editor.height(h);

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -408,6 +408,7 @@ define([
         self.$editor.width(w);
         //This forces ace to redraw if the container has changed size
         self.ace.editor.resize();
+        self.ace.editor.$blockScrolling = Infinity;
     }
   });
 

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -435,6 +435,7 @@ define([
     helpButton: null,
     hidden: true,
     fileManager: null,
+    editor: null,
     mockupInspector: null,
     unthemedInspector: null,
     $fileManager: null,
@@ -513,7 +514,25 @@ define([
         tooltip: 'rule building wizard',
         context: 'default'
       });
+      self.fullscreenButton = new ButtonView({
+        id: 'fullscreenEditor',
+        title: 'Fullscreen',
+        tooltip: 'view the editor in fullscreen',
+        context: 'default'
+      });
+      self.fullscreenButton.on('button:click', function() {
+        var btn = $('<a href="#">'+
+            '<span class="btn btn-danger closeeditor">Close Fullscreen</span>'+
+            '</a>').prependTo($('.tree'));
 
+        $(btn).click(function() {
+          $('.container').removeClass('fullscreen').trigger('resize');
+          $(btn).remove();
+        });
+
+        //resize tells the editor window to resize as well.
+        $('.container').addClass('fullscreen').trigger('resize');
+      });
       self.previewThemeButton = new ButtonView({
         id: 'previewtheme',
         title: 'Preview theme',
@@ -539,6 +558,7 @@ define([
           self.showInspectorsButton,
           self.buildRuleButton,
           self.previewThemeButton,
+          self.fullscreenButton,
           self.helpButton
         ],
         id: 'mapper'

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -435,7 +435,6 @@ define([
     helpButton: null,
     hidden: true,
     fileManager: null,
-    editor: null,
     mockupInspector: null,
     unthemedInspector: null,
     $fileManager: null,
@@ -529,7 +528,6 @@ define([
           $('.container').removeClass('fullscreen').trigger('resize');
           $(btn).remove();
         });
-
         //resize tells the editor window to resize as well.
         $('.container').addClass('fullscreen').trigger('resize');
       });

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -106,6 +106,35 @@
 
     }
 
+    .container.fullscreen {
+
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 99999999;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        background-color: white;
+
+        .tree {
+            height: 97%;
+            width: 15%;
+            border: none;
+        }
+
+        .nav-and-editor {
+            width: 83%;
+            height: 97%;
+            border: none;
+        }
+
+        .closeeditor {
+            margin-bottom: 10px;
+            font-size: x-small;
+        }
+    }
+
     .tree {
         font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
         border-color: #ddd;


### PR DESCRIPTION
Added a button to the thememapper that shows the Ace editor window in fullscreen, as requested in #476. Also fixed a minor issue causing Ace to resize incorrectly when its container size was changed.