### PR TITLE
Use official TinyMCE bower dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 
 New:
 
+- Instead of the ``tinymce-bundled`` bower dependency use the official ``tinymce`` one.
+  This one is more recent and important bugfixes.
+  We still use ``tinymce-bundled`` for the language files.
+  [thet]
+
 - Fix resource registry not allowing to go into development mode when
   bundle is selected
   [vangheem]

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "requirejs-text": "2.0.12",
     "selectivizr": "1.0.2",
     "select2": "3.5.1",
+    "tinymce": "4.3.4",
     "tinymce-builded": "4.3.0"
   },
   "devDependencies": {

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -13,7 +13,8 @@
     'insertdatetime', 'layer', 'legacyoutput', 'link', 'lists', 'media',
     'nonbreaking', 'noneditable', 'pagebreak', 'paste', 'preview', 'print',
     'save', 'searchreplace', 'spellchecker', 'tabfocus', 'table', 'template',
-    'textcolor', 'textpattern', 'visualblocks', 'visualchars', 'wordcount'
+    'textcolor', 'textpattern', 'visualblocks', 'visualchars', 'wordcount',
+    'compat3x'
   ];
 
   var requirejsOptions = {
@@ -166,6 +167,9 @@
   for(var i=0; i<tinymcePlugins.length; i=i+1){
     var plugin = tinymcePlugins[i];
     requirejsOptions.paths['tinymce-' + plugin] = 'bower_components/tinymce/plugins/' + plugin + '/plugin';
+    if (plugin === 'compat3x') {
+        requirejsOptions.paths['tinymce-' + plugin] = 'bower_components/tinymce-builded/js/tinymce/plugins/' + plugin + '/plugin';
+    }
     requirejsOptions.shim['tinymce-' + plugin] = {
       deps: ['tinymce']
     };

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -13,8 +13,7 @@
     'insertdatetime', 'layer', 'legacyoutput', 'link', 'lists', 'media',
     'nonbreaking', 'noneditable', 'pagebreak', 'paste', 'preview', 'print',
     'save', 'searchreplace', 'spellchecker', 'tabfocus', 'table', 'template',
-    'textcolor', 'textpattern', 'visualblocks', 'visualchars', 'wordcount',
-    'compat3x'
+    'textcolor', 'textpattern', 'visualblocks', 'visualchars', 'wordcount'
   ];
 
   var requirejsOptions = {
@@ -110,8 +109,8 @@
       'select2': 'bower_components/select2/select2',
       'sinon': 'bower_components/sinonjs/sinon',
       'text': 'bower_components/requirejs-text/text',
-      'tinymce': 'bower_components/tinymce-builded/js/tinymce/tinymce',
-      'tinymce-modern-theme': 'bower_components/tinymce-builded/js/tinymce/themes/modern/theme',
+      'tinymce': 'bower_components/tinymce/tinymce',
+      'tinymce-modern-theme': 'bower_components/tinymce/themes/modern/theme',
       'underscore': 'bower_components/underscore/underscore',
 
       // Patternslib
@@ -166,7 +165,7 @@
   };
   for(var i=0; i<tinymcePlugins.length; i=i+1){
     var plugin = tinymcePlugins[i];
-    requirejsOptions.paths['tinymce-' + plugin] = 'bower_components/tinymce-builded/js/tinymce/plugins/' + plugin + '/plugin';
+    requirejsOptions.paths['tinymce-' + plugin] = 'bower_components/tinymce/plugins/' + plugin + '/plugin';
     requirejsOptions.shim['tinymce-' + plugin] = {
       deps: ['tinymce']
     };

--- a/mockup/js/grunt.js
+++ b/mockup/js/grunt.js
@@ -91,11 +91,11 @@
               rename: function(dest, src) { return dest + name + '-bootstrap-' + src; }},
             // TINYMCE
             { expand: true, cwd: 'bower_components/tinymce-builded/js/tinymce/langs', src: '*', dest: bundleOptions.path + name + '-tinymce/langs'},
-            { expand: true, cwd: 'bower_components/tinymce-builded/js/tinymce/skins/lightgray/fonts/', src: 'tinymce*', dest: bundleOptions.path,
+            { expand: true, cwd: 'bower_components/tinymce/skins/lightgray/fonts/', src: 'tinymce*', dest: bundleOptions.path,
               rename: function(dest, src) { return dest + name + '-tinymce-font-' + src; }},
-            { expand: true, cwd: 'bower_components/tinymce-builded/js/tinymce/skins/lightgray/img/', src: '*', dest: bundleOptions.path,
+            { expand: true, cwd: 'bower_components/tinymce/skins/lightgray/img/', src: '*', dest: bundleOptions.path,
               rename: function(dest, src) { return dest + name + '-tinymce-img-' + src; }},
-            { expand: true, cwd: 'bower_components/tinymce-builded/js/tinymce/skins/lightgray/', src: 'content.min.css', dest: bundleOptions.path,
+            { expand: true, cwd: 'bower_components/tinymce/skins/lightgray/', src: 'content.min.css', dest: bundleOptions.path,
               rename: function(dest, src) { return dest + name + '-tinymce-' + src; }},
             // JQTREE
             { expand: true, cwd: 'bower_components/jqtree/', src: 'jqtree-circle.png', dest: bundleOptions.path,
@@ -155,7 +155,7 @@
             // replace default content.min.css
             path: bundleOptions.path,
             recursive: true,
-            pattern: '../../../bower_components/tinymce-builded/js/tinymce/skins/lightgray/content.min.css',
+            pattern: '../../../bower_components/tinymce/skins/lightgray/content.min.css',
             replacement: bundleOptions.url + '-tinymce-content.min.css'
           };
           this.gruntConfig.sed[name + '-tinymce-fonts2'] = {

--- a/mockup/patterns/tinymce/less/pattern.tinymce.less
+++ b/mockup/patterns/tinymce/less/pattern.tinymce.less
@@ -1,6 +1,6 @@
-@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/skin.less";
-@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/Content.Objects.less";
-@import (inline) "@{bowerPath}/tinymce-builded/js/tinymce/plugins/visualblocks/css/visualblocks.css";
+@import (less) "@{bowerPath}/tinymce/skins/lightgray/skin.less";
+@import (less) "@{bowerPath}/tinymce/skins/lightgray/Content.Objects.less";
+@import (inline) "@{bowerPath}/tinymce/plugins/visualblocks/css/visualblocks.css";
 @import "@{mockupPath}/modal/pattern.modal.less";
 @import "@{mockupPath}/autotoc/pattern.autotoc.less";
 @import "@{mockupPath}/upload/less/pattern.upload.less";

--- a/mockup/patterns/tinymce/less/pattern.tinymce.less
+++ b/mockup/patterns/tinymce/less/pattern.tinymce.less
@@ -1,5 +1,5 @@
-@import (less) "@{bowerPath}/tinymce/skins/lightgray/skin.less";
-@import (less) "@{bowerPath}/tinymce/skins/lightgray/Content.Objects.less";
+@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/skin.less";
+@import (less) "@{bowerPath}/tinymce-builded/js/tinymce/skins/lightgray/Content.Objects.less";
 @import (inline) "@{bowerPath}/tinymce/plugins/visualblocks/css/visualblocks.css";
 @import "@{mockupPath}/modal/pattern.modal.less";
 @import "@{mockupPath}/autotoc/pattern.autotoc.less";

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -112,8 +112,7 @@ define([
   'tinymce-textpattern',
   'tinymce-visualblocks',
   'tinymce-visualchars',
-  'tinymce-wordcount',
-  'tinymce-compat3x'
+  'tinymce-wordcount'
 ], function($, _,
             Base, RelatedItems, Modal, tinymce,
             AutoTOC, ResultTemplate, SelectionTemplate,
@@ -157,7 +156,7 @@ define([
         externalImage: _t('External Image URL (can be relative within this site or absolute if it starts with http:// or https://)')
       },
       // URL generation options
-      loadingBaseUrl: '../../../bower_components/tinymce-builded/js/tinymce/',
+      loadingBaseUrl: '../../../bower_components/tinymce/',
       prependToUrl: '',
       appendToUrl: '',
       linkAttribute: 'path', // attribute to get link value from data
@@ -177,7 +176,7 @@ define([
       imageTypes: ['Image'],
       folderTypes: ['Folder', 'Plone Site'],
       tiny: {
-        'content_css': '../../../bower_components/tinymce-builded/js/tinymce/skins/lightgray/content.min.css',
+        'content_css': '../../../bower_components/tinymce/skins/lightgray/content.min.css',
         theme: '-modern',
         plugins: ['advlist', 'autolink', 'lists', 'charmap', 'print', 'preview', 'anchor', 'searchreplace',
                   'visualblocks', 'code', 'fullscreen', 'insertdatetime', 'media', 'table', 'contextmenu',

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -112,7 +112,8 @@ define([
   'tinymce-textpattern',
   'tinymce-visualblocks',
   'tinymce-visualchars',
-  'tinymce-wordcount'
+  'tinymce-wordcount',
+  'tinymce-compat3x'
 ], function($, _,
             Base, RelatedItems, Modal, tinymce,
             AutoTOC, ResultTemplate, SelectionTemplate,


### PR DESCRIPTION
Instead of the ``tinymce-builded`` bower dependency use the official ``tinymce`` one (refers to ``https://github.com/tinymce/tinymce-dist``).
This one is more recent and important bugfixes.
We still use ``tinymce-builded`` for the language files.