### PR TITLE
Fix the regular expression

### DIFF
--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -160,12 +160,12 @@ define([
           reg = /<body.*data-view-url=[\"'](.*)[\"'].*/im.exec(response);
           if (reg && reg.length > 1) {
             // view url as data attribute on body (Plone 5)
-            return reg[1];
+            return reg[1].split('"')[0];
           }
           reg = /<body.*data-base-url=[\"'](.*)[\"'].*/im.exec(response);
           if (reg && reg.length > 1) {
             // Base url as data attribute on body (Plone 5)
-            return reg[1];
+            return reg[1].split('"')[0];
           }
           reg = /<base.*href=[\"'](.*)[\"'].*/im.exec(response);
           if (reg && reg.length > 1) {

--- a/mockup/tests/pattern-modal-test.js
+++ b/mockup/tests/pattern-modal-test.js
@@ -144,11 +144,11 @@ define([
           )).to.equal('testurl2');
           expect(modal.defaults.actionOptions.redirectToUrl(
             'ignore',
-            '<html><body data-base-url="testurl3"></body></html>'
+            '<html><body data-base-url="testurl3" rubbish="discarded"></body></html>'
           )).to.equal('testurl3');
           expect(modal.defaults.actionOptions.redirectToUrl(
             'ignore',
-            '<html><body data-view-url="testurl4"></body></html>'
+            '<html><body data-view-url="testurl4" rubbish="discarded"></body></html>'
           )).to.equal('testurl4');
           done();
         })


### PR DESCRIPTION
Regular expression was failing when the data-attribute is not the last attribute in the tag, see:
 - https://regex101.com/r/pI4kL9/1

I wanted to use jQuery instead of regexp bacause:
 - we have it
 - it is less error prone
 - it is more clear

but it turns out it is too complicated to be cross browser.