### PR TITLE
fix: treeQuery vocabularyUrl option in relateditems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Fixes:
 - Ensure we have all content for tree query in relateditems
   [Gagaro]
 
+- Fix default value for treeVocabularyUrl in relateditems.
+  [Gagaro]
+
 2.1.2 (2016-01-08)
 ------------------
 

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -108,9 +108,7 @@ define([
       attributes: ['UID', 'Title', 'portal_type', 'path','getURL', 'getIcon','is_folderish','review_state'],
       dropdownCssClass: 'pattern-relateditems-dropdown',
       maximumSelectionSize: -1,
-      treeOptions: {
-        vocabularyUrl: null, // must be set to work
-      },
+      treeVocabularyUrl: null,
       resultTemplate: '' +
         '<div class="   pattern-relateditems-result  <% if (selected) { %>pattern-relateditems-active<% } %>">' +
         '  <a href="#" class=" pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %>">' +
@@ -368,13 +366,13 @@ define([
       self.treeQuery = new utils.QueryHelper(
         $.extend(true, {}, self.options, {
           pattern: self,
-          vocabularyUrl: self.options.treeOptions.vocabularyUrl || self.options.vocabularyUrl,
+          vocabularyUrl: self.options.treeVocabularyUrl || self.options.vocabularyUrl,
           baseCriteria: [{
             i: 'is_folderish',
             o: 'plone.app.querystring.operation.selection.any',
             v: 'True'
           }]
-        }, self.options.treeOptions)
+        })
       );
 
       self.options.ajax = self.options.setupAjax.apply(self);


### PR DESCRIPTION
Fix for https://github.com/plone/mockup/pull/596

Adding `self.options.treeOptions` there overrides the `vocabularyUrl` set earlier and it doesn't fallback on `self.options.vocabularyUrl`.