### PR TITLE
pat-moment: fall back to English

### DIFF
--- a/mockup/patterns/moment/pattern.js
+++ b/mockup/patterns/moment/pattern.js
@@ -105,7 +105,7 @@ define([
       if (!date) {
         date = $.trim($el.html());
       }
-      moment.locale((new i18n()).currentLanguage);
+      moment.locale([(new i18n()).currentLanguage, 'en']);
       date = moment(date);
       if (!date.isValid()) {
         return;


### PR DESCRIPTION
Currently if you select a language which isn't supported by moment.js the last language in the list of available languages is used (Chinese). This PR uses English as the fallback instead.

See plone/Products.CMFPlone#1028

I'm having trouble adding a test for this:

      $('html').attr('lang', 'fr');
      var $el = $('<div class="pat-moment" data-pat-moment="format:relative">' + date + '</div>');
      registry.scan($el);
      var i18n = new I18n();
      console.log(i18n.currentLanguage);

Shows the language set to 'fr', but when I inspect pat-moment I see that new i18n()).currentLanguage is returning 'en-us'.