### PR TITLE
fix: modal when leaving a modal in a modal.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Fixes:
 - Set value for ``ReferenceWidget`` in querystring.
   [Gagaro]
 
+- Fix modal when leaving a modal in a modal.
+  [Gagaro]
+
 
 2.0.12 (2015-09-20)
 -------------------

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -847,18 +847,18 @@ define([
           return;
         }
       }
-      if ($('.plone-modal', self.$wrapper).size() < 2) {
-        self.backdrop.hide();
-        self.$wrapper.remove();
-        $('body').removeClass('plone-modal-open');
-      }
       self.loading.hide();
       self.$el.removeClass(self.options.templateOptions.classActiveName);
       if (self.$modal !== undefined) {
         self.$modal.remove();
         self.initModal();
       }
-      $(window.parent).off('resize.plone-modal.patterns');
+      self.$wrapper.remove();
+      if ($('.plone-modal', $('body')).size() < 1) {
+        self.backdrop.hide();
+        $('body').removeClass('plone-modal-open');
+        $(window.parent).off('resize.plone-modal.patterns');
+      }
       self.emit('hidden');
     },
 


### PR DESCRIPTION
My issue is with the static portlet. The add form is in a modal. Tinymce can open other modals (eg images/link). If I close this modal, it will close both of them.

This PR fixes that.