### PR TITLE
Fix issue with query string widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Fixes:
 
 - be able to use multiple importcss_file_filter files
   [vangheem]
+- Fix issue where if existing querystring path value is ".::1",
+  after edit, the wrong value will be selected
 
 - Calculate z-index for modals dynamically to always be on top
   [vangheem]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,12 @@ New:
 
 Fixes:
 
+- fix saving values for query string
+  [vangheem]
+
 - be able to use multiple importcss_file_filter files
   [vangheem]
+
 - Fix issue where if existing querystring path value is ".::1",
   after edit, the wrong value will be selected
 

--- a/mockup/patterns/querystring/pattern.js
+++ b/mockup/patterns/querystring/pattern.js
@@ -364,7 +364,6 @@ define([
         self.appendOperators(index);
         self.createValue(index);
       } else if (widget === 'RelativePathWidget') {
-
         if( self.advanced ) {
           self.$value = $('<input type="text"/>')
             .addClass(self.options.classValueName + '-' + widget)
@@ -376,14 +375,20 @@ define([
         }else{
           //These 2 hard-coded values correspond to the "Current (./)" and "Parent (../)" options
           //under the location index.
-          var val = ".::1";
-          if ( self.$operator.val().indexOf('relativePath') > 0 ) {
-            val = "..::1";
+          if(!value){
+            value = ".::1";
+            if ( self.$operator.val().indexOf('relativePath') > 0 ) {
+              value = "..::1";
+            }
+          }else{
+            if(value === '.::1'){
+              self.$operator.select2('val', 'plone.app.querystring.operation.string.path');
+            }
           }
           self.$value = $('<input type="hidden"/>')
           .addClass(self.options.classValueName + '-' + widget)
           .appendTo($wrapper)
-          .val(val);
+          .val(value);
         }
       } else if (widget === 'ReferenceWidget') {
         if( self.advanced ) {
@@ -441,7 +446,7 @@ define([
         }
         else {
           var trimmedValue = value;
-          if( typeof value === "string" ) {
+          if( typeof value === "string" && widget !== 'RelativePathWidget') {
             trimmedValue = value.replace(/::[0-9]+/, '');
           }
           self.$value.select2('val', trimmedValue);

--- a/mockup/patterns/querystring/pattern.js
+++ b/mockup/patterns/querystring/pattern.js
@@ -591,7 +591,12 @@ define([
       }
       else if (typeof self.$value !== 'undefined') {
         var value = self.$value.val();
-        value += self.getDepthString();
+        if(typeof(value) === 'string'){
+          var depth = self.getDepthString();
+          if(depth){
+            value += depth;
+          }
+        }
         varr.push(value);
       }
       var vval;


### PR DESCRIPTION
where if existing querystring path value is ".::1", after edit, the wrong value will be selected

@obct537 can you review this. It's a hack of a fix so maybe you have a better idea on how to fix it.