### PR TITLE
feat: add option to select moment format in structure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Changelog
     in the `Base.extend` call.
     Refer to any of the core Mockup patterns for examples.
 
+- Add the ``momentFormat`` option to the ``structure`` pattern.
+  [Gagaro]
+
+
 2.0.12 (2015-09-20)
 -------------------
 

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -101,10 +101,9 @@ define([
           container.append(view.el);
         });
       }
-
       self.moment = new Moment(self.$el, {
         selector: '.ModificationDate,.EffectiveDate,.CreationDate,.ExpirationDate',
-        format: 'relative'
+        format: self.options.app.momentFormat
       });
       self.addReordering();
       self.storeOrder();

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -75,6 +75,7 @@ define([
         'last_comment_date': 'Last comment date',
         'total_comments': 'Total comments'
       },
+      momentFormat: 'relative',
       rearrange: {
         properties: {
           'id': 'ID',


### PR DESCRIPTION
I would like to be able to choose the moment formatting in structures. As I am fairly new to mockup, I don't know if this is the best way to do it (I tried with html attributes but it seems to not working because of the Moment pattern being initialized in JS ?).

Please also note that this is not based on master because of #589.