### PR TITLE
Inline tinyMCE / mosaic fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.0.9 (Unreleased)
 ------------------
 
+- Fix inline TinyMCE to work together with mosaic. The ``inline`` option must
+  now be passed to the patterns option object instead to the patterns tiny
+  options object.
+  [thet]
+
 - Pass more i18n labels to the PickADate pattern
   [ichim-david]
 
@@ -20,10 +25,10 @@ Changelog
 2.0.8 (2015-09-08)
 ------------------
 
-- Fixed issue causing folders to be overwritten in the thememapper 
+- Fixed issue causing folders to be overwritten in the thememapper
   [obct537]
 
-- Thememapper popups now close when the user clicks somewhere else 
+- Thememapper popups now close when the user clicks somewhere else
   [obct537]
 
 - Add option to use tinyMCE inline on a contenteditable div. The pattern

--- a/mockup/patterns/textareamimetypeselector/pattern.js
+++ b/mockup/patterns/textareamimetypeselector/pattern.js
@@ -70,11 +70,11 @@
  *            "text/html": {
  *              "pattern": "tinymce",
  *              "patternOptions": {
+ *                "inline": true,
  *                "tiny": {
  *                  "plugins": [],
  *                  "menubar": "edit format tools",
- *                  "toolbar": " ",
- *                  "inline": true
+ *                  "toolbar": " "
  *                }
  *              }
  *            }

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -187,7 +187,7 @@ define([
                  'bullist numlist outdent indent | ' +
                  'unlink plonelink ploneimage',
         //'autoresize_max_height': 900,
-        'height': 400,
+        'height': 400
       },
       inline: false
     },

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -10,13 +10,14 @@
  *    folderTypes(string): TODO ('Folder,Plone Site')
  *    linkableTypes(string): TODO ('Document,Event,File,Folder,Image,News Item,Topic')
  *    tiny(object): TODO ({ plugins: [ "advlist autolink lists charmap print preview anchor", "usearchreplace visualblocks code fullscreen autoresize", "insertdatetime media table contextmenu paste plonelink ploneimage" ], menubar: "edit table format tools view insert",
- toolbar: "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | unlink plonelink ploneimage", autoresize_max_height: 1500, inline: false })
+ toolbar: "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | unlink plonelink ploneimage", autoresize_max_height: 1500 })
  *    prependToUrl(string): Text to prepend to generated internal urls. ('')
  *    appendToUrl(string): Text to append to generated internal urls. ('')
  *    prependToScalePart(string): Text to prepend to generated image scale url part. ('/imagescale/')
  *    appendToScalePart(string): Text to append to generated image scale url part. ('')
  *    linkAttribute(string): Ajax response data attribute to use for url. ('path')
  *    defaultScale(string): Scale name to default to. ('Original')
+ *    inline(boolean): Show tinyMCE editor inline instead in an iframe. Use this on textarea inputs. If you want to use this pattern directly on a contenteditable, pass "inline: true" to the "tiny" options object. (false)
  *
  * Documentation:
  *    # Default
@@ -49,7 +50,7 @@
  *
  * Example: example-3
  *    <form>
- *      <textarea class="pat-tinymce" data-pat-tinymce='{"tiny": {"inline": true}}'>
+ *      <textarea class="pat-tinymce" data-pat-tinymce='{"inline": true}'>
  *        <h3>I'm a content editable</h3>
  *        <p>Try to edit me!</p>
  *      </textarea>
@@ -187,8 +188,8 @@ define([
                  'unlink plonelink ploneimage',
         //'autoresize_max_height': 900,
         'height': 400,
-        inline: false
-      }
+      },
+      inline: false
     },
     addLinkClicked: function() {
       var self = this;
@@ -345,7 +346,10 @@ define([
       // tiny needs an id in order to initialize. Creat it if not set.
       var id = utils.setId(self.$el);
       var tinyOptions = self.options.tiny;
-      self.tinyId = tinyOptions.inline ? id + '-editable' : id;  // when displaying TinyMCE inline, a separate div is created.
+      if (self.options.inline === true) {
+        self.options.tiny.inline = true;
+      }
+      self.tinyId = self.options.inline ? id + '-editable' : id;  // when displaying TinyMCE inline, a separate div is created.
       tinyOptions.selector = '#' + self.tinyId;
       tinyOptions.addLinkClicked = function() {
         self.addLinkClicked.apply(self, []);
@@ -386,7 +390,7 @@ define([
           self.options.imageTypes = self.options.imageTypes.split(',');
         }
 
-        if (tinyOptions.inline === true) {
+        if (self.options.inline === true) {
           // create a div, which will be made content-editable by TinyMCE and
           // copy contents from textarea to it. Then hide textarea.
           self.$el.after('<div id="' + self.tinyId + '">' + self.$el.val() + '</div>');
@@ -400,7 +404,7 @@ define([
          * but this fixes overlays not saving data */
         var $form = self.$el.parents('form');
         $form.on('submit', function() {
-          if (tinyOptions.inline === true) {
+          if (self.options.inline === true) {
             // save back from contenteditable to textarea
             self.$el.val(self.tiny.getContent());
           } else {
@@ -412,7 +416,7 @@ define([
     },
     destroy: function() {
       if (this.tiny) {
-        if (this.options.tiny.inline === true) {
+        if (this.options.inline === true) {
           // destroy also inline editable
           this.$el.val(this.tiny.getContent());
           $('#' + this.tinyId).remove();

--- a/mockup/tests/pattern-textareamimetypeselector-test.js
+++ b/mockup/tests/pattern-textareamimetypeselector-test.js
@@ -90,11 +90,11 @@ define([
         '        "text/html": {' +
         '          "pattern": "tinymce",' +
         '          "patternOptions": {' +
+        '            "inline": true,' +
         '            "tiny": {' +
         '              "plugins": [],' +
         '              "menubar": "edit format tools",' +
-        '              "toolbar": " ",' +
-        '              "inline": true' +
+        '              "toolbar": " "' +
         '            }' +
         '          }' +
         '        }' +

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -390,7 +390,7 @@ define([
     it('test inline tinyMCE roundtrip', function() {
       var $container = $(
        '<form>' +
-       '<textarea class="pat-tinymce" data-pat-tinymce=\'{"tiny": {"inline": true}}\'>' +
+       '<textarea class="pat-tinymce" data-pat-tinymce=\'{"inline": true}\'>' +
        '<h1>just testing</h1>' +
        '</textarea>' +
        '</form>'


### PR DESCRIPTION
Fix inline tinyMCE to work together with mosaic. The inline option must now be passed to the patterns option object instead to the patterns tiny options object.