### PR TITLE
fix: separate buttons from checkbox label in the resource registry

### DIFF
--- a/mockup/patterns/resourceregistry/js/registry.js
+++ b/mockup/patterns/resourceregistry/js/registry.js
@@ -356,7 +356,7 @@ define([
 
   var RegistryView = BaseResourcesPane.extend({
     template: _.template(
-      '<div class="buttons-container">' +
+      '<div class="row buttons-container">' +
         '<div class="plone-btn-group pull-right">' +
           '<button class="plone-btn plone-btn-primary save"><%- _t("Save") %></button>' +
           '<button class="plone-btn plone-btn-default cancel"><%- _t("Cancel") %></button>' +


### PR DESCRIPTION
When we have a longer label (in the place "Development Mode(only logged in users)"), it goes in front of the buttons and we can't click on them anymore.