### PR TITLE
fix: ensure we have all content for tree query in relateditems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,11 @@ Fixes:
 
 - Fix `aria-hidden` attribute control problem on folder content panel
   [terapyon]
+
 - Trim links in tinymce before inserting them in the source.
+  [Gagaro]
+
+- Ensure we have all content for tree query in relateditems
   [Gagaro]
 
 2.1.2 (2016-01-08)

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -108,6 +108,9 @@ define([
       attributes: ['UID', 'Title', 'portal_type', 'path','getURL', 'getIcon','is_folderish','review_state'],
       dropdownCssClass: 'pattern-relateditems-dropdown',
       maximumSelectionSize: -1,
+      treeOptions: {
+        vocabularyUrl: null, // must be set to work
+      },
       resultTemplate: '' +
         '<div class="   pattern-relateditems-result  <% if (selected) { %>pattern-relateditems-active<% } %>">' +
         '  <a href="#" class=" pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %>">' +
@@ -365,12 +368,13 @@ define([
       self.treeQuery = new utils.QueryHelper(
         $.extend(true, {}, self.options, {
           pattern: self,
+          vocabularyUrl: self.options.treeOptions.vocabularyUrl || self.options.vocabularyUrl,
           baseCriteria: [{
             i: 'is_folderish',
             o: 'plone.app.querystring.operation.selection.any',
             v: 'True'
           }]
-        })
+        }, self.options.treeOptions)
       );
 
       self.options.ajax = self.options.setupAjax.apply(self);

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -307,7 +307,8 @@ define([
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
       var pattern = $('.pat-relateditems', $el).patternRelateditems().data('patternRelateditems');
 
@@ -329,7 +330,8 @@ define([
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
       var pattern = $('.pat-relateditems', $el).patternRelateditems().data('patternRelateditems');
 
@@ -353,7 +355,8 @@ define([
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
       var pattern = $('.pat-relateditems', $el).patternRelateditems().data('patternRelateditems');
 
@@ -384,7 +387,8 @@ define([
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
         '                          maximumSelectionSize: 1;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
       var pattern = $('.pat-relateditems', $el).patternRelateditems().data('patternRelateditems');
 
@@ -405,7 +409,8 @@ define([
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
         '        data-pat-relateditems="width: 300px;' +
         '                          maximumSelectionSize: 1;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
       var pattern = $('.pat-relateditems', $el).patternRelateditems().data('patternRelateditems');
 
@@ -421,7 +426,8 @@ define([
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
         '        data-pat-relateditems="width: 300px;' +
         '                          maximumSelectionSize: 1;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
 
       var clock = sinon.useFakeTimers();
@@ -443,7 +449,8 @@ define([
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
         '        data-pat-relateditems="width: 300px;' +
         '                          maximumSelectionSize: 1;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
 
       var clock = sinon.useFakeTimers();
@@ -469,7 +476,8 @@ define([
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
         '        data-pat-relateditems="width: 300px;' +
         '                          maximumSelectionSize: 1;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
 
       var clock = sinon.useFakeTimers();
@@ -498,7 +506,8 @@ define([
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
         '        data-pat-relateditems="width: 300px;' +
         '                          maximumSelectionSize: 1;' +
-        '                          vocabularyUrl: /relateditems-test.json" />' +
+        '                          vocabularyUrl: /relateditems-test.json;' +
+        '                          treeOptions: {vocabularyUrl: /relateditems-test.json}" />' +
         '</div>').appendTo('body');
 
       var clock = sinon.useFakeTimers();


### PR DESCRIPTION
There is no changelog yet because it does not seem to be completely fixed and I'm not sure this is the better way to do it, so I'd like to discuss it first.

The issue I have is that for certain related widget (in my case, in the collection portlet), the `vocabularyUrl` option is set to `@@getSource`, which cause the results to be filtered by the field parameters (in my case, only `Collections`).

So it is impossible to browser the site using the related items widget in the Collection portlet form. I was able to kinda solve it with this fix but I'd like some input.

* Is `$('body').attr('data-portal-url')` the best way to get the portal url in a mockup ?
* I seem to only be able to browser a single level when using the right arrow (probably because it uses the results from the actual request), but I didn't find where it is done yet. If anyone have an idea, don't hesitate to comment :smile: .

Thanks.