### PR TITLE
tinyMCE inline editing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 Changelog
 =========
 
-2.0.7 (Unreleased)
+2.0.8 (Unreleased)
 ------------------
 
-- No changes yet.
+- Add option to use tinyMCE inline on a contenteditable div. The pattern
+  creates the contenteditable div from the textarea, copies it's content to it
+  and handles saving changed data back to the textarea on form submit.
+  [thet]
 
 
 2.0.7 (2015-09-07)

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -387,6 +387,33 @@ define([
       expect(pattern.linkModal.linkTypes.anchor.toUrl()).to.equal('#foobar');
     });
 
+    it('test inline tinyMCE roundtrip', function() {
+      var $container = $(
+       '<form>' +
+       '<textarea class="pat-tinymce" data-pat-tinymce=\'{"tiny": {"inline": true}}\'>' +
+       '<h1>just testing</h1>' +
+       '</textarea>' +
+       '</form>'
+      ).appendTo('body');
+      registry.scan($container);
+
+      var $el = $container.find('textarea');
+      var id = $el.attr('id');
+
+      var $editable = $container.find('#' + id + '-editable');
+
+      // check, if everything is in place
+      expect($editable.is('div')).to.be.equal(true);
+      expect($editable.html()).to.be.equal($el.val());
+
+      // check, if changes are submitted on form submit
+      var changed_txt = 'changed contents';
+      $editable.html(changed_txt);
+      var $form = $container.find('form');
+      $container.trigger('submit');
+      expect($el.val()).to.be.equal(changed_txt);
+    });
+
   });
 
 });


### PR DESCRIPTION
Add option to use tinyMCE inline on a contenteditable div. The pattern creates
the contenteditable div from the textarea, copies it's content to it and
handles saving changed data back to the textarea on form submit.