### PR TITLE
Modal fix: configs of additional modals in a page are ignored.

### DIFF
--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -522,9 +522,9 @@ define([
           .addClass(self.options.templateOptions.classWrapperName)
           .insertBefore(self.backdrop.$backdrop)
           .on('click', function(e) {
-            e.stopPropagation();
-            e.preventDefault();
             if (this.options.backdropOptions.closeOnClick) {
+              e.stopPropagation();
+              e.preventDefault();
               this.backdrop.hide();
             }
           }.bind(this));

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -187,10 +187,7 @@ define([
         if (self.options.automaticallyAddButtonActions) {
           actions[self.options.buttons] = {};
         }
-
-        if (self.options.loadLinksWithinModal) {
-          actions.a = {};
-        }
+        actions.a = {};
 
         $.each(actions, function(action, options) {
           var actionKeys = _.union(_.keys(self.options.actionOptions), ['templateOptions']);
@@ -527,10 +524,10 @@ define([
           .on('click', function(e) {
             e.stopPropagation();
             e.preventDefault();
-            if (self.options.backdropOptions.closeOnClick) {
-              self.backdrop.hide();
+            if (this.options.backdropOptions.closeOnClick) {
+              this.backdrop.hide();
             }
-          });
+          }.bind(this));
       }
 
       // Router

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -469,16 +469,6 @@ define([
 
         self.$modal
           .addClass(self.options.templateOptions.className)
-          .on('click', function(e) {
-            e.stopPropagation();
-            if ($.nodeName(e.target, 'a')) {
-              e.preventDefault();
-
-              // TODO: open links inside modal
-              // and slide modal body
-            }
-            self.$modal.trigger('modal-click');
-          })
           .on('destroy.plone-modal.patterns', function(e) {
             e.stopPropagation();
             self.hide();
@@ -489,8 +479,19 @@ define([
             self.positionModal();
           })
           .appendTo(self.$wrapperInner);
-        self.$modal.data('pattern-' + self.name, self);
 
+        if (self.options.loadLinksWithinModal) {
+          self.$modal.on('click', function(e) {
+            e.stopPropagation();
+            if ($.nodeName(e.target, 'a')) {
+              e.preventDefault();
+              // TODO: open links inside modal
+              // and slide modal body
+            }
+            self.$modal.trigger('modal-click');
+          });
+        }
+        self.$modal.data('pattern-' + self.name, self);
         self.emit('after-render');
       }
     },

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -500,6 +500,7 @@ define([
     },
     init: function() {
       var self = this;
+      self.options.loadLinksWithinModal = $.parseJSON(self.options.loadLinksWithinModal);
 
       self.backdrop = new Backdrop(
           self.$el.parents(self.options.backdrop),

--- a/mockup/tests/pattern-modal-test.js
+++ b/mockup/tests/pattern-modal-test.js
@@ -74,9 +74,9 @@ define([
 
       registry.scan($el);
 
-      expect($('.plone-modal-backdrop', $el).is(':hidden')).to.be.equal(true);
+      expect($('.plone-modal-wrapper', $el).size()).to.be.equal(0);
       expect($el.hasClass('plone-backdrop-active')).to.be.equal(false);
-      expect($('.plone-modal-wrapper', $el).is(':hidden')).to.be.equal(true);
+      expect($('.plone-modal-backdrop', $el).size()).to.be.equal(0);
       expect($('.plone-modal', $el).size()).to.equal(0);
 
       $('a.pat-plone-modal', $el).click();


### PR DESCRIPTION
The event handler on the inner wrapper which listens to clicks and decides whether a modal should be closed or not, was being hijacked by the first modal that was registered so that modal's config would have first say.

I updated the code to lazily create the backdrop, wrapper and inner wrapper, and I remove the wrapper afterwards, so that the click event is registered lazily per modal.

Fixes a problem @instification had at Plone conf sprint.