### PR TITLE
Fixes TinyMCE visual aid for tables and others

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,14 @@ Fixes:
   [maurits]
 - Import TinyMCE ``Content.less`` from the lightgray skin as less file, not
   inline. Fixes plone/Products.CMFPlone/#755.
+- Enforce a ``min-width`` for tables while editing and visual aids turned on.
+  Fixes plone/Products.CMFPlone#920.
+  [thet]
+
+- Import TinyMCE ``Content.Objects.less`` from the lightgray skin in ``less``
+  mode, not ``Content.less`` in ``inline`` mode.
+  Fixes plone/Products.CMFPlone/#755 - visual aids not visible.
+  ``Content.Objects.less`` also doesn't overwrite our fonts.
   [thet]
 
 - Cleanup and rework: contenttype-icons and showing thumbnails

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ Fixes:
 - Use ``selection.any`` in querystring pattern.
   Issue https://github.com/plone/Products.CMFPlone/issues/1040
   [maurits]
+- Import TinyMCE ``Content.less`` from the lightgray skin as less file, not
+  inline. Fixes plone/Products.CMFPlone/#755.
+  [thet]
 
 - Cleanup and rework: contenttype-icons and showing thumbnails
   for images/leadimages in listings ...

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,16 +30,15 @@ Fixes:
 - Use ``selection.any`` in querystring pattern.
   Issue https://github.com/plone/Products.CMFPlone/issues/1040
   [maurits]
-- Import TinyMCE ``Content.less`` from the lightgray skin as less file, not
-  inline. Fixes plone/Products.CMFPlone/#755.
-- Enforce a ``min-width`` for tables while editing and visual aids turned on.
-  Fixes plone/Products.CMFPlone#920.
-  [thet]
 
 - Import TinyMCE ``Content.Objects.less`` from the lightgray skin in ``less``
   mode, not ``Content.less`` in ``inline`` mode.
   Fixes plone/Products.CMFPlone/#755 - visual aids not visible.
   ``Content.Objects.less`` also doesn't overwrite our fonts.
+  [thet]
+
+- Enforce a ``min-width`` for tables while editing and visual aids turned on.
+  Fixes plone/Products.CMFPlone#920.
   [thet]
 
 - Cleanup and rework: contenttype-icons and showing thumbnails

--- a/mockup/patterns/tinymce/less/pattern.tinymce.less
+++ b/mockup/patterns/tinymce/less/pattern.tinymce.less
@@ -1,5 +1,5 @@
 @import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/skin.less";
-@import (inline) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/Content.less";
+@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/Content.less";
 @import (inline) "@{bowerPath}/tinymce-builded/js/tinymce/plugins/visualblocks/css/visualblocks.css";
 @import "@{mockupPath}/modal/pattern.modal.less";
 @import "@{mockupPath}/autotoc/pattern.autotoc.less";

--- a/mockup/patterns/tinymce/less/pattern.tinymce.less
+++ b/mockup/patterns/tinymce/less/pattern.tinymce.less
@@ -1,5 +1,5 @@
 @import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/skin.less";
-@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/Content.less";
+@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/Content.Objects.less";
 @import (inline) "@{bowerPath}/tinymce-builded/js/tinymce/plugins/visualblocks/css/visualblocks.css";
 @import "@{mockupPath}/modal/pattern.modal.less";
 @import "@{mockupPath}/autotoc/pattern.autotoc.less";
@@ -100,3 +100,6 @@ div.linkModal {
     max-width: 80px;
 }
 
+.mce-item-table td {
+	min-width: 0.6em;  // enforce a min-width while editing for tables with visual aid turned on
+}


### PR DESCRIPTION
- Import TinyMCE ``Content.Objects.less`` from the lightgray skin in ``less``
  mode, not ``Content.less`` in ``inline`` mode.
  Fixes plone/Products.CMFPlone#755 - visual aids not visible.
  ``Content.Objects.less`` also doesn't overwrite our fonts.

- Enforce a ``min-width`` for tables while editing and visual aids turned on.
  Fixes plone/Products.CMFPlone#920.

Actually it's more like another fix for plone/Products.CMFPlone#755
@vangheem - I think this could make https://github.com/plone/plonetheme.barceloneta/pull/31/files obsolete. See my comments there.
