### PR TITLE
Thememapper updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,23 @@ Changelog
 
 2.1.0 (unreleased)
 ------------------
+- add "Save As" option in less builder
+  [obct537]
+
+- add Refresh button to filemanager
+  [obct537]
+
+- filemanager tree now remains open after add/delete/rename/upload
+  [obct537]
+
+- changed styling in thememapper/filemanager to be more consistent and user friendly
+  [obct537]
+
+- better interaction with insert uploaded image/link in tinymce
+  [vangheem]
+
+- add plone primary button styles for insert tinymce modals
+  [vangheem]
 
 - remove unused tablesorter pattern
   [vangheem]
@@ -12,6 +29,9 @@ Changelog
 
 - detect valid url on tinymce external
   [vangheem]
+
+- add Python syntax coloring in text editor
+  [ebrehault]
 
 
 2.0.5 (2015-07-18)

--- a/mockup/patterns/filemanager/js/addnew.js
+++ b/mockup/patterns/filemanager/js/addnew.js
@@ -34,7 +34,12 @@ define([
           },
           success: function(data) {
             self.hide();
-            self.app.refreshTree();          
+            self.data = data;
+            self.app.refreshTree(function() {
+              var path = self.data.parent + '/' +  self.data.name;
+              self.app.selectItem(path);
+              delete self.data;
+            });
           }
         });
         // XXX show loading

--- a/mockup/patterns/filemanager/js/delete.js
+++ b/mockup/patterns/filemanager/js/delete.js
@@ -34,8 +34,21 @@ define([
         },
         success: function(data) {
           self.hide();
-          self.app.refreshTree()
-          self.app.closeActiveTab();
+          self.data = data;
+          self.app.refreshTree(function() {
+
+            var parent = self.data.path;
+            parent = parent.substr(0, parent.lastIndexOf('/'));
+
+            var node = self.app.getNodeByPath(parent);
+            if( node !== null ) {
+                self.app.$tree.tree('openNode', node);
+            }
+
+            delete self.app.fileData[self.data.path];
+            delete self.data;
+          });
+          self.app.closeTab(data.path);
           self.app.resizeEditor();
         }
       });

--- a/mockup/patterns/filemanager/js/newfolder.js
+++ b/mockup/patterns/filemanager/js/newfolder.js
@@ -34,7 +34,12 @@ define([
           },
           success: function(data) {
             self.hide();
-            self.app.refreshTree();
+            self.data = data;
+            self.app.refreshTree(function() {
+              var node = self.app.getNodeByPath(self.data.parent);
+              self.app.$tree.tree('openNode', node);
+              delete self.data;
+            });
           }
         });
         // XXX show loading

--- a/mockup/patterns/filemanager/js/rename.js
+++ b/mockup/patterns/filemanager/js/rename.js
@@ -44,9 +44,28 @@ define([
           },
           success: function(data) {
             self.hide();
-            self.app.refreshTree();
-            // ugly, $tabs should have an API
-            $('.nav .active .remove').click();
+            self.data = data;
+            self.app.refreshTree(function() {
+              if( self.data.newParent != "/" ) {
+                var path = [self.data.newParent, self.data.newName].join('/');
+                var oldPath = [self.data.oldParent, self.data.oldName].join('/');
+              }
+              else {
+                var path = '/' + self.data.newName;
+                var oldPath = '/' + self.data.oldName
+              }
+
+              if( self.app.fileData[path] !== undefined ) {
+                self.app.refreshFile(path)
+              }
+              else {
+                var node = self.app.getNodeByPath(path);
+                self.app.selectItem(path);
+              }
+
+              self.app.closeTab(oldPath);
+              delete self.data;
+            });
           }
         });
         // XXX show loading

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -625,6 +625,14 @@ define([
 
         view.upload.dropzone.options.url = url;
       }
+    },
+    refreshFile: function() {
+      var self = this;
+
+      var path = self.getSelectedNode().path;
+      self.closeActiveTab();
+      delete self.fileData[path];
+      self.selectItem(path);
     }
   });
 

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -523,6 +523,9 @@ define([
           $('[data-path="' + path + '"]').addClass("modified");
         }
       });
+      self.ace.editor.on('paste', function() {
+        $('[data-path="' + path + '"]').addClass("modified");
+      });
       self.ace.editor.commands.addCommand({
         name: 'saveFile',
         bindKey: {

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -354,6 +354,21 @@ define([
         self.openEditor();
       }
     },
+    closeTab: function(path) {
+      var self = this;
+      if( path === undefined ) {
+        return;
+      }
+
+      var tabs = self.$tabs.children();
+
+      $(tabs).each(function() {
+        if( $(this).data('path') == path )
+        {
+          $(this).find('a.remove').trigger('click');
+        }
+      });
+    },
     createTab: function(path) {
       var self = this;
       var $item = $(self.tabItemTemplate({path: path}));
@@ -447,7 +462,7 @@ define([
         for( var z = 0; z < children.length; z++ )
         {
           if( children[z].name == folders[i] ) {
-            if( children[z].folder == true ) {
+            if( children[z].folder == true && i != (folders.length - 1) ) {
               children = children[z].children;
               break;
             }
@@ -629,11 +644,13 @@ define([
         view.upload.dropzone.options.url = url;
       }
     },
-    refreshFile: function() {
+    refreshFile: function(path) {
       var self = this;
 
-      var path = self.getSelectedNode().path;
-      self.closeActiveTab();
+      if( path === undefined ) {
+        path = self.getSelectedNode().path;
+      }
+      self.closeTab(path);
       delete self.fileData[path];
       self.selectItem(path);
     }

--- a/mockup/patterns/thememapper/js/lessbuilderview.js
+++ b/mockup/patterns/thememapper/js/lessbuilderview.js
@@ -11,6 +11,8 @@ define([
       '<span class="message"></span>' +
       '<span style="display: none;" class="errorMessage"></span>' +
       '<div class="buttonBox">' +
+        '<label for="lessFileName">Save as:</label>' +
+        '<input id="lessFileName" type="text" placeholder="filename" />' +
         '<a id="compileBtn" class="btn btn-success" href="#">Compile</a>' +
         '<a id="errorBtn" class="btn btn-default" href="#">Clear</a>' +
       '</div>' +
@@ -32,6 +34,7 @@ define([
       self.$message = $('.message', this.$el);
       self.$error = $('.errorMessage', this.$el);
       self.$button = $('#compileBtn', this.$el);
+      self.$filename = $('#lessFileName', this.$el);
       self.$errorButton = $('#errorBtn', this.$el);
       self.$button.on('click', function() {
         self.showLessBuilder();
@@ -45,6 +48,16 @@ define([
     },
     toggle: function(button, e) {
       PopoverView.prototype.toggle.apply(this, [button, e]);
+      this.setFilename();
+    },
+    setFilename: function() {
+        var self = this;
+        if( self.app.lessPaths['save'] === undefined ) {
+            return;
+        }
+        var f = self.app.lessPaths['save'];
+        f = f.substr(f.lastIndexOf('/') + 1, f.length);
+        self.$filename.attr('placeholder', f);
     },
     start: function() {
       var self = this;

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -411,7 +411,7 @@ define([
       self.fileManager.doAction('saveFile', {
         type: 'POST',
         data: {
-          path: savePath,
+          path: self.lessPaths['save'],
           data: styles,
           _authenticator: utils.getAuthenticator()
         },

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -507,6 +507,16 @@ define([
         tooltip: _t('Compile LESS file'),
         context: 'default'
       });
+      self.refreshButton = new ButtonView({
+        id: 'refreshButton ',
+        title: _t('Refresh'),
+        icon: 'refresh',
+        tooltip: _t('Reload the current file'),
+        context: 'default'
+      });
+      self.refreshButton.on("button:click", function() {
+        self.fileManager.refreshFile();
+      });
       self.helpButton = new ButtonView({
         id: 'helpbutton',
         title: _t('Help'),
@@ -532,6 +542,7 @@ define([
           self.previewThemeButton,
           self.fullscreenButton,
           self.buildLessButton,
+          self.refreshButton,
           self.helpButton
         ],
         id: 'mapper'

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -346,17 +346,6 @@ define([
         }
       };
 
-      //If Ace isn't currently in focus, the browser
-      //will go back to the previous page.
-      //...it's pretty irritating.
-      document.onkeydown = function(e) {
-        if( e.which == 8 )
-        {
-          // 8 = backspace
-          e.preventDefault();
-        }
-      }
-
       // initially, let's hide the panels
       self.hideInspectors();
     },

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -334,7 +334,7 @@ define([
       });
       self.fileManager.$tree.bind('tree.click', function(e){
       });
-      self.buildLessButton.$el.hide();
+      self.buildLessButton.disable();
 
       if( !self.editable ) {
         if( self.fileManager.toolbar ) {
@@ -367,10 +367,10 @@ define([
       var self = this;
 
       if( node.fileType == "less" ){
-        self.buildLessButton.$el.show();
+        self.buildLessButton.enable();
       }
       else{
-        self.buildLessButton.$el.hide();
+        self.buildLessButton.disable();
       }
 
       if( node.path != "" ) {

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -349,6 +349,20 @@ define([
       // initially, let's hide the panels
       self.hideInspectors();
     },
+    setSavePath: function() {
+        var self = this;
+        var filename = self.lessbuilderView.$filename.val()
+
+        if( filename == "" ) {
+            filename = self.lessbuilderView.$filename.attr('placeholder');
+        }
+
+        var s = self.lessPaths['save'];
+        var folder = s.substr(0, s.lastIndexOf('/'));
+
+        var savePath = folder + '/' + filename;
+        self.lessPaths['save'] = savePath;
+    },
     setLessPaths: function(node) {
       var self = this;
 
@@ -392,10 +406,12 @@ define([
         return false;
       }
 
+      self.setSavePath();
+
       self.fileManager.doAction('saveFile', {
         type: 'POST',
         data: {
-          path: self.lessPaths['save'],
+          path: savePath,
           data: styles,
           _authenticator: utils.getAuthenticator()
         },

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -346,6 +346,17 @@ define([
         }
       };
 
+      //If Ace isn't currently in focus, the browser
+      //will go back to the previous page.
+      //...it's pretty irritating.
+      document.onkeydown = function(e) {
+        if( e.which == 8 )
+        {
+          // 8 = backspace
+          e.preventDefault();
+        }
+      }
+
       // initially, let's hide the panels
       self.hideInspectors();
     },

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -310,7 +310,15 @@ body.plone-toolbar-left-default {
 
     #lessBuilder .buttonBox {
         margin-top: 10px;
+
+		label {
+			display: block;
+		}
     }
+
+	#lessFileName {
+		margin-bottom: 15px;
+	}
     .errorMessage {
         word-wrap: break-word;
         font-size: small;

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -322,6 +322,12 @@ body.plone-toolbar-left-default {
 		label {
 			display: block;
 		}
+
+        a {
+            margin-bottom: 5px;
+            margin-left: 5px;
+            padding: 5px;
+        }
     }
 
 	#lessFileName {

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -304,6 +304,14 @@ body.plone-toolbar-left-default {
         }
     }
 
+    .pat-filemanager .navbar a.btn {
+        line-height: 10px;
+        padding: 5px;
+        font-size: small;
+        padding-bottom: 8px;
+        margin-bottom: -15px;
+    }
+
     .btn-group {
         margin-right: 30px;
     }
@@ -326,4 +334,12 @@ body.plone-toolbar-left-default {
     #styleBox {
         display: none;
     }
+
+	#refreshFile {
+		box-shadow: 2px 2px 10px black;
+		position: absolute;
+		z-index: 1000;
+		bottom: 10px;
+		right: 20px;
+	}
 }

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -156,6 +156,10 @@ body.plone-toolbar-left-default {
         .jqtree-tree {
             margin-top: 0px;
 
+            .jqtree-title {
+                padding: 2px;
+            }
+
             li {
                 white-space: nowrap;
                 overflow: hidden;
@@ -171,8 +175,37 @@ body.plone-toolbar-left-default {
             margin-right: 5px;
         }
 
-        .jqtree-selected {
+        ul.jqtree-tree li.jqtree-selected {
             font-weight: bold;
+
+            > .jqtree_common {
+                background-color: #1C4257;
+            }
+
+            a {
+                color: white;
+            }
+
+            span {
+                text-shadow: none;
+                color: white;
+            }
+
+            span:hover {
+                color: #1C4257;
+            }
+
+            div:hover > span{
+                color: #1C4257;
+            }
+        }
+
+        ul.jqtree-tree li.jqtree-selected > div > span:hover {
+            color: white;
+        }
+
+        ul.jqtree-tree li.jqtree-selected > div:hover > span {
+            color: white;
         }
     }
 
@@ -340,12 +373,4 @@ body.plone-toolbar-left-default {
     #styleBox {
         display: none;
     }
-
-	#refreshFile {
-		box-shadow: 2px 2px 10px black;
-		position: absolute;
-		z-index: 1000;
-		bottom: 10px;
-		right: 20px;
-	}
 }

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -175,37 +175,25 @@ body.plone-toolbar-left-default {
             margin-right: 5px;
         }
 
-        ul.jqtree-tree li.jqtree-selected {
-            font-weight: bold;
-
-            > .jqtree_common {
-                background-color: #1C4257;
+        ul.jqtree-tree li.jqtree_common > div:hover {
+            background-color: #1C4257;
+            span {
+                color: white;
+                text-shadow: none;
             }
 
             a {
                 color: white;
-            }
-
-            span {
                 text-shadow: none;
-                color: white;
-            }
-
-            span:hover {
-                color: #1C4257;
-            }
-
-            div:hover > span{
-                color: #1C4257;
             }
         }
 
-        ul.jqtree-tree li.jqtree-selected > div > span:hover {
-            color: white;
-        }
+        ul.jqtree-tree li.jqtree-selected {
+            font-weight: bold;
 
-        ul.jqtree-tree li.jqtree-selected > div:hover > span {
-            color: white;
+            > .jqtree_common {
+                background-color: #E7E7E7;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes/adds several features to the thememapper:
- Let's users specify a filename when building LESS into CSS
- Adds button to reload a file from server
- "Build CSS" button is now disabled, instead of hidden when editing a non-less file, to maintain a      consistent button layout
- Pasting text into the Ace editor will now mark the file as "modified" properly
- The filemanager tree now stays open after a add new/delete/upload/rename
- Renaming a file to a previously-but-no-longer-existent filename will now correctly load the new version of the file
- Slightly changed the highlighting scheme in the thememapper tree to make folder selection more intuitive
- Changed styling of the toolbar buttons to be both more consistent with Plone, and to allow for more buttons on screen


There's a lot going on here, I probably should have broken this into more than 1 pull request ;)