### PR TITLE
Fixed issue where the label on 'development-mode' was overlapping 50%…

### DIFF
--- a/mockup/patterns/resourceregistry/pattern.resourceregistry.less
+++ b/mockup/patterns/resourceregistry/pattern.resourceregistry.less
@@ -111,6 +111,7 @@
 
     .development-mode {
         padding-left: 15px;
+        display: inline-block;
     }
 
     .plone-legacy-resource-entry{


### PR DESCRIPTION
Fixed issue where the label on 'development-mode' was overlapping 50% of the "Save" button next to be by being floated with display: block; on it.