### PR TITLE
Allow to provide a sort_on and sort_order attributes for the QueryHelper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.4 (Unreleased)
 ------------------
 
+- Allow to provide a sort_on and sort_order attributes for the QueryHelper
+  [frapell]
+
 - handle errors better with the modal pattern
   [vangheem]
 

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -22,6 +22,8 @@ define([
       attributes: ['UID', 'Title', 'Description', 'getURL', 'portal_type'],
       batchSize: 10, // number of results to retrive
       baseCriteria: [],
+      sort_on: 'is_folderish',
+      sort_order: 'reverse',
       pathDepth: 1
     };
     self.options = $.extend({}, defaults, options);
@@ -144,7 +146,9 @@ define([
     self.getQueryData = function(term, page) {
       var data = {
         query: JSON.stringify({
-          criteria: self.getCriterias(term)
+          criteria: self.getCriterias(term),
+          sort_on: self.options.sort_on,
+          sort_order: self.options.sort_order
         }),
         attributes: JSON.stringify(self.options.attributes)
       };

--- a/mockup/tests/utils-test.js
+++ b/mockup/tests/utils-test.js
@@ -109,7 +109,7 @@ define([
       it('getQueryData correctly', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/'});
         var qd = qh.getQueryData('foobar');
-        expect(qd.query).to.equal('{"criteria":[{"i":"SearchableText","o":"plone.app.querystring.operation.string.contains","v":"foobar*"}]}');
+        expect(qd.query).to.equal('{"criteria":[{"i":"SearchableText","o":"plone.app.querystring.operation.string.contains","v":"foobar*"}],"sort_on":"is_folderish","sort_order":"reverse"}');
       });
       it('getQueryData use attributes correctly', function() {
         var qh = new utils.QueryHelper({
@@ -128,7 +128,7 @@ define([
       it('selectAjax gets data correctly', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/'});
         var sa = qh.selectAjax();
-        expect(sa.data('foobar').query).to.equal('{"criteria":[{"i":"SearchableText","o":"plone.app.querystring.operation.string.contains","v":"foobar*"}]}');
+        expect(sa.data('foobar').query).to.equal('{"criteria":[{"i":"SearchableText","o":"plone.app.querystring.operation.string.contains","v":"foobar*"}],"sort_on":"is_folderish","sort_order":"reverse"}');
       });
       it('selectAjax formats results correctly', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/'});
@@ -140,11 +140,11 @@ define([
 
       it('getUrl correct', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/'});
-        expect(qh.getUrl()).to.equal('http://foobar.com/?query=%7B%22criteria%22%3A%5B%5D%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22portal_type%22%5D');
+        expect(qh.getUrl()).to.equal('http://foobar.com/?query=%7B%22criteria%22%3A%5B%5D%2C%22sort_on%22%3A%22is_folderish%22%2C%22sort_order%22%3A%22reverse%22%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22portal_type%22%5D');
       });
       it('getUrl correct and url query params already present', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/?foo=bar'});
-        expect(qh.getUrl()).to.equal('http://foobar.com/?foo=bar&query=%7B%22criteria%22%3A%5B%5D%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22portal_type%22%5D');
+        expect(qh.getUrl()).to.equal('http://foobar.com/?foo=bar&query=%7B%22criteria%22%3A%5B%5D%2C%22sort_on%22%3A%22is_folderish%22%2C%22sort_order%22%3A%22reverse%22%7D&attributes=%5B%22UID%22%2C%22Title%22%2C%22Description%22%2C%22getURL%22%2C%22portal_type%22%5D');
       });
 
 


### PR DESCRIPTION
This allows to specify an order in which results for the tree will be returned.

I'm creating a PR instead of directly commiting, because this will affect the related items widget, where returned items will be first folders, and then items.

In my opinion, we should also sort those folders and items alphabetically, but that should be done in the vocabulary, not here.