### PR TITLE
Refs CMFPlone #891 added more i18n strings to pickadate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.9 (Unreleased)
 ------------------
 
+- Pass more i18n labels to the PickADate pattern
+  [ichim-david]
+
 - Use hash to keep autotoc position settings
   [vangheem]
 

--- a/mockup/patterns/pickadate/pattern.js
+++ b/mockup/patterns/pickadate/pattern.js
@@ -102,7 +102,14 @@ define([
         selectYears: true,
         selectMonths: true,
         formatSubmit: 'yyyy-mm-dd',
-        format: 'yyyy-mm-dd'
+        format: 'yyyy-mm-dd',
+        clear: _t('Clear'),
+        close: _t('Close'),
+        today: _t('Today'),
+        labelMonthNext: _t('Next month'),
+        labelMonthPrev: _t('Previous month'),
+        labelMonthSelect: _t('Select a month'),
+        labelYearSelect: _t('Select a year')
       },
       time: {
       },


### PR DESCRIPTION
This should add extra i18n labels for the pickadate widget needed for the
https://github.com/plone/Products.CMFPlone/issues/891

@vangheem  I have some question regarding the i18n process.
I ran:
 <pre>make i18n</pre> 
This is advised in the readme of the mockup to generate a widgets.pot file.
Here is the diff for it and the widgets.pot from plone.app.locales
https://gist.github.com/ichim-david/83686321d847d4723e2e

EDIT: Basically the new labels for pickdate plugin are referenced from build/plone.js instead of patterns/pickadate/js/pattern.js plus some deleted strings which I don't know if they were still relevant.

I don't know if this is correct and if you need to pass any flags to the make  i18n command.
Running on buildout root:
<pre>bin/i18n-update-all</pre>
produced the following output:
https://gist.github.com/ichim-david/af4f7e4f28272a74d459

I see some errors but I didn't make any changes to the widgets.pot file from plone.app.locales
so I assume that once widgets.pot was created in mockups it was overridden in plone.app.locales.

Let me know if I should update widgets.pot or if there is a better workflow that I need to follow in order to get the strings correctly added.