### PR TITLE
Structure selection well XSS fix

### DIFF
--- a/mockup/patterns/structure/templates/paging.xml
+++ b/mockup/patterns/structure/templates/paging.xml
@@ -11,7 +11,7 @@
     </li>
     <% _.each(pages, function(p){ %>
     <li class="<% if (currentPage == p) { %>active<% } %>">
-      <a href="#" class="page"><%= p %></a>
+      <a href="#" class="page"><%- p %></a>
     </li>
     <% }); %>
     <li class="<% if (currentPage === lastPage) { %>disabled<% } %>">
@@ -42,9 +42,9 @@
   <ul class="pagination pagination-sm">
     <li class="disabled">
       <a href="#">
-        <%- _t("Page:") %> <span class="current"><%= currentPage %></span>
+        <%- _t("Page:") %> <span class="current"><%- currentPage %></span>
         <%- _t("of") %>
-        <span class="total"><%= totalPages %></span>
+        <span class="total"><%- totalPages %></span>
               <%- _t("shown") %>
       </a>
     </li>

--- a/mockup/patterns/structure/templates/selection_button.xml
+++ b/mockup/patterns/structure/templates/selection_button.xml
@@ -1,1 +1,5 @@
-<span class="glyphicon glyphicon-list"></span><%= title %> <span class="label<% if (length > 0) { %> label-success<% } else { %> label-default<% } %>">  <%= length %></span>
+<span class="glyphicon glyphicon-list"></span>
+  <%- title %>
+<span class="label<% if (length > 0) { %> label-success<% } else { %> label-default<% } %>">
+  <%- length %>
+</span>

--- a/mockup/patterns/structure/templates/selection_item.xml
+++ b/mockup/patterns/structure/templates/selection_item.xml
@@ -1,1 +1,6 @@
-<span class="selected-item">  <a href="#" data-uid="<%= UID %>" title="remove" class="remove">    <span class="glyphicon glyphicon-remove-circle"></span>  </a>  <%= Title %></span>
+<span class="selected-item">
+  <a href="#" data-uid="<%- UID %>" title="remove" class="remove">
+    <span class="glyphicon glyphicon-remove-circle"></span>
+  </a>
+  <%- Title %>
+</span>

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -1,10 +1,10 @@
-<div class="alert alert-<%= statusType %> status">
-    <%= status %>
+<div class="alert alert-<%- statusType %> status">
+    <%- status %>
 </div>
 <table class="table table-striped table-bordered">
   <thead>
     <tr class="fc-breadcrumbs-container">
-      <td colspan="<%= activeColumns.length + 3 %>">
+      <td colspan="<%- activeColumns.length + 3 %>">
         <% if(pathParts.length > 0) { %>
           <div class="input-group context-buttons" style="display:none">
             <span class="input-group-addon">


### PR DESCRIPTION
The Title attribute for a given object could be used as an XSS attack vector. If the attacker can create new object or modify the title an existing object within a Plone instance, then convince her victim (or anyone with access) to use the folder_contents view and select the affected item, this would then populate the raw title text into the selection well without being sanitized, triggering the XSS attack.

The UID field is also vulnerable, but irrelevant as an attack vector for a typical Plone instance.

This pull request contains the test that demonstrates this problem, and then the fix to address this.

The status text set during copy/cut/paste is also vulnerable, however the i18n translation seems to sidestep this issue within the Plone instance context. That said, this pull request also correct this issue.