### PR TITLE
Fixes problems with the thememapper's LESS builder

### DIFF
--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -87,15 +87,25 @@ define([
         self.$el.html('Must specify actionUrl setting for pattern');
         return;
       }
+
       self.options.treeConfig = $.extend(true, {}, self.treeConfig, {
         dataUrl: self.options.actionUrl + '?action=dataTree',
         onCreateLi: function(node, li) {
+          var imageTypes = ['png', 'jpg', 'jpeg', 'gif', 'ico'];
+          var themeTypes = ['css', 'html', 'htm', 'txt', 'xml', 'js', 'cfg', 'less'];
+
           $('span', li).addClass('glyphicon');
           if( node.folder ) {
             $('span', li).addClass('glyphicon-folder-close')
           }
+          else if( $.inArray(node.fileType, imageTypes) >= 0) {
+            $('span', li).addClass('glyphicon-picture');
+          }
+          else if( $.inArray(node.fileType, themeTypes) >= 0) {
+            $('span', li).addClass('glyphicon-file');
+          }
           else {
-            $('span', li).addClass('glyphicon-file')
+            $('span', li).addClass('glyphicon-cog')
           }
         }
       });
@@ -243,10 +253,6 @@ define([
       if( callback === undefined ) {
         callback = function() {};
       }
-      var nodes = self.$tree.find('span');
-      $(nodes).each(function() {
-        $(this).addClass('glyphicon glyphicon-file');
-      });
       self.$tree.tree('loadDataFromUrl',
         self.options.actionUrl + '?action=dataTree',
         null,

--- a/mockup/patterns/thememapper/js/lessbuilderview.js
+++ b/mockup/patterns/thememapper/js/lessbuilderview.js
@@ -122,15 +122,9 @@ define([
             function() {
               var $ = window.parent.$;
               var iframe = window.iframe['lessc'];
-              var styles = $('style', iframe.document);
-              var styleBox = $('#styleBox');
+              var styles = $('style', iframe.document)[0].innerHTML;
 
-              $(styleBox).empty();
-              $(styles).each(function() {
-                styleBox.append(this.innerHTML);
-              });
-
-              iframe.options.callback();
+              iframe.options.callback(styles);
             }
           );
         }

--- a/mockup/patterns/thememapper/js/lessbuilderview.js
+++ b/mockup/patterns/thememapper/js/lessbuilderview.js
@@ -122,9 +122,15 @@ define([
             function() {
               var $ = window.parent.$;
               var iframe = window.iframe['lessc'];
-              var styles = $('style', iframe.document)[0].innerHTML;
+              var styles = $('style', iframe.document);
 
-              iframe.options.callback(styles);
+              var css = "";
+
+              $(styles).each(function() {
+                 css += this.innerHTML;
+              });
+
+              iframe.options.callback(css);
             }
           );
         }

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -383,11 +383,10 @@ define([
         return false;
       }
     },
-    saveThemeCSS: function() {
+    saveThemeCSS: function(styles) {
       var self = this.env;
-      var css = self.$styleBox.html();
 
-      if( css === "" ) {
+      if( styles === "" ) {
         //There was probably a problem during compilation
         return false;
       }
@@ -396,7 +395,7 @@ define([
         type: 'POST',
         data: {
           path: self.lessPaths['save'],
-          data: css,
+          data: styles,
           _authenticator: utils.getAuthenticator()
         },
         success: function(data) {

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -386,7 +386,7 @@ define([
     saveThemeCSS: function(styles) {
       var self = this.env;
 
-      if( styles === "" ) {
+      if( styles === "" || styles === undefined ) {
         //There was probably a problem during compilation
         return false;
       }

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -342,6 +342,7 @@ define([
           $(items).each(function() {
             this.disable();
           });
+          self.lessbuilderView.triggerView.disable();
         }
       };
 


### PR DESCRIPTION
Fixes a bug that cases the thememapper's LESS builder from converting characters to entities (< to &lt;...etc)

Also gives the filemanager tree the ability to differentiate between files, images, and other non-theme files.