### PR TITLE
Fix Build CSS button in thememapper with file system-based

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ Fixes:
   the data to aid in view rendering.
   [metatoaster]
 
+- Fix Build CSS button in thememapper with file system-based themes to display
+  the generated CSS in the editor.
+  [ebrehault]
 
 2.1.3 (2016-02-27)
 New:

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -448,11 +448,19 @@ define([
           _authenticator: utils.getAuthenticator()
         },
         success: function(data) {
-          self.fileManager.refreshTree(function() {
-            //We need to make sure we open the newest version
-            delete self.fileManager.fileData['/' + self.lessPaths['save']]
-            self.fileManager.selectItem(self.lessPaths['save'])
-          });
+          if(data.success == 'tmp') {
+            self.fileManager.fileData['_generated_.css'] = {
+              contents: data.value,
+              ext: 'css'
+            }
+            self.fileManager.openEditor('_generated_.css');
+          } else {
+            self.fileManager.refreshTree(function() {
+              //We need to make sure we open the newest version
+              delete self.fileManager.fileData['/' + self.lessPaths['save']]
+              self.fileManager.selectItem(self.lessPaths['save'])
+            });
+          }
           self.lessbuilderView.end();
         }
       });


### PR DESCRIPTION
Related to https://github.com/plone/Products.CMFPlone/issues/1468
The backend part is here https://github.com/plone/plone.resourceeditor/pull/17