### PR TITLE
Relative urls

### DIFF
--- a/mockup/patterns/thememapper/js/lessbuilderview.js
+++ b/mockup/patterns/thememapper/js/lessbuilderview.js
@@ -130,8 +130,8 @@ define([
           };
           iframe.styles = [];
         },
-        onLoad: function(self) {
-          less.pageLoadFinished.then(
+        onLoad: function(iframe) {
+          iframe.window.less.pageLoadFinished.then(
             function() {
               var $ = window.parent.$;
               var iframe = window.iframe['lessc'];

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -412,6 +412,7 @@ define([
         type: 'POST',
         data: {
           path: self.lessPaths['save'],
+          relativeUrls: true,
           data: styles,
           _authenticator: utils.getAuthenticator()
         },


### PR DESCRIPTION
Fixes the lessbuilder throwing "less is undefined" when the user isn't in dev mode.

Added the option to remove absolute urls from CSS files built in the lessbuilder.
Goes along with: https://github.com/plone/plone.resourceeditor/pull/9