### PR TITLE
Pathing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.0.8 (Unreleased)
 ------------------
 
+- Fixed issue causing folders to be overwritten in the thememapper 
+  [obct537]
+
+- Thememapper popups now close when the user clicks somewhere else 
+  [obct537]
+
 - Add option to use tinyMCE inline on a contenteditable div. The pattern
   creates the contenteditable div from the textarea, copies it's content to it
   and handles saving changed data back to the textarea on form submit.

--- a/mockup/patterns/filemanager/js/delete.js
+++ b/mockup/patterns/filemanager/js/delete.js
@@ -45,10 +45,11 @@ define([
                 self.app.$tree.tree('openNode', node);
             }
 
+            self.app.closeActiveTab();
+
             delete self.app.fileData[self.data.path];
             delete self.data;
           });
-          self.app.closeTab(data.path);
           self.app.resizeEditor();
         }
       });

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -222,7 +222,7 @@ define([
 
       self._save = function() {
 
-        var path = self.getNodePath();
+        var path = $('.active', self.$tabs).data('path');
         if( path === undefined ) {
           alert("No file selected.");
           return;
@@ -230,12 +230,12 @@ define([
         self.doAction('saveFile', {
           type: 'POST',
           data: {
-            path: self.getNodePath(),
+            path: path,
             data: self.ace.editor.getValue(),
             _authenticator: utils.getAuthenticator()
           },
           success: function(data) {
-            $('[data-path="' + self.getNodePath() + '"]').removeClass("modified");
+            $('[data-path="' + path + '"]').removeClass("modified");
           }
         });
       };

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -272,6 +272,25 @@ define([
       self.tree = new Tree(self.$tree, self.options.treeConfig);
       self.$editor = self.$('.editor');
 
+      /* close popovers when clicking away */
+      $(document).click(function(e){
+          var $el = $(e.target);
+          if(!$el.is(':visible')){
+              // ignore this, fake event trigger to element that is not visible
+              return;
+          }
+          if($el.is('a') || $el.parent().is('a')){
+              return;
+          }
+          var $popover = $('.popover:visible');
+          if($popover.length > 0 && !$.contains($popover[0], $el[0])){
+              var popover = $popover.data('component');
+              if(popover){
+                  popover.hide();
+              }
+          }
+      });
+
       self.$tree.bind('tree.select', function(e) {
         if( e.node === null ) {
           self.toggleButtons(false);

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -223,7 +223,7 @@ define([
       self._save = function() {
 
         var path = $('.active', self.$tabs).data('path');
-        if( path === undefined ) {
+        if( path === undefined || path === false ) {
           alert("No file selected.");
           return;
         }
@@ -235,6 +235,9 @@ define([
             _authenticator: utils.getAuthenticator()
           },
           success: function(data) {
+            if( data['error'] !== undefined ) {
+              alert("There was a problem saving the file.");
+            }
             $('[data-path="' + path + '"]').removeClass("modified");
           }
         });

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -593,7 +593,9 @@ define([
       if (path !== '/'){
         path += '/';
       }
-      return path + node.name;
+
+      var name = (node.name !== undefined) ? node.name : '';
+      return path + name;
     },
     getFolderPath: function(node){
       var self = this;


### PR DESCRIPTION
Fixes several issues with paths being set incorrectly in the filemanager, including one that could potentially overwrite an entire folder.

Fixes erratic behavior when using the Delete button in the filemanager.

Also makes popovers close when the user clicks elsewhere in the thememapper