### PR TITLE
Raise pat-modal z-index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.0.9 (Unreleased)
 ------------------
 
+- Raise pat-modal ``z-index`` to make sure, it's displayed above anything else,
+  e.g. TinyMCE's toolbar in inline editing mode.
+  [thet]
+
 - Fix inline TinyMCE to work together with ``pat-textareamimetypeselector``.
   [thet]
 

--- a/mockup/patterns/modal/pattern.modal.less
+++ b/mockup/patterns/modal/pattern.modal.less
@@ -1,5 +1,9 @@
 @import "@{mockuplessPath}/base.less";
 
+.plone-modal-wrapper {
+    z-index: 999999 !important; // make sure, modal is on very top.
+}
+
 .plone-modal-loading {
   .plone-progress-bar();
   .progress.active .progress-bar();


### PR DESCRIPTION
Raise pat-modal ``z-index`` to make sure, it's displayed above anything
else, e.g. TinyMCE's toolbar in inline editing mode.