### PR TITLE
Z-index error in widget related items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Fixes:
 
 - Set value for ``ReferenceWidget`` in querystring.
   [Gagaro]
+  
+- Correction of a mistake in css z-index related items widget. 
+  The content bar appeared behind the widget.
+  [hersonrodrigues]
 
 
 2.0.12 (2015-09-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,8 +34,7 @@ Fixes:
   [Gagaro]
   
 - Correction of a mistake in css z-index related items widget. 
-  The content bar appeared behind the widget.
-  [hersonrodrigues]
+  The content bar appeared behind the widget. [hersonrodrigues]
 
 
 2.0.12 (2015-09-20)

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -38,7 +38,7 @@
   font-size: 12px;
   border: 1px solid #aaa;
   border-bottom-style: none;
-  z-index: 999;
+  z-index: 4;
   position: relative;
   padding: 0 6px;
   color: #333;


### PR DESCRIPTION
The position of the widget related items (z-index) is high in relation to the added content menu.