### PR TITLE
Relateditems pattern XSS fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Fixes:
 - Fix path widgets initialization in querystring pattern.
   [Gagaro]
 
+- Fix XSS vulnerability issues in structure and relateditem pattern.
+  [metatoaster]
+
 2.1.2 (2016-01-08)
 ------------------
 

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -6,9 +6,9 @@
  *    basePath(string): If this is set the widget will start in "Browse" mode and will pass the path to the server to filter the results. ('/')
  *    rootPath(string): If this is set the widget will only display breadcrumb path elements deeprt than this path.
  *    mode(string): Possible values: 'search', 'browse'. If set to 'search', the catalog is searched for a searchterm. If set to 'browse', browsing starts at basePath. Default: 'search'.
- *    breadCrumbTemplate(string): Template to use for a single item in the breadcrumbs. ('/<a href="<%= path %>"><%= text %></a>')
+ *    breadCrumbTemplate(string): Template to use for a single item in the breadcrumbs. ('/<a href="<%- path %>"><%- text %></a>')
  *    breadCrumbTemplateSelector(string): Select an element from the DOM from which to grab the breadCrumbTemplate. (null)
- *    breadCrumbsTemplate(string): Template for element to which breadCrumbs will be appended. ('<span><span class="pattern-relateditems-path-label"><%= searchText %></span><a class="icon-home" href="/"></a><%= items %></span>')
+ *    breadCrumbsTemplate(string): Template for element to which breadCrumbs will be appended. ('<span><span class="pattern-relateditems-path-label"><%- searchText %></span><a class="icon-home" href="/"></a><%- items %></span>')
  *    breadCrumbsTemplateSelector(string): Select an element from the DOM from which to grab the breadCrumbsTemplate. (null)
  *    cache(boolean): Whether or not results from the server should be
  *    cached. (true)
@@ -111,23 +111,23 @@ define([
       resultTemplate: '' +
         '<div class="   pattern-relateditems-result  <% if (selected) { %>pattern-relateditems-active<% } %>">' +
         '  <a href="#" class=" pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %>">' +
-        '    <% if (typeof getIcon !== "undefined" && getIcon) { %><img src="<%= getURL %>/@@images/image/icon "> <% } %>' +
-        '    <span class="pattern-relateditems-result-title  <% if (typeof review_state !== "undefined") { %> state-<%= review_state %> <% } %>  " /span>' +
-        '    <span class="pattern-relateditems contenttype-<%- portal_type.toLowerCase() %>"><%= Title %></span>' +
-        '    <span class="pattern-relateditems-result-path"><%= path %></span>' +
+        '    <% if (typeof getIcon !== "undefined" && getIcon) { %><img src="<%- getURL %>/@@images/image/icon "> <% } %>' +
+        '    <span class="pattern-relateditems-result-title  <% if (typeof review_state !== "undefined") { %> state-<%- review_state %> <% } %>  " /span>' +
+        '    <span class="pattern-relateditems contenttype-<%- portal_type.toLowerCase() %>"><%- Title %></span>' +
+        '    <span class="pattern-relateditems-result-path"><%- path %></span>' +
         '  </a>' +
         '  <span class="pattern-relateditems-buttons">' +
         '  <% if (is_folderish) { %>' +
-        '     <a class="pattern-relateditems-result-browse" href="#" data-path="<%= path %>"></a>' +
+        '     <a class="pattern-relateditems-result-browse" href="#" data-path="<%- path %>"></a>' +
         '   <% } %>' +
         ' </span>' +
         '</div>',
       resultTemplateSelector: null,
       selectionTemplate: '' +
         '<span class="pattern-relateditems-item">' +
-        ' <% if (typeof getIcon !== "undefined" && getIcon) { %> <img src="<%= getURL %>/@@images/image/icon"> <% } %>' +
-        ' <span class="pattern-relateditems-item-title contenttype-<%- portal_type.toLowerCase() %> <% if (typeof review_state !== "undefined") { %> state-<%= review_state  %> <% } %>" ><%= Title %></span>' +
-        ' <span class="pattern-relateditems-item-path"><%= path %></span>' +
+        ' <% if (typeof getIcon !== "undefined" && getIcon) { %> <img src="<%- getURL %>/@@images/image/icon"> <% } %>' +
+        ' <span class="pattern-relateditems-item-title contenttype-<%- portal_type.toLowerCase() %> <% if (typeof review_state !== "undefined") { %> state-<%- review_state  %> <% } %>" ><%- Title %></span>' +
+        ' <span class="pattern-relateditems-item-path"><%- path %></span>' +
         '</span>',
       selectionTemplateSelector: null,
       breadCrumbsTemplate: '<span>' +
@@ -144,12 +144,15 @@ define([
           '</div>' +
         '</span>' +
         '<span class="pattern-relateditems-path-label">' +
-          '<%= searchText %></span><a class="crumb" href="<%= rootPath %>"><span class="glyphicon glyphicon-home"></span></a><%= items %>' +
+          '<%- searchText %></span><a class="crumb" href="<%- rootPath %>">' +
+          '<span class="glyphicon glyphicon-home"></span></a>' +
+          // ``items assumed to be santized html``
+          '<%= items %>' +
         '</span>' +
       '</span>',
       breadCrumbsTemplateSelector: null,
       breadCrumbTemplate: '' +
-        '/<a href="<%= path %>" class="crumb"><%= text %></a>',
+        '/<a href="<%- path %>" class="crumb"><%- text %></a>',
       breadCrumbTemplateSelector: null,
       escapeMarkup: function(text) {
         return text;

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -170,8 +170,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
-/*fgrcon
-    it('select an item by clicking add button', function () {
+
+    it.skip('select an item by clicking add button', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -194,9 +194,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
-*/
-/*fgrcon 
-    it('deselect an item from selected items using click', function () {
+
+    it.skip('deselect an item from selected items using click', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -230,9 +229,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
-*/
-/*fgrcon
-    it('deselect an item from results using click', function () {
+
+    it.skip('deselect an item from results using click', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -263,9 +261,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
-*/
-/*fgrcon
-    it('allow only a single type to be selectable', function () {
+
+    it.skip('allow only a single type to be selectable', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems" />' +
@@ -291,9 +288,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
-*/
-/*fgrcon
-    it('clicking folder button filters to that folder', function() {
+
+    it.skip('clicking folder button filters to that folder', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -317,9 +313,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
-*/
-/*fgrcon
-    it('after selecting a folder, it remains in the results list', function() {
+
+    it.skip('after selecting a folder, it remains in the results list', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -345,9 +340,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
-*/
-/*fgrcon
-    it('clicking on breadcrumbs goes back up', function() {
+
+    it.skip('clicking on breadcrumbs goes back up', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -377,8 +371,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
-*/
-/*fgrcon    it('maximum number of selected items', function() {
+
+    it.skip('maximum number of selected items', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -400,7 +394,7 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
-*/
+
     it('init selection', function() {
       var $el = $('' +
         '<div>' +
@@ -419,8 +413,8 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
-/*fgrcon
-    it('test tree initialized', function() {
+
+    it.skip('test tree initialized', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -445,7 +439,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it('test tree select', function() {
+    it.skip('test tree select', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -474,7 +468,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it('test tree sub select', function() {
+    it.skip('test tree sub select', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -505,7 +499,7 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
-*/
+
     it('test tree cancel', function() {
       var $el = $('' +
         '<div>' +
@@ -535,8 +529,6 @@ define([
       $el.remove();
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
-
-
 
   });
 

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -11,6 +11,8 @@ define([
   window.mocha.setup('bdd').globals(['jQuery*']);
   $.fx.off = true;
 
+  var $el;
+
   /* ==========================
    TEST: Related Items
   ========================== */
@@ -173,8 +175,14 @@ define([
       });
     });
 
+    afterEach(function() {
+      this.server.restore();
+      $el.remove();
+      $('.select2-sizer, .select2-drop').remove();
+    });
+
     it('test initialize', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -185,13 +193,10 @@ define([
       expect($('.select2-container-multi', $el)).to.have.length(1);
       expect($('.pattern-relateditems-container', $el)).to.have.length(1);
       expect($('.pattern-relateditems-path', $el)).to.have.length(1);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop').remove();
     });
 
     it('select an item by clicking add button', function () {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -209,13 +214,10 @@ define([
         expect(pattern.$el.select2('val')[0]).to.equal('gfn5634f');
       }).click();
       clock.tick(1000);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop').remove();
     });
 
     it('deselect an item from selected items using click', function () {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -244,13 +246,10 @@ define([
       // backspaceEvent.which = 8;
       // $('.select2-search-field input').trigger( backspaceEvent );
       // expect(pattern.$el.select2('data')).to.have.length(0);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop').remove();
     });
 
     it('deselect an item from results using click', function () {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -276,13 +275,10 @@ define([
       expect($result.is('.pattern-relateditems-active')).to.equal(false);
       expect(pattern.$el.select2('data')).to.have.length(0);
       expect(pattern.$el.select2('val')).to.have.length(0);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop').remove();
     });
 
     it('allow only a single type to be selectable', function () {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems" />' +
         '</div>').appendTo('body');
@@ -303,13 +299,10 @@ define([
 
       $('.contenttype-image:parent').first().click();
       expect(pattern.$el.select2('data')).to.have.length(1);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop').remove();
     });
 
     it('clicking folder button filters to that folder', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -328,13 +321,10 @@ define([
         expect(pattern.browsing).to.be.equal(true);
         expect(pattern.currentPath).to.equal($(this).attr('data-path'));
       }).click();
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('after selecting a folder, it remains in the results list', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -355,13 +345,10 @@ define([
       var result = $('.pattern-relateditems-result-path')
         .filter(function() { return $(this).text() === '/about'; });
       expect(result.length).to.equal(1);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop').remove();
     });
 
     it('clicking on breadcrumbs goes back up', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -386,13 +373,10 @@ define([
       }).click();
       clock.tick(1000);
       expect(pattern.currentPath).to.equal('/about');
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('maximum number of selected items', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        data-pat-relateditems="width: 300px;' +
@@ -409,13 +393,10 @@ define([
       expect(pattern.$el.select2('data')).to.have.length(1);
       $('.pattern-relateditems-result-select').last().click();
       expect(pattern.$el.select2('data')).to.have.length(1);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('init selection', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
@@ -428,13 +409,10 @@ define([
       var clock = sinon.useFakeTimers();
       pattern.$el.select2('open');
       clock.tick(1000);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('test tree initialized', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
@@ -453,13 +431,10 @@ define([
       clock.tick(1000);
 
       expect($el.find('.pat-tree ul li').length).to.equal(4);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('test tree select', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
@@ -482,13 +457,10 @@ define([
       clock.tick(1000);
 
       expect($el.find('.crumb').length).to.equal(2);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('test tree sub select', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
@@ -514,13 +486,10 @@ define([
       clock.tick(1000);
 
       expect($el.find('.crumb').length).to.equal(3);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
     it('test tree cancel', function() {
-      var $el = $('' +
+      $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
         '        value="asdf1234,sdfbsfdh345,asdlfkjasdlfkjasdf,kokpoius98"' +
@@ -544,9 +513,6 @@ define([
 
       expect($el.find('.crumb').length).to.equal(1);
       expect($el.find('.tree-container').is(':visible')).to.equal(false);
-
-      $el.remove();
-      $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
   });

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -56,6 +56,17 @@ define([
           {UID: 'asdfasdf9sdf', Title: 'Mike', path: '/about/staff/mike', portal_type: 'Document', getIcon: ""},
           {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', portal_type: 'Document', getIcon: ""}
         ];
+
+        var addMissingFields = function(item) {
+          item.getURL = 'http://localhost:8081' + item.path;
+          item.is_folderish = item.portal_type === 'Folder';
+          item.review_state = 'published';
+        };
+
+        _.each(root, addMissingFields);
+        _.each(about, addMissingFields);
+        _.each(staff, addMissingFields);
+
         var searchables = about.concat(root).concat(staff);
 
         var addUrls = function(list) {
@@ -91,6 +102,8 @@ define([
             var criteria = query.criteria[i];
             if (criteria.i === 'path') {
               path = criteria.v.split('::')[0];
+            } else if (criteria.i === 'is_folderish') {
+              term = criteria;
             } else {
               term = criteria.v;
             }
@@ -107,11 +120,17 @@ define([
             var q;
             var keys = (item.UID + ' ' + item.Title + ' ' + item.path + ' ' + item.portal_type).toLowerCase();
             if (typeof(term) === 'object') {
-              for (var i = 0; i < term.length; i = i + 1) {
-                q = term[i].toLowerCase();
-                if (keys.indexOf(q) > -1) {
+              if (term.i === 'is_folderish') {
+                if (item.is_folderish) {
                   results.push(item);
-                  break;
+                }
+              } else {
+                for (var i = 0; i < term.length; i = i + 1) {
+                  q = term[i].toLowerCase();
+                  if (keys.indexOf(q) > -1) {
+                    results.push(item);
+                    break;
+                  }
                 }
               }
             } else {
@@ -171,7 +190,7 @@ define([
       $('.select2-sizer, .select2-drop').remove();
     });
 
-    it.skip('select an item by clicking add button', function () {
+    it('select an item by clicking add button', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -195,7 +214,7 @@ define([
       $('.select2-sizer, .select2-drop').remove();
     });
 
-    it.skip('deselect an item from selected items using click', function () {
+    it('deselect an item from selected items using click', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -230,7 +249,7 @@ define([
       $('.select2-sizer, .select2-drop').remove();
     });
 
-    it.skip('deselect an item from results using click', function () {
+    it('deselect an item from results using click', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -262,7 +281,7 @@ define([
       $('.select2-sizer, .select2-drop').remove();
     });
 
-    it.skip('allow only a single type to be selectable', function () {
+    it('allow only a single type to be selectable', function () {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems" />' +
@@ -282,14 +301,14 @@ define([
       $('.pattern-relateditems-result-select').first().click();
       expect(pattern.$el.select2('data')).to.have.length(0);
 
-      $('.pattern-relateditems-type-Image .pattern-relateditems-result-select').first().click();
+      $('.contenttype-image:parent').first().click();
       expect(pattern.$el.select2('data')).to.have.length(1);
 
       $el.remove();
       $('.select2-sizer, .select2-drop').remove();
     });
 
-    it.skip('clicking folder button filters to that folder', function() {
+    it('clicking folder button filters to that folder', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -314,7 +333,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it.skip('after selecting a folder, it remains in the results list', function() {
+    it('after selecting a folder, it remains in the results list', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -341,7 +360,7 @@ define([
       $('.select2-sizer, .select2-drop').remove();
     });
 
-    it.skip('clicking on breadcrumbs goes back up', function() {
+    it('clicking on breadcrumbs goes back up', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -372,7 +391,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it.skip('maximum number of selected items', function() {
+    it('maximum number of selected items', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -414,7 +433,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it.skip('test tree initialized', function() {
+    it('test tree initialized', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -439,7 +458,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it.skip('test tree select', function() {
+    it('test tree select', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +
@@ -468,7 +487,7 @@ define([
       $('.select2-sizer, .select2-drop, .select2-drop-mask').remove();
     });
 
-    it.skip('test tree sub select', function() {
+    it('test tree sub select', function() {
       var $el = $('' +
         '<div>' +
         ' <input class="pat-relateditems"' +

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -56,7 +56,8 @@ define([
 
         var staff = [
           {UID: 'asdfasdf9sdf', Title: 'Mike', path: '/about/staff/mike', portal_type: 'Document', getIcon: ""},
-          {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', portal_type: 'Document', getIcon: ""}
+          {UID: 'cvbcvb82345', Title: 'Joe', path: '/about/staff/joe', portal_type: 'Document', getIcon: ""},
+          {UID: 'hax0r', Title: '<script>window.xss=1</script>', path: '/about/staff/xss', portal_type: 'Document', getIcon: ""}
         ];
 
         var addMissingFields = function(item) {
@@ -208,7 +209,7 @@ define([
       pattern.$el.select2('open');
       clock.tick(1000);
       expect(pattern.$el.select2('data')).to.have.length(0);
-      expect($('.pattern-relateditems-result-select')).to.have.length(13);
+      expect($('.pattern-relateditems-result-select')).to.have.length(14);
       $('.pattern-relateditems-result-select').first().on('click', function() {
         expect(pattern.$el.select2('data')).to.have.length(1);
         expect(pattern.$el.select2('val')[0]).to.equal('gfn5634f');
@@ -336,7 +337,7 @@ define([
       pattern.$el.select2('open');
       clock.tick(1000);
       expect(pattern.$el.select2('data')).to.have.length(0);
-      expect($('.pattern-relateditems-result-select')).to.have.length(13);
+      expect($('.pattern-relateditems-result-select')).to.have.length(14);
       $('.pattern-relateditems-result-path')
         .filter(function() { return $(this).text() === '/about'; })
         .click();
@@ -368,6 +369,8 @@ define([
       var $crumbs = $('.pattern-relateditems-path a.crumb');
       // /about/staff
       expect($crumbs).to.have.length(3);
+      // Staff XSS bomb
+      expect(window.xss).not.equal(1);
       // /about
       $crumbs.eq(1).on('click', function() {
       }).click();


### PR DESCRIPTION
The embedded template uses `<%= value %>` for everything which enables XSS attack.  Replaced all of this with `<%- value %>` and made a note for `<%= item %>` as that contains markup generated by the breadCrumbs template.  Requires pull request #628 as I need all existing test to run because overzealous cleansing broke breadCrumbs, heh.

As an aside, should better review be in place in the first place to actually not let tests be removed without proper explanation? Also maybe need some automated audit of the usage of the `<%= value %>` syntax as part of the tests, because I don't like XSS in my CMS.  Though this second part is a difficult requirement to address at the moment as I see it.