### PR TITLE
fix: path widgets initialization in querystring pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Fixes:
 - Calculate z-index for modals dynamically to always be on top
   [vangheem]
 
+- Fix path widgets initialization in querystring pattern.
+  [Gagaro]
 
 2.1.2 (2016-01-08)
 ------------------

--- a/mockup/patterns/querystring/pattern.js
+++ b/mockup/patterns/querystring/pattern.js
@@ -242,6 +242,12 @@ define([
       self.removeOperator();
       self.createPathOperators();
 
+      // We must test if we have a "simple" path or an "advanced" one and change the widgets accordingly
+      if (index === 'path' && value && value !== '.::1' && value !== '..::1' && !value.match(/^[0-9a-f]{32}::-?[0-9]+$/)) {
+        self.advanced = true;
+        self.resetPathOperators();
+      }
+
       self.appendOperators(index);
 
       if (operator === undefined) {
@@ -447,7 +453,7 @@ define([
         else {
           var trimmedValue = value;
           if( typeof value === "string" && widget !== 'RelativePathWidget') {
-            trimmedValue = value.replace(/::[0-9]+/, '');
+            trimmedValue = value.replace(/::-?[0-9]+/, '');
           }
           self.$value.select2('val', trimmedValue);
         }


### PR DESCRIPTION
The select is on simple mode by default event if the value is an advanced one.

Also fix a bug where the depth was -1.