### PR TITLE
Take complex portal types into account

### DIFF
--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -1,7 +1,7 @@
 <td class="selection"><input type="checkbox" <% if(selected){ %> checked="checked" <% } %>/></td>
 
 <td class="title">
-  <a href="<%- getURL %>" class="manage state-<%- review_state %> contenttype-<%- portal_type.toLowerCase() %>"
+  <a href="<%- getURL %>" class="manage state-<%- review_state %> contenttype-<%- portal_type.toLowerCase().replace(/\.| /g, '-') %>"
   title="<%- portal_type %>" >
  
    <%- Title %></a>


### PR DESCRIPTION
In folder_contents view, the news item icon doesn't appear because its portal_type is "News Item". The code in line 4 results in a class string "contenttype-news item", which effectively means two classes, "contenttype-news" and "item".

Another typical case where this fails is for custom content types, which by default with dexterity will be named something like "my.package.mytype". This results in the class string "contenttype-my.package.mytype" which can't be referenced in css, as it is illegal.

This patch simply replaces these cases with a dash. For news items, this results in contenttype-news-item, which is exactly how the news item icon is coded in contents.plone.less, so news items will immediately have an icon again.