### PR TITLE
fix: trim links in tinymce before inserting them

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Fixes:
 - Fix XSS vulnerability issues in structure and relateditem pattern.
   [metatoaster]
 
+- Trim links in tinymce before inserting them in the source.
+  [Gagaro]
+
 2.1.2 (2016-01-08)
 ------------------
 

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -29,7 +29,7 @@ define([
     },
 
     value: function() {
-      return this.getEl().val();
+      return $.trim(this.getEl().val());
     },
 
     toUrl: function() {


### PR DESCRIPTION
Space at the beginning of an absolute link (" http://...") is encoded as %20, and thus the link is considered as relative. This trim the link to ensure this doesn't happen.