### PR TITLE
Filemanager navigation overhaul.

### DIFF
--- a/mockup/patterns/filemanager/js/delete.js
+++ b/mockup/patterns/filemanager/js/delete.js
@@ -17,11 +17,13 @@ define([
     events: {
       'click button': 'deleteButtonClicked'
     },
-    getPath: function() {
-      return this.app.getNodePath();
-    },
     deleteButtonClicked: function(e) {
       var self = this;
+      var path = self.app.getNodePath();
+      if( path === undefined ) {
+        alert("No file selected.");
+        return;
+      }
       self.app.doAction('delete', {
         type: 'POST',
         data: {

--- a/mockup/patterns/filemanager/js/delete.js
+++ b/mockup/patterns/filemanager/js/delete.js
@@ -30,9 +30,8 @@ define([
         success: function(data) {
           self.hide();
           self.app.refreshTree()
+          self.app.closeActiveTab();
           self.app.resizeEditor();
-          // ugly, $tabs should have an API
-          $('.nav .active .remove').click();
         }
       });
       // XXX show loading

--- a/mockup/patterns/filemanager/js/delete.js
+++ b/mockup/patterns/filemanager/js/delete.js
@@ -17,6 +17,9 @@ define([
     events: {
       'click button': 'deleteButtonClicked'
     },
+    getPath: function() {
+      return this.app.getNodePath();
+    },
     deleteButtonClicked: function(e) {
       var self = this;
       var path = self.app.getNodePath();
@@ -27,7 +30,7 @@ define([
       self.app.doAction('delete', {
         type: 'POST',
         data: {
-          path: self.app.getNodePath()
+          path: path
         },
         success: function(data) {
           self.hide();

--- a/mockup/patterns/filemanager/pattern.filemanager.less
+++ b/mockup/patterns/filemanager/pattern.filemanager.less
@@ -160,6 +160,6 @@
             color: @brand-warning;
         }
     }
-    
+
 
 }

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -95,6 +95,7 @@ define([
       self.saveBtn = new ButtonView({
         id: 'save',
         title: _t('Save'),
+        icon: 'floppy-disk',
         context: 'success'
       });
 
@@ -103,6 +104,7 @@ define([
           id: 'newfolder',
           title: _t('New folder'),
           tooltip: _t('Add new folder to current directory'),
+          icon: 'folder-open',
           context: 'default'
         }),
         app: self
@@ -112,6 +114,7 @@ define([
           id: 'addnew',
           title: _t('Add new file'),
           tooltip: _t('Add new file to current folder'),
+          icon: 'file',
           context: 'default'
         }),
         app: self
@@ -121,6 +124,7 @@ define([
           id: 'rename',
           title: _t('Rename'),
           tooltip: _t('Rename currently selected resource'),
+          icon: 'erase',
           context: 'default'
         }),
         app: self
@@ -130,6 +134,7 @@ define([
           id: 'delete',
           title: _t('Delete'),
           tooltip: _t('Delete currently selected resource'),
+          icon: 'trash',
           context: 'danger'
         }),
         app: self
@@ -152,6 +157,7 @@ define([
             id: 'upload',
             title: _t('Upload'),
             tooltip: _t('Upload file to current directory'),
+            icon: 'upload',
             context: 'default'
           }),
           app: self,
@@ -220,7 +226,7 @@ define([
       if( callback === undefined ) {
         callback = function() {};
       }
-      self.$tree.tree('loadDataFromUrl', 
+      self.$tree.tree('loadDataFromUrl',
         self.options.actionUrl + '?action=dataTree',
         null,
         callback
@@ -236,23 +242,78 @@ define([
       self.$tree = self.$('.tree');
       self.$nav = self.$('nav');
       self.$tabs = $('ul.nav', self.$nav);
-      self.options.treeConfig.onLoad = function() {
-        // on loading initial data, activate first node if available
-        var node = self.$tree.tree('getNodeById', 1);
-        if (node){
-          self.$tree.tree('selectNode', node);
-          self.openFile({node: node});
-        }
-      };
       self.tree = new Tree(self.$tree, self.options.treeConfig);
-      self.$tree.bind('tree.click', function(e) {
-        self.openFile(e);
-      });
       self.$editor = self.$('.editor');
 
+      self.$tree.bind('tree.select', function(e) {
+        self.handleClick(e);
+      });
+
+      $(self.$tabs).on('click', function(e) {
+        var path = $(e.target).data('path');
+        if( path === undefined ) {
+          path = $(e.target.parentElement).data('path');
+          if( path === undefined ) {
+            return false;
+          }
+        }
+        self.selectItem(path);
+      });
       $(window).on('resize', function() {
         self.resizeEditor();
       });
+    },
+    handleClick: function(event) {
+      var self = this;
+      self.openFile(event);
+    },
+    createTab: function(path) {
+      var self = this;
+      var $item = $(self.tabItemTemplate({path: path}));
+      self.shrinkTab($item);
+      self.$tabs.append($item);
+      $('.remove', $item).click(function(e){
+        e.preventDefault();
+        if ($(this).parent().hasClass('active'))
+        {
+          var $siblings = $(this).parent().siblings();
+          if ($siblings.length > 0){
+            var $item;
+            if ($(this).parent().prev().length > 0){
+              $item = $(this).parent().prev();
+            } else {
+              $item = $(this).parent().next();
+            }
+            $(this).parent().remove();
+            $item.click();
+          } else {
+            $(this).parent().remove();
+            self.openEditor();
+          }
+        }
+        else {
+          $(this).parent().remove();
+        }
+      });
+      $('.select', $item).click(function(e){
+        e.preventDefault();
+        $('li', self.$tabs).removeClass('active');
+        var $li = $(this).parent();
+        $li.addClass('active');
+      });
+    },
+    updateTabs: function(path) {
+      var self = this;
+      if( path === undefined ) {
+        return;
+      }
+      $('li', self.$tabs).removeClass('active');
+      var $existing = $('[data-path="' + path + '"]', self.$tabs);
+      if ($existing.length === 0){
+        self.createTab(path);
+      }else{
+        $existing.addClass('active');
+      }
     },
     shrinkTab: function(tab) {
         var self = this;
@@ -275,50 +336,7 @@ define([
         }
         return true;
       }
-      if( event.node ) {
-        self.$tree.tree('selectNode', event.node);
-      }
       if(self.fileData[doc]) {
-        $('li', self.$tabs).removeClass('active');
-        var $existing = $('[data-path="' + doc + '"]');
-        if ($existing.length === 0){
-          var $item = $(self.tabItemTemplate({path: doc}));
-          self.shrinkTab($item);
-          self.$tabs.append($item);
-          $('.remove', $item).click(function(e){
-            e.preventDefault();
-            if ($(this).parent().hasClass('active'))
-            {
-              var $siblings = $(this).parent().siblings();
-              if ($siblings.length > 0){
-                var $item;
-                if ($(this).parent().prev().length > 0){
-                  $item = $(this).parent().prev();
-                } else {
-                  $item = $(this).parent().next();
-                }
-                $item.addClass('active');
-                $(this).parent().remove();
-                self.openFileByPath($item.attr('data-path'));
-              } else {
-                $(this).parent().remove();
-                self.openEditor();
-              }
-            }
-            else {
-              $(this).parent().remove();
-            }
-          });
-          $('.select', $item).click(function(e){
-            e.preventDefault();
-            $('li', self.$tabs).removeClass('active');
-            var $li = $(this).parent();
-            $li.addClass('active');
-            self.openFile({node: event.node});
-          });
-        }else{
-          $existing.addClass('active');
-        }
         self.openEditor(doc);
       } else {
         self.doAction('getFile', {
@@ -326,23 +344,23 @@ define([
           dataType: 'json',
           success: function(data) {
             self.fileData[doc] = data;
-            self.openFile(event);
+            self.openEditor(doc);
           }
         });
       }
     },
-    openFileByPath: function(path) {
+    getNodeByPath: function(path) {
       var self = this;
       if( path === undefined || path === "" )
       {
-       return false;
+       return null;
       }
 
       if( path.indexOf('/') === 0 )
       {
         path = path.substr(1,path.length);
       }
-      
+
       var folders = path.split('/');
       var children = self.$tree.tree('getTree').children;
 
@@ -356,15 +374,13 @@ define([
               break;
             }
             else {
-              self.$tree.tree('selectNode', children[z]);
-              self.openFile({node: children[z]});
-              return true;
+              return children[z];
             }
           }
         }
       }
 
-      return false;
+      return null;
     },
     doAction: function(action, options) {
       var self = this;
@@ -384,6 +400,8 @@ define([
     },
     openEditor: function(path) {
       var self = this;
+
+      self.updateTabs(path);
       // first we need to save the current editor content
       if(self.currentPath) {
         self.fileData[self.currentPath].contents = self.ace.editor.getValue();
@@ -502,6 +520,11 @@ define([
           self.ace.editor.$blockScrolling = Infinity;
           self.ace.editor.focus();
         }
+    },
+    selectItem: function(path) {
+      var self = this;
+      var node = self.getNodeByPath(path);
+      self.$tree.tree('selectNode', node);
     },
     setUploadUrl: function(path) {
       var self = this;

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -268,14 +268,10 @@ define([
 
       self.$tree.bind('tree.select', function(e) {
         if( e.node === null ) {
-          $('#btn-delete', this.$el).attr('disabled', 'disabled');
-          $('#btn-save', this.$el).attr('disabled', 'disabled');
-          $('#btn-rename', this.$el).attr('disabled', 'disabled');
+          self.toggleButtons(false);
         }
         else{
-          $('#btn-delete', this.$el).attr('disabled', false);
-          $('#btn-save', this.$el).attr('disabled', false);
-          $('#btn-rename', this.$el).attr('disabled', false);
+          self.toggleButtons(true);
           self.handleClick(e);
         }
       });
@@ -313,6 +309,22 @@ define([
         self.resizeEditor();
       });
     },
+    toggleButtons: function(on) {
+      if( on === undefined ) {
+        return;
+      }
+
+      if( on ) {
+        $('#btn-delete', this.$el).attr('disabled', false);
+        $('#btn-save', this.$el).attr('disabled', false);
+        $('#btn-rename', this.$el).attr('disabled', false);
+      }
+      else{
+        $('#btn-delete', this.$el).attr('disabled', 'disabled');
+        $('#btn-save', this.$el).attr('disabled', 'disabled');
+        $('#btn-rename', this.$el).attr('disabled', 'disabled');
+      }
+    },
     handleClick: function(event) {
       var self = this;
       self.openFile(event);
@@ -332,6 +344,7 @@ define([
         $item.click();
       } else {
         $(active).parent().remove();
+        self.toggleButtons(false);
         self.openEditor();
       }
     },

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -357,7 +357,7 @@ define([
       else{
         self.buildLessButton.$el.hide();
       }
-      
+
       if( node.path != "" ) {
         var reg = new RegExp("/(.*\\.)less$", "m");
         var path = reg.exec(node.path);
@@ -403,8 +403,8 @@ define([
           self.fileManager.refreshTree(function() {
             //We need to make sure we open the newest version
             delete self.fileManager.fileData['/' + self.lessPaths['save']]
-            self.fileManager.openFileByPath(self.lessPaths['save'])
-          }); 
+            self.fileManager.selectItem(self.lessPaths['save'])
+          });
           self.lessbuilderView.end();
         }
       });
@@ -436,6 +436,7 @@ define([
       self.showInspectorsButton = new ButtonView({
         id: 'showinspectors',
         title: _t('Show inspectors'),
+        icon: 'search',
         tooltip: _t('Show inspector panels'),
         context: 'default'
       });
@@ -450,12 +451,14 @@ define([
       self.buildRuleButton = new ButtonView({
         id: 'buildrule',
         title: _t('Build rule'),
+        icon: 'wrench',
         tooltip: _t('rule building wizard'),
         context: 'default'
       });
       self.fullscreenButton = new ButtonView({
         id: 'fullscreenEditor',
         title: _t('Fullscreen'),
+        icon: 'fullscreen',
         tooltip: _t('view the editor in fullscreen'),
         context: 'default'
       });
@@ -474,6 +477,7 @@ define([
       self.previewThemeButton = new ButtonView({
         id: 'previewtheme',
         title: _t('Preview theme'),
+        icon: 'new-window',
         tooltip: _t('preview theme in a new window'),
         context: 'default'
       });
@@ -483,12 +487,14 @@ define([
       self.buildLessButton = new ButtonView({
         id: 'buildless',
         title: _t('Build CSS'),
+        icon: 'cog',
         tooltip: _t('Compile LESS file'),
         context: 'default'
       });
       self.helpButton = new ButtonView({
         id: 'helpbutton',
         title: _t('Help'),
+        icon: 'question-sign',
         tooltip: _t('Show help'),
         context: 'default'
       });

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -157,8 +157,18 @@ body.plone-toolbar-left-default {
             margin-top: 0px;
 
             li {
-                padding-bottom: 2px;
+                white-space: nowrap;
+                overflow: hidden;
+                padding: 3px 0 3px 0;
             }
+        }
+
+        .glyphicon {
+            top: -1px;
+        }
+
+        .glyphicon:before {
+            margin-right: 5px;
         }
 
         .jqtree-selected {
@@ -292,6 +302,10 @@ body.plone-toolbar-left-default {
         .frame-shelf-container {
             margin-right: 5px;
         }
+    }
+
+    .btn-group {
+        margin-right: 30px;
     }
 
     #lessBuilder .buttonBox {

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -2,6 +2,14 @@
 /* just be lazy here and include all of bootstrap... */
 @import "@{mockupPath}/filemanager/pattern.filemanager.less";
 
+body.plone-toolbar-left-default {
+	padding-left: 0px;
+}
+
+#edit-zone {
+	display: none;
+}
+
 .pat-thememapper{
     font-family: Roboto, sans-serif;
 
@@ -22,7 +30,6 @@
         line-height: 12px;
         padding: 0 0 0 18px;
         margin: 4px 0 0 2px;
-        //background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGNVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4A4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19HvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzzHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+BkmfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8OcxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqhz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5nkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aruq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15TMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5Da9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5QH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4BGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAyElEQVQokX3SMUoEQRAF0Nczy4ZipmggCLp6AJP1CIIewBuYzKH2El7EYFdW1kRMxdwyqZGmR7ahqKb6/1+/q7tEhHaVUkpERCnlEbc4xiWORMQk0GW+wzciY9tN5LNJ5jd8VPXXfepL7FJ5gy+sZo33Dh1+cIMzvOMeC5z+qaJvOs0xYFnVejUwbQyYN+S+suoJD7iqPA95OBuBFdkqL7RO8G600YJHwnM15zWuRxv/vVGHi2pQJzjP/fQLpMcDvOSsP3G4j/AL85OZj4EeME0AAAAASUVORK5CYII=');
         background-repeat: no-repeat;
         text-decoration: none;
         border-bottom: none !important;
@@ -30,17 +37,12 @@
         font-size: 90%;
         content: none;
     }
-    .fullscreenActive {
-        //background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAD8GlDQ1BJQ0MgUHJvZmlsZQAAKJGNVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4A4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19HvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzzHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+BkmfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8OcxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqhz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5nkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aruq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15TMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5Da9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5QH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4BGDj42bzn+Vmc+NL9L8GcMn8F1kAcXjEKMJAAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA1klEQVQokW3SMUoDURDG8d9sIuwFLPQGYrF94g0WPIAnsLT1LmJpn1NYB7FLYwotbAUFccciEwnrPhj+j3nz+L4382SmqUCLtvYd1uinCpviAisssUViM3VhVryson28oGv8X1E8LX4VrzJz3UBENBExi4gjzKvgrNgWbyOinUNmDpX8wXftn3CPZ7zhfS/f4gLHOME5HjPzbsLun/wN+oP8R1ltS3XYGclh35lldeKzeF35+biLTUR0eBg98LWYU7Y2dbAtpRUWh0MczUlvN/Zu/CWm4hfV25ukt9oGAwAAAABJRU5ErkJggg==');
-    }
-
     .refresh {
         vertical-align: top;
         display: inline-block;
         line-height: 12px;
         padding: 0 0 0 12px;
         margin: 4px 0 0 5px;
-        //background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAEJGlDQ1BJQ0MgUHJvZmlsZQAAOBGFVd9v21QUPolvUqQWPyBYR4eKxa9VU1u5GxqtxgZJk6XtShal6dgqJOQ6N4mpGwfb6baqT3uBNwb8AUDZAw9IPCENBmJ72fbAtElThyqqSUh76MQPISbtBVXhu3ZiJ1PEXPX6yznfOec7517bRD1fabWaGVWIlquunc8klZOnFpSeTYrSs9RLA9Sr6U4tkcvNEi7BFffO6+EdigjL7ZHu/k72I796i9zRiSJPwG4VHX0Z+AxRzNRrtksUvwf7+Gm3BtzzHPDTNgQCqwKXfZwSeNHHJz1OIT8JjtAq6xWtCLwGPLzYZi+3YV8DGMiT4VVuG7oiZpGzrZJhcs/hL49xtzH/Dy6bdfTsXYNY+5yluWO4D4neK/ZUvok/17X0HPBLsF+vuUlhfwX4j/rSfAJ4H1H0qZJ9dN7nR19frRTeBt4Fe9FwpwtN+2p1MXscGLHR9SXrmMgjONd1ZxKzpBeA71b4tNhj6JGoyFNp4GHgwUp9qplfmnFW5oTdy7NamcwCI49kv6fN5IAHgD+0rbyoBc3SOjczohbyS1drbq6pQdqumllRC/0ymTtej8gpbbuVwpQfyw66dqEZyxZKxtHpJn+tZnpnEdrYBbueF9qQn93S7HQGGHnYP7w6L+YGHNtd1FJitqPAR+hERCNOFi1i1alKO6RQnjKUxL1GNjwlMsiEhcPLYTEiT9ISbN15OY/jx4SMshe9LaJRpTvHr3C/ybFYP1PZAfwfYrPsMBtnE6SwN9ib7AhLwTrBDgUKcm06FSrTfSj187xPdVQWOk5Q8vxAfSiIUc7Z7xr6zY/+hpqwSyv0I0/QMTRb7RMgBxNodTfSPqdraz/sDjzKBrv4zu2+a2t0/HHzjd2Lbcc2sG7GtsL42K+xLfxtUgI7YHqKlqHK8HbCCXgjHT1cAdMlDetv4FnQ2lLasaOl6vmB0CMmwT/IPszSueHQqv6i/qluqF+oF9TfO2qEGTumJH0qfSv9KH0nfS/9TIp0Wboi/SRdlb6RLgU5u++9nyXYe69fYRPdil1o1WufNSdTTsp75BfllPy8/LI8G7AUuV8ek6fkvfDsCfbNDP0dvRh0CrNqTbV7LfEEGDQPJQadBtfGVMWEq3QWWdufk6ZSNsjG2PQjp3ZcnOWWing6noonSInvi0/Ex+IzAreevPhe+CawpgP1/pMTMDo64G0sTCXIM+KdOnFWRfQKdJvQzV1+Bt8OokmrdtY2yhVX2a+qrykJfMq4Ml3VR4cVzTQVz+UoNne4vcKLoyS+gyKO6EHe+75Fdt0Mbe5bRIf/wjvrVmhbqBN97RD1vxrahvBOfOYzoosH9bq94uejSOQGkVM6sN/7HelL4t10t9F4gPdVzydEOx83Gv+uNxo7XyL/FtFl8z9ZAHF4bBsrEwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAO5JREFUKBWNkb0RgkAQhe8ccrEDZwgIhQ6wErEDS6EE7IAOpATMIKAGNWcGv3dyigm6M8v+vfduj7PjOBpvcRwfrLU59ZZ+SKzxahiGKgiCuuu61IoQRdFaDYYJLru/ghHpbRDsSpUHo15TJgw2cuW4J5OC1RrEROC2bfeuy2c69UT6dYqFcGGtjIGUr8RFWwF2x/4DlpK79KLkNGSTm1J36V8EwDswIfdsAoFpfB7DmJL1jnMRgIV+P146wmyoX1j4WsoTOKPXIHSeEwQONQCoXBZKGWt47UyJv4PW0EPleIUblEVSnjNL+75/qP8E/EloRr2HQksAAAAASUVORK5CYII=');
         background-repeat: no-repeat;
         text-decoration: none;
         border-bottom: none !important;
@@ -106,7 +108,10 @@
             text-decoration: none;
             font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
+    }
 
+    .navbar.ui-offset-parent {
+        margin-bottom: 0px;
     }
 
     .container.fullscreen {
@@ -182,7 +187,7 @@
             background-color: transparent;
         }
     }
-    
+
     .navbar-nav > li.active {
         background-color: #FFF;
     }
@@ -281,7 +286,7 @@
         }
     }
 
-    #btn-inspectors {
+    #inspectors {
         clear: both;
 
         .frame-shelf-container {

--- a/mockup/tests/pattern-thememapper-test.js
+++ b/mockup/tests/pattern-thememapper-test.js
@@ -66,11 +66,11 @@ define([
       expect($('.container', this.$el).hasClass('fullscreen')).to.be.equal(false);
       expect($('.closeeditor', this.$el).length === 0).to.be.equal(true);
 
-      expect($('#btn-inspectors', this.$el).is(':visible')).to.be.equal(false);
+      expect($('#inspectors', this.$el).is(':visible')).to.be.equal(false);
       $('#btn-showinspectors', this.$el).click();
       expect($('#inspectors', this.$el).is(':visible')).to.be.equal(true);
       $('#btn-showinspectors', this.$el).click();
-      expect($('#btn-inspectors', this.$el).is(':visible')).to.be.equal(false);
+      expect($('#inspectors', this.$el).is(':visible')).to.be.equal(false);
     });
   });
 });


### PR DESCRIPTION
Reorganized the navigation in the filemanager to be much easier to work with, and to remove countless small issues involving the navigation tree/tabs. 

Added icons to the buttons in the thememapper, and to the navigation tree.

Added a feature support test for the filemanager's uploadview.

Fixed a few broken tests.

Lot of changes here, input?