### PR TITLE
Structure pattern action items changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ New:
   Open ``editItem`` under ``/@@edit`` instead ``/edit``.
   Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
   Add ``iconCSS`` option for action menus items to add icons.
+  Use icons for all actionmenu entries.
   Add ``modal`` option for action menus items to allow links open in a modal.
   Add ``iconSize`` option to set the icon size if a item has an image.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,14 @@ Fixes:
 
 New:
 
+- Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
+  This resolves a moment deprecation warning in structure examples.
+- Structure pattern: Allow definition of action menu items not only as dropdowns but also as buttons.
+  Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
+  Open ``openItem`` links directly, omitting ``/view``.
+  Open ``editItem`` under ``/@@edit`` instead ``/edit``.
+  [thet]
+
 - set XML syntax coloring for .pt files in text editor
   [ebrehault]
 
@@ -42,11 +50,6 @@ New:
 
 - Alternative parameter/syntax for specification of the pushState url to
   be inline with the usage of ``{path}`` token in URL templates.
-  [metatoaster]
-
-- Structure can use the ``viewURL`` from a returned data item, alongside
-  with the previous default of simply appending ``/view`` to the
-  ``getURL`` attribute if this was not provided, for its view URL,
   [metatoaster]
 
 Fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ New:
   - Add ``iconSize`` option to set the icon size if a item has an image.
   - Use icons for all actionmenu entries.
   - Use the tooltip pattern for all actionmenu buttons.
+  - Use pat-moment also for ``start``, ``end`` and ``last_comment_date`` columns.
 
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ New:
   - Use the tooltip pattern for all actionmenu buttons.
   - Use pat-moment also for ``start``, ``end`` and ``last_comment_date`` columns.
   - For columns with date fields, show an empty column if the date value is 'None'.
+  - Remove the checkbox and the actionmenu from the breadcrumbs bar for the current active folder to simplify the structure pattern.
+    The actionmenu contained redundant actions (cut, copy, paste) and selecting the current folder is possible one level up.
 
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ New:
   Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.
   Open ``editItem`` under ``/@@edit`` instead ``/edit``.
   Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
+  Add ``iconCSS`` option for action menus items to add icons.
+  Add ``linkCSS`` option for action menus items to allow additional CSS classes, e.g. to add a pattern like ``pat-modal``.
+  Add ``iconSize`` option to set the icon size if a item has an image.
   [thet]
 
 - set XML syntax coloring for .pt files in text editor

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ New:
   - Use icons for all actionmenu entries.
   - Use the tooltip pattern for all actionmenu buttons.
   - Use pat-moment also for ``start``, ``end`` and ``last_comment_date`` columns.
+  - For columns with date fields, show an empty column if the date value is 'None'.
 
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ New:
   This resolves a moment deprecation warning in structure examples.
 - Structure pattern: Allow definition of action menu items not only as dropdowns but also as buttons.
   Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
-  Open ``openItem`` links directly, omitting ``/view``.
+  Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.
   Open ``editItem`` under ``/@@edit`` instead ``/edit``.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,8 +31,9 @@ New:
   Open ``editItem`` under ``/@@edit`` instead ``/edit``.
   Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
   Add ``iconCSS`` option for action menus items to add icons.
-  Add ``linkCSS`` option for action menus items to allow additional CSS classes, e.g. to add a pattern like ``pat-modal``.
+  Add ``modal`` option for action menus items to allow links open in a modal.
   Add ``iconSize`` option to set the icon size if a item has an image.
+
   [thet]
 
 - set XML syntax coloring for .pt files in text editor

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,27 +1,13 @@
 Changelog
 =========
 
-2.2.1 (Unreleased)
+2.3.0 (Unreleased)
 ------------------
 
 Incompatibilities:
 
 New:
 
-Fixes:
-
-- Moment pattern: Don't try to parse obvious invalid dates ("None", "").
-  Avoids Moment.js deprecation warnings.
-  [thet]
-
-
-2.2.0 (2016-03-31)
-------------------
-
-New:
-
-- Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
-  This resolves a moment deprecation warning in structure examples.
 - Add ``test-dev-ff`` as Makefile target and the related grunt/karma setup to run tests in Firefox.
   [thet]
 
@@ -38,6 +24,21 @@ New:
   - Use the tooltip pattern for all actionmenu buttons.
 
   [thet]
+
+Fixes:
+
+- Fix tests and mocks on real browsers for structure pattern test, which threw CSRF errors.
+  [metatoaster]
+
+- Moment pattern: Don't try to parse obvious invalid dates ("None", "").
+  Avoids Moment.js deprecation warnings.
+  [thet]
+
+
+2.2.0 (2016-03-31)
+------------------
+
+New:
 
 - set XML syntax coloring for .pt files in text editor
   [ebrehault]
@@ -68,8 +69,6 @@ Fixes:
 - Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
   This resolves a moment deprecation warning in structure examples.
   [thet]
-- Fix tests and mocks on real browsers for structure pattern test, which threw CSRF errors.
-  [metatoaster]
 
 - JSHint fixes and jscs formatings for structure pattern.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ Fixes:
 - Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
   This resolves a moment deprecation warning in structure examples.
   [thet]
+- Fix tests and mocks on real browsers for structure pattern test, which threw CSRF errors.
+  [metatoaster]
 
 - JSHint fixes and jscs formatings for structure pattern.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,15 +25,17 @@ New:
 - Add ``test-dev-ff`` as Makefile target and the related grunt/karma setup to run tests in Firefox.
   [thet]
 
-- Structure pattern: Allow definition of action menu items not only as dropdowns but also as buttons.
-  Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
-  Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.
-  Open ``editItem`` under ``/@@edit`` instead ``/edit``.
-  Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
-  Add ``iconCSS`` option for action menus items to add icons.
-  Use icons for all actionmenu entries.
-  Add ``modal`` option for action menus items to allow links open in a modal.
-  Add ``iconSize`` option to set the icon size if a item has an image.
+- Structure pattern:
+  - Allow definition of action menu items not only as dropdowns but also as buttons.
+  - Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
+  - Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.
+  - Open ``editItem`` under ``/@@edit`` instead ``/edit``.
+  - Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
+  - Add ``iconCSS`` option for action menus items to add icons.
+  - Add ``modal`` option for action menus items to allow links open in a modal.
+  - Add ``iconSize`` option to set the icon size if a item has an image.
+  - Use icons for all actionmenu entries.
+  - Use the tooltip pattern for all actionmenu buttons.
 
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ New:
 
 - Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
   This resolves a moment deprecation warning in structure examples.
+- Add ``test-dev-ff`` as Makefile target and the related grunt/karma setup to run tests in Firefox.
+  [thet]
+
 - Structure pattern: Allow definition of action menu items not only as dropdowns but also as buttons.
   Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
   Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ New:
   Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
   Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.
   Open ``editItem`` under ``/@@edit`` instead ``/edit``.
+  Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
   [thet]
 
 - set XML syntax coloring for .pt files in text editor

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ test-jenkins: stamp-bower
 test-dev:
 	NODE_PATH=$(NODE_PATH) $(GRUNT) test_dev $(DEBUG) $(VERBOSE) --gruntfile=mockup/Gruntfile.js --pattern=$(pattern)
 
+test-dev-ff:
+	NODE_PATH=$(NODE_PATH) $(GRUNT) test_dev_ff $(DEBUG) $(VERBOSE) --gruntfile=mockup/Gruntfile.js --pattern=$(pattern)
+
 test-serve:
 	NODE_PATH=$(NODE_PATH) $(GRUNT) test_serve $(DEBUG) $(VERBOSE) --gruntfile=mockup/Gruntfile.js --pattern=$(pattern)
 
@@ -123,6 +126,6 @@ publish-docs:
 	# echo -e "Publishing 'docs' bundle!\n"; cd mockup/docs; git add -fA .; git commit -m "Travis build $(TRAVIS_BUILD_NUMBER) pushed to 'docs'."; git push -fq https://$(GH_TOKEN)@github.com/plone/mockup.git gh-pages > /dev/null; cd ..;
 
 i18n-dump:
-	NODE_PATH=$(NODE_PATH) $(GRUNT) i18n-dump --gruntfile=mockup/Gruntfile.js 
+	NODE_PATH=$(NODE_PATH) $(GRUNT) i18n-dump --gruntfile=mockup/Gruntfile.js
 
-.PHONY: bundle bundle-widgets bundle-structure bundle-plone docs bootstrap bootstrap-nix jshint test test-once test-dev test-ci publish-docs clean clean-deep
+.PHONY: bundle bundle-widgets bundle-structure bundle-plone docs bootstrap bootstrap-nix jshint test test-once test-dev test-dev-ff test-ci publish-docs clean clean-deep

--- a/mockup/js/grunt.js
+++ b/mockup/js/grunt.js
@@ -307,6 +307,7 @@
       grunt.registerTask('test_once', [ 'jshint', 'karma:testOnce' ]);
       grunt.registerTask('test_jenkins', [ 'jshint', 'karma:testJenkins' ]);
       grunt.registerTask('test_dev', [ 'karma:testDev' ]);
+      grunt.registerTask('test_dev_ff', [ 'karma:testDevFF' ]);
       grunt.registerTask('test_serve', [ 'karma:testServe' ]);
       grunt.registerTask('test_ci', [ 'jshint', 'karma:testCI'].concat(bundles));
 
@@ -365,6 +366,17 @@
               'karma-chai',
               'karma-requirejs',
               'karma-chrome-launcher'
+            ]
+          },
+          testDevFF: {
+            browsers: ['Firefox'],
+            preprocessors: {},
+            reporters: ['dots', 'progress'],
+            plugins: [
+              'karma-mocha',
+              'karma-chai',
+              'karma-requirejs',
+              'karma-firefox-launcher'
             ]
           },
           testServe: {

--- a/mockup/less/base.less
+++ b/mockup/less/base.less
@@ -51,3 +51,16 @@
 .plone-progress-bar-striped{ .progress-bar-striped() }
 .plone-progress-bar{ .progress-bar() }
 
+/* rotate transforms */
+.rright {
+    /* right-rotate by 90° */
+    -ms-transform: rotate(90deg); /* IE 9 */
+    -webkit-transform: rotate(90deg); /* iOS, Android */
+    transform: rotate(90deg);
+}
+.rleft {
+    /* left-rotate by 90° */
+    -ms-transform: rotate(-90deg); /* IE 9 */
+    -webkit-transform: rotate(-90deg); /* iOS, Android */
+    transform: rotate(-90deg);
+}

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -3,16 +3,12 @@ define(['underscore'], function(_) {
 
   var menuOptions = {
     'openItem': {
-      'library':  'mockup-patterns-structure-url/js/navigation',
-      'method':   'openClicked',
       'url':      '#',
       'title':    'Open',
       'category': 'button',
       'iconCSS':  'glyphicon glyphicon-eye-open'
     },
     'editItem': {
-      'library':  'mockup-patterns-structure-url/js/navigation',
-      'method':   'editClicked',
       'url':      '#',
       'title':    'Edit',
       'category': 'button',

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -22,7 +22,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Cut',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-scissors',
       'modal':    false
     },
     'copyItem': {
@@ -31,7 +31,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Copy',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-duplicate',
       'modal':    false
     },
     'pasteItem': {
@@ -40,7 +40,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Paste',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-open-file',
       'modal':    false
     },
     'move-top': {
@@ -49,7 +49,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Move to top of folder',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-step-backward rright',
       'modal':    false
     },
     'move-bottom': {
@@ -58,7 +58,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Move to bottom of folder',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-step-backward rleft',
       'modal':    false
     },
     'set-default-page': {
@@ -67,7 +67,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Set as default page',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-ok-circle',
       'modal':    false
     },
     'selectAll': {
@@ -76,7 +76,7 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Select all contained items',
       'category': 'dropdown',
-      'iconCSS':  '',
+      'iconCSS':  'glyphicon glyphicon-check',
       'modal':    false
     }
   };

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -1,61 +1,79 @@
-define([], function() {
+define(['underscore'], function(_) {
   'use strict';
 
   var menuOptions = {
-    'cutItem': [
-      'mockup-patterns-structure-url/js/actions',
-      'cutClicked',
-      '#',
-      'Cut',
-    ],
-    'copyItem': [
-      'mockup-patterns-structure-url/js/actions',
-      'copyClicked',
-      '#',
-      'Copy'
-    ],
-    'pasteItem': [
-      'mockup-patterns-structure-url/js/actions',
-      'pasteClicked',
-      '#',
-      'Paste'
-    ],
-    'move-top': [
-      'mockup-patterns-structure-url/js/actions',
-      'moveTopClicked',
-      '#',
-      'Move to top of folder'
-    ],
-    'move-bottom': [
-      'mockup-patterns-structure-url/js/actions',
-      'moveBottomClicked',
-      '#',
-      'Move to bottom of folder'
-    ],
-    'set-default-page': [
-      'mockup-patterns-structure-url/js/actions',
-      'setDefaultPageClicked',
-      '#',
-      'Set as default page'
-    ],
-    'selectAll': [
-      'mockup-patterns-structure-url/js/actions',
-      'selectAll',
-      '#',
-      'Select all contained items'
-    ],
-    'openItem': [
-      'mockup-patterns-structure-url/js/navigation',
-      'openClicked',
-      '#',
-      'Open'
-    ],
-    'editItem': [
-      'mockup-patterns-structure-url/js/navigation',
-      'editClicked',
-      '#',
-      'Edit'
-    ],
+    'openItem': {
+      'library':  'mockup-patterns-structure-url/js/navigation',
+      'method':   'openClicked',
+      'url':      '#',
+      'title':    'Open',
+      'category': 'button',
+      'iconCSS':  'glyphicon glyphicon-eye-open'
+    },
+    'editItem': {
+      'library':  'mockup-patterns-structure-url/js/navigation',
+      'method':   'editClicked',
+      'url':      '#',
+      'title':    'Edit',
+      'category': 'button',
+      'iconCSS':  'glyphicon glyphicon-pencil'
+    },
+    'cutItem': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'cutClicked',
+      'url':      '#',
+      'title':    'Cut',
+      'category': 'dropdown',
+      'iconCSS':  '',
+    },
+    'copyItem': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'copyClicked',
+      'url':      '#',
+      'title':    'Copy',
+      'category': 'dropdown',
+      'iconCSS':  ''
+    },
+    'pasteItem': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'pasteClicked',
+      'url':      '#',
+      'title':    'Paste',
+      'category': 'dropdown',
+      'iconCSS':  ''
+    },
+    'move-top': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'moveTopClicked',
+      'url':      '#',
+      'title':    'Move to top of folder',
+      'category': 'dropdown',
+      'iconCSS':  ''
+    },
+    'move-bottom': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'moveBottomClicked',
+      'url':      '#',
+      'title':    'Move to bottom of folder',
+      'category': 'dropdown',
+      'iconCSS':  ''
+    },
+    'set-default-page': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'setDefaultPageClicked',
+      'url':      '#',
+      'title':    'Set as default page',
+      'category': 'dropdown',
+      'iconCSS':  ''
+    },
+    'selectAll': {
+      'library':  'mockup-patterns-structure-url/js/actions',
+      'method':   'selectAll',
+      'url':      '#',
+      'title':    'Select all contained items',
+      'category': 'dropdown',
+      'iconCSS':  ''
+    }
   };
 
   var ActionMenu = function(menu) {
@@ -65,26 +83,25 @@ define([], function() {
       return menu.menuOptions;
     }
 
-    var result = {};
-    result.cutItem = menuOptions.cutItem;
-    result.copyItem = menuOptions.copyItem;
-    if (menu.app.pasteAllowed && menu.model.attributes.is_folderish) {
-      result.pasteItem = menuOptions.pasteItem;
+    var result = _.clone(menuOptions);
+    if ( !(menu.app.pasteAllowed && menu.model.attributes.is_folderish)) {
+      delete result.pasteItem;
     }
-    if (!menu.app.inQueryMode() && menu.options.canMove !== false) {
-      result['move-top'] = menuOptions['move-top'];
-      result['move-bottom'] = menuOptions['move-bottom'];
+    if (menu.app.inQueryMode() || menu.options.canMove === false) {
+      delete result['move-top'];
+      delete result['move-bottom'];
     }
-    if (!menu.model.attributes.is_folderish && menu.app.setDefaultPageUrl) {
-      result['set-default-page'] = menuOptions['set-default-page'];
+    if (menu.model.attributes.is_folderish || !menu.app.setDefaultPageUrl) {
+      delete result['set-default-page'];
     }
-    if (menu.model.attributes.is_folderish) {
-      result.selectAll = menuOptions.selectAll;
+
+    if (!menu.model.attributes.is_folderish) {
+      delete result.selectAll;
     }
-    if (menu.options.header) {
-      result.openItem = menuOptions.openItem;
-    }
-    result.editItem = menuOptions.editItem;
+
+    result.openItem.url = menu.model.attributes.getURL;
+    result.editItem.url = menu.model.attributes.getURL + '/@@edit';
+
     return result;
   };
 

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -6,13 +6,15 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Open',
       'category': 'button',
-      'iconCSS':  'glyphicon glyphicon-eye-open'
+      'iconCSS':  'glyphicon glyphicon-eye-open',
+      'modal':    false
     },
     'editItem': {
       'url':      '#',
       'title':    'Edit',
       'category': 'button',
-      'iconCSS':  'glyphicon glyphicon-pencil'
+      'iconCSS':  'glyphicon glyphicon-pencil',
+      'modal':    false
     },
     'cutItem': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -21,6 +23,7 @@ define(['underscore'], function(_) {
       'title':    'Cut',
       'category': 'dropdown',
       'iconCSS':  '',
+      'modal':    false
     },
     'copyItem': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -28,7 +31,8 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Copy',
       'category': 'dropdown',
-      'iconCSS':  ''
+      'iconCSS':  '',
+      'modal':    false
     },
     'pasteItem': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -36,7 +40,8 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Paste',
       'category': 'dropdown',
-      'iconCSS':  ''
+      'iconCSS':  '',
+      'modal':    false
     },
     'move-top': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -44,7 +49,8 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Move to top of folder',
       'category': 'dropdown',
-      'iconCSS':  ''
+      'iconCSS':  '',
+      'modal':    false
     },
     'move-bottom': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -52,7 +58,8 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Move to bottom of folder',
       'category': 'dropdown',
-      'iconCSS':  ''
+      'iconCSS':  '',
+      'modal':    false
     },
     'set-default-page': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -60,7 +67,8 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Set as default page',
       'category': 'dropdown',
-      'iconCSS':  ''
+      'iconCSS':  '',
+      'modal':    false
     },
     'selectAll': {
       'library':  'mockup-patterns-structure-url/js/actions',
@@ -68,7 +76,8 @@ define(['underscore'], function(_) {
       'url':      '#',
       'title':    'Select all contained items',
       'category': 'dropdown',
-      'iconCSS':  ''
+      'iconCSS':  '',
+      'modal':    false
     }
   };
 

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -83,24 +83,29 @@ define(['underscore'], function(_) {
       return menu.menuOptions;
     }
 
+    var model = menu.model.attributes;
+    var app = menu.app;
+
     var result = _.clone(menuOptions);
-    if ( !(menu.app.pasteAllowed && menu.model.attributes.is_folderish)) {
+    if ( !(app.pasteAllowed && model.is_folderish)) {
       delete result.pasteItem;
     }
-    if (menu.app.inQueryMode() || menu.options.canMove === false) {
+    if (app.inQueryMode() || menu.options.canMove === false) {
       delete result['move-top'];
       delete result['move-bottom'];
     }
-    if (menu.model.attributes.is_folderish || !menu.app.setDefaultPageUrl) {
+    if (model.is_folderish || !app.setDefaultPageUrl) {
       delete result['set-default-page'];
     }
 
-    if (!menu.model.attributes.is_folderish) {
+    if (!model.is_folderish) {
       delete result.selectAll;
     }
 
-    result.openItem.url = menu.model.attributes.getURL;
-    result.editItem.url = menu.model.attributes.getURL + '/@@edit';
+    var typeToViewAction = app.options.typeToViewAction;
+    var viewAction = typeToViewAction && typeToViewAction[model.portal_type] || '';
+    result.openItem.url = model.getURL + viewAction;
+    result.editItem.url = model.getURL + '/@@edit';
 
     return result;
   };

--- a/mockup/patterns/structure/js/models/result.js
+++ b/mockup/patterns/structure/js/models/result.js
@@ -5,7 +5,8 @@ define(['backbone'], function(Backbone) {
     defaults: function() {
       return {
         'is_folderish': false,
-        'review_state': ''
+        'review_state': '',
+        'getURL': ''
       };
     },
     uid: function() {

--- a/mockup/patterns/structure/js/navigation.js
+++ b/mockup/patterns/structure/js/navigation.js
@@ -11,30 +11,6 @@ define([
       this.app = options.app;
       this.model = options.model;
     },
-
-    getSelectedBaseUrl: function() {
-      var self = this;
-      return self.model.attributes.getURL;
-    },
-    openUrl: function(url) {
-      var win = utils.getWindow();
-      var keyEvent = this.app.keyEvent;
-      if (keyEvent && keyEvent.ctrlKey) {
-        win.open(url);
-      } else {
-        win.location = url;
-      }
-    },
-    openClicked: function(e) {
-      e.preventDefault();
-      var self = this;
-      self.openUrl(self.getSelectedBaseUrl());
-    },
-    editClicked: function(e) {
-      e.preventDefault();
-      var self = this;
-      self.openUrl(self.getSelectedBaseUrl() + '/@@edit');
-    },
     folderClicked: function(e) {
       e.preventDefault();
       // handler for folder, go down path and show in contents window.

--- a/mockup/patterns/structure/js/navigation.js
+++ b/mockup/patterns/structure/js/navigation.js
@@ -28,12 +28,12 @@ define([
     openClicked: function(e) {
       e.preventDefault();
       var self = this;
-      self.openUrl(self.getSelectedBaseUrl() + '/view');
+      self.openUrl(self.getSelectedBaseUrl());
     },
     editClicked: function(e) {
       e.preventDefault();
       var self = this;
-      self.openUrl(self.getSelectedBaseUrl() + '/edit');
+      self.openUrl(self.getSelectedBaseUrl() + '/@@edit');
     },
     folderClicked: function(e) {
       e.preventDefault();

--- a/mockup/patterns/structure/js/views/actionmenu.js
+++ b/mockup/patterns/structure/js/views/actionmenu.js
@@ -23,8 +23,8 @@ define([
 
     eventConstructor: function(definition) {
       var self = this;
-      var libName = definition[0],
-        method = definition[1];
+      var libName = definition.library,
+          method = definition.method;
 
       if (!((typeof libName === 'string') && (typeof method === 'string'))) {
         return false;
@@ -39,14 +39,33 @@ define([
     },
 
     events: function() {
+      /* Backbone.view.events
+       * Specify a set of DOM events, which will bound to methods on the view.
+       */
       var self = this;
       var result = {};
-      _.each(self.menuOptions, function(menuOption, idx) {
-        var e = self.eventConstructor(menuOption);
-        if (e) {
-          result['click .' + idx + ' a'] = e;
-        }
+      var menuOptionsCategorized = {dropdown: []};
+      _.each(self.menuOptions, function(menuOption, key) {
+          // set a unique identifier to uniquely bind the events.
+          var idx = utils.generateId();
+          menuOption.idx = idx;
+          menuOption.name = key;  // we want to add the action's key as class name to the output.
+          
+          var category = menuOption.category || 'dropdown';
+          if (menuOptionsCategorized[category] === undefined) {
+              menuOptionsCategorized[category] = [];
+          }
+          menuOptionsCategorized[category].push(menuOption);
+
+		      // Create event handler and add it to the results object.
+          var e = self.eventConstructor(menuOption);
+          if (e) {
+            result['click a.' + idx] = e;
+          }
       });
+
+      // Abusing the loop above to also initialize menuOptionsCategorized
+      self.menuOptionsCategorized = menuOptionsCategorized;
       return result;
     },
 
@@ -76,7 +95,7 @@ define([
 
       var data = this.model.toJSON();
       data.header = self.options.header || null;
-      data.menuOptions = self.menuOptions;
+      data.menuOptions = self.menuOptionsCategorized;
 
       self.$el.html(self.template($.extend({
         _t: _t,

--- a/mockup/patterns/structure/js/views/actionmenu.js
+++ b/mockup/patterns/structure/js/views/actionmenu.js
@@ -44,7 +44,7 @@ define([
        */
       var self = this;
       var result = {};
-      var menuOptionsCategorized = {dropdown: []};
+      var menuOptionsCategorized = {};
       _.each(self.menuOptions, function(menuOption, key) {
           // set a unique identifier to uniquely bind the events.
           var idx = utils.generateId();
@@ -102,8 +102,10 @@ define([
         id: utils.generateId()
       }, data)));
 
-      self.$dropdown = self.$('.dropdown-toggle');
-      self.$dropdown.dropdown();
+      if (data.menuOptions.dropdown) {
+        self.$dropdown = self.$('.dropdown-toggle');
+        self.$dropdown.dropdown();
+      }
 
       if (self.options.className) {
         self.$el.addClass(self.options.className);

--- a/mockup/patterns/structure/js/views/actionmenu.js
+++ b/mockup/patterns/structure/js/views/actionmenu.js
@@ -10,6 +10,7 @@ define([
   'pat-registry',
   'translate',
   'mockup-patterns-modal',
+  'mockup-patterns-tooltip',
   'bootstrap-dropdown'
 ], function($, _, BaseView, utils, Result, Actions, ActionMenu, ActionMenuTemplate, registry, _t) {
   'use strict';
@@ -59,7 +60,7 @@ define([
               menuOptionsCategorized[category] = [];
           }
           menuOptionsCategorized[category].push(menuOption);
-          if (menuOption.modal) {
+          if (menuOption.modal || menuOption.category === 'button') {
             self.needsRescan = true;
           }
 

--- a/mockup/patterns/structure/js/views/actionmenu.js
+++ b/mockup/patterns/structure/js/views/actionmenu.js
@@ -7,9 +7,11 @@ define([
   'mockup-patterns-structure-url/js/actions',
   'mockup-patterns-structure-url/js/actionmenu',
   'text!mockup-patterns-structure-url/templates/actionmenu.xml',
+  'pat-registry',
   'translate',
+  'mockup-patterns-modal',
   'bootstrap-dropdown'
-], function($, _, BaseView, utils, Result, Actions, ActionMenu, ActionMenuTemplate, _t) {
+], function($, _, BaseView, utils, Result, Actions, ActionMenu, ActionMenuTemplate, registry, _t) {
   'use strict';
 
   var ActionMenuView = BaseView.extend({
@@ -20,6 +22,7 @@ define([
     menuOptions: null,
     // Dynamic menu options
     menuGenerator: 'mockup-patterns-structure-url/js/actionmenu',
+    needsRescan: false,
 
     eventConstructor: function(definition) {
       var self = this;
@@ -56,6 +59,9 @@ define([
               menuOptionsCategorized[category] = [];
           }
           menuOptionsCategorized[category].push(menuOption);
+          if (menuOption.modal) {
+            self.needsRescan = true;
+          }
 
 		      // Create event handler and add it to the results object.
           var e = self.eventConstructor(menuOption);
@@ -110,6 +116,11 @@ define([
       if (self.options.className) {
         self.$el.addClass(self.options.className);
       }
+
+      if (this.needsRescan) {
+        registry.scan(this.$el);
+      }
+
       return this;
     }
   });

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -27,7 +27,7 @@ define([
       self.listenTo(self.selectedCollection, 'reset', self.render);
       self.collection.pager();
       self.subsetIds = [];
-      self.contextInfo = self.folderModel = self.folderMenu = null;
+      self.contextInfo = null;
 
       self.app.on('context-info-loaded', function(data) {
         self.contextInfo = data;
@@ -48,7 +48,6 @@ define([
     events: {
       'click .fc-breadcrumbs a': 'breadcrumbClicked',
       'change .select-all': 'selectAll',
-      'change .fc-breadcrumbs-container input[type="checkbox"]': 'selectFolder'
     },
     setContextInfo: function() {
       var self = this;
@@ -64,24 +63,6 @@ define([
         _.each(crumbs, function(crumb, idx) {
           $crumbs.eq(idx).html(crumb.title);
         });
-      }
-      if (data.object) {
-        self.folderModel = new Result(data.object);
-        $('.context-buttons', self.$el).show();
-        if (self.selectedCollection.findWhere({UID: data.object.UID})){
-          $('input[type="checkbox"]', self.$breadcrumbs)[0].checked = true;
-        }
-        self.folderMenu = new ActionMenuView({
-          app: self.app,
-          model: self.folderModel,
-          menuOptions: self.app.menuOptions,
-          menuGenerator: self.app.menuGenerator,
-          header: _t('Actions on current folder'),
-          canMove: false
-        });
-        $('.input-group-btn', self.$breadcrumbs).empty().append(self.folderMenu.render().el);
-      } else {
-        self.folderModel = null;
       }
     },
     render: function() {
@@ -99,7 +80,6 @@ define([
         activeColumns: self.app.activeColumns,
         availableColumns: self.app.availableColumns
       }));
-      self.$breadcrumbs = $('.fc-breadcrumbs-container', self.$el);
 
       if (self.collection.length) {
         var container = self.$('tbody');
@@ -148,17 +128,6 @@ define([
       path += $el.attr('data-path');
       this.app.setCurrentPath(path);
       this.collection.pager();
-    },
-    selectFolder: function(e) {
-      var self = this;
-      if (self.folderModel){
-        if ($(e.target).is(':checked')) {
-          self.selectedCollection.add(self.folderModel.clone());
-        } else {
-          this.selectedCollection.removeByUID(self.folderModel.attributes.UID);
-        }
-        self.setContextInfo();
-      }
     },
     selectAll: function(e) {
       if ($(e.target).is(':checked')) {

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -103,7 +103,7 @@ define([
         });
       }
       self.moment = new Moment(self.$el, {
-        selector: '.ModificationDate,.EffectiveDate,.CreationDate,.ExpirationDate',
+        selector: '.ModificationDate,.EffectiveDate,.CreationDate,.ExpirationDate,.start,.end,.last_comment_date',
         format: self.options.app.momentFormat
       });
 

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -34,6 +34,16 @@ define([
         /* set default page info */
         self.setContextInfo();
       });
+
+      self.dateColumns = [
+        'ModificationDate',
+        'EffectiveDate',
+        'CreationDate',
+        'ExpirationDate',
+        'start',
+        'end',
+        'last_comment_date'
+      ];
     },
     events: {
       'click .fc-breadcrumbs a': 'breadcrumbClicked',
@@ -94,6 +104,13 @@ define([
       if (self.collection.length) {
         var container = self.$('tbody');
         self.collection.each(function(result) {
+          self.dateColumns.map(function (col) {
+            // empty column instead of displaying "None".
+            if (result.attributes.hasOwnProperty(col) && (result.attributes[col] === 'None' || !result.attributes[col] )) {
+              result.attributes[col] = '';
+            }
+          });
+
           var view = (new TableRowView({
             model: result,
             app: self.app,
@@ -103,7 +120,7 @@ define([
         });
       }
       self.moment = new Moment(self.$el, {
-        selector: '.ModificationDate,.EffectiveDate,.CreationDate,.ExpirationDate,.start,.end,.last_comment_date',
+        selector: '.' + self.dateColumns.join(',.'),
         format: self.options.app.momentFormat
       });
 
@@ -170,7 +187,7 @@ define([
       self.$el.addClass('order-support');
       var dd = new Sortable(self.$('tbody'), {
         selector: 'tr',
-        createDragItem: function(pattern, $el){
+        createDragItem: function(pattern, $el) {
           var $tr = $el.clone();
           var $table = $('<table><tbody></tbody></table>');
           $('tbody', $table).append($tr);

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -55,7 +55,7 @@ define([
           $crumbs.eq(idx).html(crumb.title);
         });
       }
-      if (data.object){
+      if (data.object) {
         self.folderModel = new Result(data.object);
         $('.context-buttons', self.$el).show();
         if (self.selectedCollection.findWhere({UID: data.object.UID})){
@@ -70,7 +70,7 @@ define([
           canMove: false
         });
         $('.input-group-btn', self.$breadcrumbs).empty().append(self.folderMenu.render().el);
-      }else {
+      } else {
         self.folderModel = null;
       }
     },

--- a/mockup/patterns/structure/js/views/tablerow.js
+++ b/mockup/patterns/structure/js/views/tablerow.js
@@ -37,6 +37,10 @@ define([
       data.portal_type = data.portal_type ? data.portal_type : '';
       data.contenttype = data.portal_type.toLowerCase().replace(/\.| /g, '-');
       data._authenticator = utils.getAuthenticator();
+
+      var viewAction = self.app.typeToViewAction && self.app.typeToViewAction[data.attributes.portal_type] || '';
+      data.viewURL = data.attributes.getURL + viewAction;
+
       data._t = _t;
       self.$el.html(self.template(data));
       var attrs = self.model.attributes;

--- a/mockup/patterns/structure/js/views/tablerow.js
+++ b/mockup/patterns/structure/js/views/tablerow.js
@@ -31,16 +31,6 @@ define([
       if (this.selectedCollection.findWhere({UID: data.UID})) {
         data.selected = true;
       }
-      if (!data.viewURL) {
-        // XXX
-        // This is for the new window link.  There should also be a
-        // separate one for the default link and it shouldn't require a
-        // javascript function to append '/view' on the default click.
-        // Need actual documentation reference for this and also support
-        // from the vocabulary that generates the data for the default
-        // portal_contents view.
-        data.viewURL = data.getURL + '/view';
-      }
       data.attributes = self.model.attributes;
       data.activeColumns = self.app.activeColumns;
       data.availableColumns = self.app.availableColumns;

--- a/mockup/patterns/structure/js/views/tablerow.js
+++ b/mockup/patterns/structure/js/views/tablerow.js
@@ -37,6 +37,7 @@ define([
       data.portal_type = data.portal_type ? data.portal_type : '';
       data.contenttype = data.portal_type.toLowerCase().replace(/\.| /g, '-');
       data._authenticator = utils.getAuthenticator();
+      data.iconSize = self.app.iconSize;
 
       var viewAction = self.app.typeToViewAction && self.app.typeToViewAction[data.attributes.portal_type] || '';
       data.viewURL = data.attributes.getURL + viewAction;

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -89,18 +89,6 @@
             }
         }
         .fc-breadcrumbs-container{
-            .input-group{
-                .input-group-addon{
-                    padding: 2px 5px;
-                }
-                .btn{
-                    padding: 2px 4px;
-                }
-
-                display: inline-block;
-                float: left;
-                padding-right: 5px;
-            }
             .fc-breadcrumbs{
                 font-size: 15px;
                 padding-top: 2px;

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -215,9 +215,6 @@
             }
         }
     }
-    .icon-group-right{
-        float: right;
-    }
 }
 
 .pat-structure {
@@ -259,7 +256,7 @@
     .itemRow.folder .title a{
         color: #005580;
     }
-    .itemRow.default-page .title:before{
+    .itemRow.default-page .title > *:first-child:before{
         content: '*';
         color: red;
     }

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -100,6 +100,13 @@ define([
           'mockup-patterns-structure-url/js/navigation', 'openClicked']
       },
 
+      typeToViewAction: null,
+      _default_typeToViewAction: {
+          'File': '/view',
+          'Image': '/view',
+          'Blob': '/view'
+      },
+
       collectionConstructor:
         'mockup-patterns-structure-url/js/collections/result',
 
@@ -159,8 +166,7 @@ define([
         May want to consider moving the _default_* values out of the
         options object.
       */
-      var replaceDefaults = [
-          'attributes', 'activeColumns', 'availableColumns', 'buttons'];
+      var replaceDefaults = ['attributes', 'activeColumns', 'availableColumns', 'buttons', 'typeToViewAction'];
       _.each(replaceDefaults, function(idx) {
         if (self.options[idx] === null) {
           self.options[idx] = self.options['_default_' + idx];

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -63,10 +63,23 @@ define([
 
       attributes: null,
       _default_attributes: [
-        'UID', 'Title', 'portal_type', 'path', 'review_state',
-        'ModificationDate', 'EffectiveDate', 'CreationDate',
-        'is_folderish', 'Subject', 'getURL', 'id', 'exclude_from_nav',
-        'getObjSize', 'last_comment_date', 'total_comments', 'getIcon'
+        'CreationDate',
+        'EffectiveDate',
+        'exclude_from_nav',
+        'getIcon',
+        'getObjSize',
+        'getURL',
+        'id',
+        'is_folderish',
+        'last_comment_date',
+        'ModificationDate',
+        'path',
+        'portal_type',
+        'review_state',
+        'Subject',
+        'Title',
+        'total_comments',
+        'UID'
       ],
 
       activeColumns: null,

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -94,10 +94,8 @@ define([
       // action triggered for the primary link for each table row.
       tableRowItemAction: null,
       _default_tableRowItemAction: {
-        folder: [
-          'mockup-patterns-structure-url/js/navigation', 'folderClicked'],
-        other: [
-          'mockup-patterns-structure-url/js/navigation', 'openClicked']
+        folder: ['mockup-patterns-structure-url/js/navigation', 'folderClicked'],
+        other: []
       },
 
       typeToViewAction: null,

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -48,6 +48,8 @@ define([
 
       activeColumnsCookie: 'activeColumns',
 
+      iconSize: 'icon',
+
       /*
         As the options operate on a merging basis per new attribute
         (key/value pairs) on the option Object in a recursive fashion,
@@ -64,7 +66,7 @@ define([
         'UID', 'Title', 'portal_type', 'path', 'review_state',
         'ModificationDate', 'EffectiveDate', 'CreationDate',
         'is_folderish', 'Subject', 'getURL', 'id', 'exclude_from_nav',
-        'getObjSize', 'last_comment_date', 'total_comments','getIcon'
+        'getObjSize', 'last_comment_date', 'total_comments', 'getIcon'
       ],
 
       activeColumns: null,

--- a/mockup/patterns/structure/templates/actionmenu.xml
+++ b/mockup/patterns/structure/templates/actionmenu.xml
@@ -1,5 +1,5 @@
 <% _.each(menuOptions.button, function(menuOption){ %>
-<a class="action <%- menuOption.name %> <%- menuOption.idx %> <% if (menuOption.modal) { %>pat-plone-modal<% } %>"
+<a class="action <%- menuOption.name %> <%- menuOption.idx %> pat-tooltip <% if (menuOption.modal) { %>pat-plone-modal<% } %>"
     href="<%- menuOption.url %>"
     title="<%- _t(menuOption.title) %>">
   <% if (menuOption.iconCSS) { %>

--- a/mockup/patterns/structure/templates/actionmenu.xml
+++ b/mockup/patterns/structure/templates/actionmenu.xml
@@ -31,10 +31,10 @@
   <li>
     <a class="action <%- menuOption.name %> <%- menuOption.idx %> <% if (menuOption.modal) { %>pat-plone-modal<% } %>"
         href="<%- menuOption.url %>">
-      <%- _t(menuOption.title) %>
       <% if (menuOption.iconCSS) { %>
       <span class="<%- menuOption.iconCSS %>"></span>
       <% } %>
+      <%- _t(menuOption.title) %>
     </a>
   </li>
   <% }); %>

--- a/mockup/patterns/structure/templates/actionmenu.xml
+++ b/mockup/patterns/structure/templates/actionmenu.xml
@@ -1,15 +1,38 @@
-<a class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" href="#"
-    aria-haspopup="true" aria-expanded="true" id="<%- id %>" title="Actions">
-  <span class="glyphicon glyphicon-cog"></span>
-  <span class="caret"></span>
+<% _.each(menuOptions.button, function(menuOption){ %>
+<a class="action <%- menuOption.name %> <%- menuOption.idx %>"
+    href="<%- menuOption.url %>"
+    title="<%- _t(menuOption.title) %>">
+  <span class="<%- menuOption.iconCSS %>"></span>
+</a>&nbsp;
+<% }); %>
+
+
+<% if (menuOptions.dropdown) { %>
+<a class="dropdown-toggle"
+    data-toggle="dropdown"
+    href="#"
+    aria-haspopup="true"
+    aria-expanded="true"
+    id="<%- id %>"
+    title="Actions">
+  <span class="glyphicon glyphicon-cog"></span><span class="caret"></span>
 </a>
 <ul class="dropdown-menu pull-right" aria-labelledby="<%- id %>">
-  <% if(header) { %>
+  <% if (header) { %>
     <li class="dropdown-header"><%- header %></li>
     <li class="divider"></li>
   <% } %>
 
-  <% _.each(menuOptions, function(menuOption, idx){ %>
-  <li class="<%- idx %>"><a href="<%- menuOption[2] %>"><%- _t(menuOption[3]) %></a></li>
+  <% _.each(menuOptions.dropdown, function(menuOption){ %>
+  <li>
+    <a class="action <%- menuOption.name %> <%- menuOption.idx %>"
+        href="<%- menuOption.url %>">
+      <%- _t(menuOption.title) %>
+      <% if (menuOption.iconCSS) { %>
+      <span class="<%- menuOption.iconCSS %>"></span>
+      <% } %>
+    </a>
+  </li>
   <% }); %>
 </ul>
+<% } %>

--- a/mockup/patterns/structure/templates/actionmenu.xml
+++ b/mockup/patterns/structure/templates/actionmenu.xml
@@ -1,5 +1,5 @@
 <% _.each(menuOptions.button, function(menuOption){ %>
-<a class="action <%- menuOption.name %> <%- menuOption.idx %>"
+<a class="action <%- menuOption.name %> <%- menuOption.idx %> <% if (menuOption.modal) { %>pat-plone-modal<% } %>"
     href="<%- menuOption.url %>"
     title="<%- _t(menuOption.title) %>">
   <% if (menuOption.iconCSS) { %>
@@ -29,7 +29,7 @@
 
   <% _.each(menuOptions.dropdown, function(menuOption){ %>
   <li>
-    <a class="action <%- menuOption.name %> <%- menuOption.idx %>"
+    <a class="action <%- menuOption.name %> <%- menuOption.idx %> <% if (menuOption.modal) { %>pat-plone-modal<% } %>"
         href="<%- menuOption.url %>">
       <%- _t(menuOption.title) %>
       <% if (menuOption.iconCSS) { %>

--- a/mockup/patterns/structure/templates/actionmenu.xml
+++ b/mockup/patterns/structure/templates/actionmenu.xml
@@ -2,7 +2,11 @@
 <a class="action <%- menuOption.name %> <%- menuOption.idx %>"
     href="<%- menuOption.url %>"
     title="<%- _t(menuOption.title) %>">
+  <% if (menuOption.iconCSS) { %>
   <span class="<%- menuOption.iconCSS %>"></span>
+  <% } else { %>
+  <%- _t(menuOption.title) %> 
+  <% } %>
 </a>&nbsp;
 <% }); %>
 

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -1,6 +1,4 @@
-<div class="alert alert-<%- statusType %> status">
-  <%- status %>
-</div>
+<div class="alert alert-<%- statusType %> status"><%- status %></div>
 
 <table class="table table-striped table-bordered">
   <thead>

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -3,28 +3,18 @@
 <table class="table table-striped table-bordered">
   <thead>
     <tr class="fc-breadcrumbs-container">
-      <td colspan="<%- activeColumns.length + 3 %>">
-        <% if(pathParts.length > 0) { %>
-          <div class="input-group context-buttons" style="display:none">
-            <span class="input-group-addon">
-              <input type="checkbox" />
-            </span>
-            <div class="input-group-btn"></div>
-          </div>
-        <% } %>
-        <div class="fc-breadcrumbs">
-          <a href="#" data-path="/">
-            <span class="glyphicon glyphicon-home"></span> /
-          </a>
-          <% _.each(pathParts, function(part, idx, list){
-            if(part){
-              if(idx > 0){ %>
-                /
-              <% } %>
-              <a href="#" class="crumb" data-path="<%- part %>"><%- part %></a>
-            <% }
-          }); %>
-        </div>
+      <td class="fc-breadcrumbs" colspan="<%- activeColumns.length + 3 %>">
+        <a href="#" data-path="/">
+          <span class="glyphicon glyphicon-home"></span> /
+        </a>
+        <% _.each(pathParts, function(part, idx, list){
+          if(part){
+            if(idx > 0){ %>
+              /
+            <% } %>
+            <a href="#" class="crumb" data-path="<%- part %>"><%- part %></a>
+          <% }
+        }); %>
       </td>
     </tr>
     <tr>

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -1,22 +1,22 @@
 <td class="selection"><input type="checkbox" <% if(selected){ %> checked="checked" <% } %>/></td>
 
 <td class="title">
-
-  <a href="<%- viewURL %>"
-      class="manage state-<%- review_state %> contenttype-<%- contenttype %>"
-      title="<%- portal_type %>">
-    <%- Title %>
-  </a>
-  <% if(attributes["getIcon"] ){ %>
-  <div class="icon-group-right">
-    <img class="image-<%- iconSize %>" src="<%- getURL %>/@@images/image/<%- iconSize %>">
+  <div class="pull-left">
+    <a href="<%- viewURL %>"
+        class="manage state-<%- review_state %> contenttype-<%- contenttype %>"
+        title="<%- portal_type %>">
+      <%- Title %>
+    </a>
   </div>
+  <% if(attributes["getIcon"] ){ %>
+  <img class="image-<%- iconSize %> pull-right" src="<%- getURL %>/@@images/image/<%- iconSize %>">
   <% } %>
+</td>
 
-  <% _.each(activeColumns, function(column) { %>
-    <% if(_.has(availableColumns, column)) { %>
-      <td class="<%- column %>"><%- attributes[column] %></td>
-    <% } %>
-  <% }); %>
+<% _.each(activeColumns, function(column) { %>
+  <% if(_.has(availableColumns, column)) { %>
+    <td class="<%- column %>"><%- attributes[column] %></td>
+  <% } %>
+<% }); %>
 
 <td class="actionmenu-container"></td>

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -9,11 +9,11 @@
   </a>
   <% if(attributes["getIcon"] ){ %>
   <div class="icon-group-right">
-    <img class="image-icon" src="<%- getURL %>/@@images/image/icon"><span> &nbsp;</span>
+    <img class="image-<%- iconSize %>" src="<%- getURL %>/@@images/image/<%- iconSize %>">
   </div>
   <% } %>
 
-  <% _.each(activeColumns, function(column){ %>
+  <% _.each(activeColumns, function(column) { %>
     <% if(_.has(availableColumns, column)) { %>
       <td class="<%- column %>"><%- attributes[column] %></td>
     <% } %>

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -2,14 +2,16 @@
 
 <td class="title">
 
-  <a href="<%- getURL %>"
+  <a href="<%- viewURL %>"
       class="manage state-<%- review_state %> contenttype-<%- contenttype %>"
       title="<%- portal_type %>">
     <%- Title %>
   </a>
+  <% if(attributes["getIcon"] ){ %>
   <div class="icon-group-right">
-    <% if(attributes["getIcon"] ){ %> <img class="image-icon" src="<%- getURL %>/@@images/image/icon"><span> &nbsp;</span><% } %>
+    <img class="image-icon" src="<%- getURL %>/@@images/image/icon"><span> &nbsp;</span>
   </div>
+  <% } %>
 
   <% _.each(activeColumns, function(column){ %>
     <% if(_.has(availableColumns, column)) { %>

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -9,7 +9,6 @@
   </a>
   <div class="icon-group-right">
     <% if(attributes["getIcon"] ){ %> <img class="image-icon" src="<%- getURL %>/@@images/image/icon"><span> &nbsp;</span><% } %>
-    <a href="<%- viewURL %>" title="<%- _t('View') %>"><span class="glyphicon glyphicon-new-window"></span></a>
   </div>
 
   <% _.each(activeColumns, function(column){ %>

--- a/mockup/tests/fakeserver.js
+++ b/mockup/tests/fakeserver.js
@@ -245,6 +245,11 @@ define([
         '2013-03-12T10:10:10+02:00',
         '2012-04-01T10:10:10+02:00',
         '2013-03-20T10:10:10+02:00',
+        'None',
+        'None',
+        'None',
+        'None',
+        'None',
       ];
       for (var i = 0; i < list.length; i = i + 1) {
         var data = list[i];

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -149,7 +149,8 @@ define([
       var model = new Result({
           "Title": "Dummy Object",
           "is_folderish": true,
-          "review_state": "published"
+          "review_state": "published",
+          "getURL": "http://nohost/dummy_object"
       });
 
       var menu = new ActionMenuView({
@@ -161,13 +162,14 @@ define([
       var el = menu.render().el;
 
       expect($('li.dropdown-header', el).text()).to.equal('Menu Header');
-      expect($('li a', el).length).to.equal(7);
-      expect($($('li a', el)[0]).text()).to.equal('Cut');
+      expect($('a.action', el).length).to.equal(7);
+      expect($($('li a', el)[0]).text().trim()).to.equal('Cut');
+      expect($('a.openItem', el).attr('href')).to.equal('http://nohost/dummy_object');
 
-      $('.cutItem a', el).click();
+      $('a.cutItem', el).click();
       this.clock.tick(500);
 
-      expect(this.app.$('.status').text()).to.equal('Cut "Dummy Object"');
+      expect(this.app.$('.status').text().trim()).to.equal('Cut "Dummy Object"');
 
     });
 
@@ -182,22 +184,23 @@ define([
         app: this.app,
         model: model,
         menuOptions: {
-          'cutItem': [
-            'mockup-patterns-structure-url/js/actions',
-            'cutClicked',
-            '#',
-            'Cut',
-          ],
+          'cutItem': {
+            'library': 'mockup-patterns-structure-url/js/actions',
+            'method': 'cutClicked',
+            'url': '#',
+            'title': 'Cut',
+            'category': 'dropdown',
+          },
         },
       });
 
       var el = menu.render().el;
       expect($('li a', el).length).to.equal(1);
-      expect($($('li a', el)[0]).text()).to.equal('Cut');
+      expect($($('li a', el)[0]).text().trim()).to.equal('Cut');
 
-      $('.cutItem a', el).click();
+      $('a.cutItem', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text()).to.equal('Cut "Dummy Object"');
+      expect(this.app.$('.status').text().trim()).to.equal('Cut "Dummy Object"');
 
     });
 
@@ -221,8 +224,8 @@ define([
       this.clock.tick(500);
 
       var model = new Result({
-          "is_folderish": true,
-          "review_state": "published"
+        'is_folderish': true,
+        'review_state': 'published'
       });
 
       // Make use if that dummy in here.
@@ -230,22 +233,23 @@ define([
         app: this.app,
         model: model,
         menuOptions: {
-          'foobar': [
-            'dummytestactions',
-            'foobarClicked',
-            '#',
-            'Foo Bar',
-          ],
+          'foobar': {
+            'library': 'dummytestactions',
+            'method': 'foobarClicked',
+            'url': '#',
+            'title': 'Foo Bar',
+            'category': 'dropdown',
+          },
         },
       });
 
       var el = menu.render().el;
       expect($('li a', el).length).to.equal(1);
-      expect($($('li a', el)[0]).text()).to.equal('Foo Bar');
+      expect($($('li a', el)[0]).text().trim()).to.equal('Foo Bar');
 
-      $('.foobar a', el).click();
+      $('a.foobar', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text()).to.equal('Status: foobar clicked');
+      expect(this.app.$('.status').text().trim()).to.equal('Status: foobar clicked');
     });
 
     it('custom action menu actions missing.', function() {
@@ -269,8 +273,8 @@ define([
       this.clock.tick(500);
 
       var model = new Result({
-          "is_folderish": true,
-          "review_state": "published"
+        'is_folderish': true,
+        'review_state': 'published'
       });
 
       // Make use if that dummy in here.
@@ -278,24 +282,26 @@ define([
         app: this.app,
         model: model,
         menuOptions: {
-          'foobar': [
-            'dummytestactions',
-            'foobarClicked',
-            '#',
-            'Foo Bar',
-          ],
-          'barbaz': [
-            'dummytestactions',
-            'barbazClicked',
-            '#',
-            'Bar Baz',
-          ],
+          'foobar': {
+            'library':    'dummytestactions',
+            'method':     'foobarClicked',
+            'url':        '#',
+            'title':      'Foo Bar',
+            'category': 'dropdown',
+          },
+          'barbaz': {
+            'library':    'dummytestactions',
+            'method':     'barbazClicked',
+            'url':        '#',
+            'title':      'Bar Baz',
+            'category': 'dropdown',
+          },
         },
       });
 
       // Broken/missing action
       var el = menu.render().el;
-      $('.foobar a', el).click();
+      $('a.foobar', el).click();
       this.clock.tick(500);
       expect(this.app.$('.status').text().trim()).to.equal('');
     });
@@ -319,24 +325,25 @@ define([
       define('dummytestactionmenu', ['backbone'], function(Backbone) {
         var ActionMenu = function(menu) {
           return {
-            'barbaz': [
-              'dummytestactions',
-              'barbazClicked',
-              '#',
-              'Bar Baz'
-            ]
+            'barbaz': {
+              'library':    'dummytestactions',
+              'method':     'barbazClicked',
+              'url':        '#',
+              'title':      'Bar Baz',
+              'category':   'dropdown'
+            }
           };
         };
         return ActionMenu;
       });
       // use them both to make it available synchronously.
-      require(['dummytestactions'], function(){});
-      require(['dummytestactionmenu'], function(){});
+      require(['dummytestactions'], function() {});
+      require(['dummytestactionmenu'], function() {});
       this.clock.tick(500);
 
       var model = new Result({
-          "is_folderish": true,
-          "review_state": "published"
+        'is_folderish': true,
+        'review_state': 'published'
       });
 
       // Make use if that dummy in here.
@@ -348,10 +355,9 @@ define([
 
       // Broken/missing action
       var el = menu.render().el;
-      $('.barbaz a', el).click();
+      $('a.barbaz', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text().trim()).to.equal(
-        'Status: barbaz clicked');
+      expect(this.app.$('.status').text().trim()).to.equal('Status: barbaz clicked');
     });
 
   });
@@ -714,14 +720,11 @@ define([
       expect($content_row.find('td').eq(2).text().trim()).to.equal('');
       expect($content_row.find('td').eq(3).text().trim()).to.equal('');
       expect($content_row.find('td').eq(4).text().trim()).to.equal('published');
-      expect($content_row.find('td .icon-group-right a').attr('href')
-        ).to.equal('http://localhost:8081/folder/view');
+      expect($content_row.find('a.openItem').attr('href')).to.equal('http://localhost:8081/folder');
 
       var $content_row1 = this.$el.find('table tbody tr').eq(1);
-      expect($content_row1.find('td').eq(1).text().trim()).to.equal(
-        'Document 0');
-      expect($content_row1.find('td .icon-group-right a').attr('href')
-        ).to.equal('http://localhost:8081/item0/view');
+      expect($content_row1.find('td').eq(1).text().trim()).to.equal('Document 0');
+      expect($content_row1.find('a.openItem').attr('href')).to.equal('http://localhost:8081/item0');
     });
 
     it('test select all contained item action', function() {
@@ -735,11 +738,11 @@ define([
       this.clock.tick(1000);
 
       var menu = $('.fc-breadcrumbs-container .actionmenu', this.$el);
-      var options = $('ul li a', menu);
+      var options = $('a.action', menu);
       expect(options.length).to.equal(5);
 
-      var selectAll = $('.selectAll a', menu);
-      expect(selectAll.text()).to.eql('Select all contained items');
+      var selectAll = $('a.selectAll', menu);
+      expect(selectAll.text().trim()).to.eql('Select all contained items');
       selectAll.trigger('click');
       this.clock.tick(1000);
       expect($('table tbody .selection input:checked', this.$el).length
@@ -752,11 +755,11 @@ define([
       this.clock.tick(500);
       var $row = this.$el.find('table thead tr').eq(1);
       expect($row.find('th').length).to.equal(6);
-      expect($row.find('th').eq(1).text()).to.equal('Title');
-      expect($row.find('th').eq(2).text()).to.equal('Last modified');
-      expect($row.find('th').eq(3).text()).to.equal('Published');
-      expect($row.find('th').eq(4).text()).to.equal('Review state');
-      expect($row.find('th').eq(5).text()).to.equal('Actions');
+      expect($row.find('th').eq(1).text().trim()).to.equal('Title');
+      expect($row.find('th').eq(2).text().trim()).to.equal('Last modified');
+      expect($row.find('th').eq(3).text().trim()).to.equal('Published');
+      expect($row.find('th').eq(4).text().trim()).to.equal('Review state');
+      expect($row.find('th').eq(5).text().trim()).to.equal('Actions');
 
       expect($.cookie('_fc_activeColumns')).to.be(undefined);
 
@@ -770,14 +773,14 @@ define([
       this.clock.tick(500);
 
       var $popover = this.$el.find('.popover.attribute-columns');
-      expect($popover.find('button').text()).to.equal('Save');
+      expect($popover.find('button').text().trim()).to.equal('Save');
       $popover.find('button').trigger('click');
       this.clock.tick(500);
 
       $row = this.$el.find('table thead tr').eq(1);
       expect($row.find('th').length).to.equal(7);
-      expect($row.find('th').eq(5).text()).to.equal('Object Size');
-      expect($row.find('th').eq(6).text()).to.equal('Actions');
+      expect($row.find('th').eq(5).text().trim()).to.equal('Object Size');
+      expect($row.find('th').eq(6).text().trim()).to.equal('Actions');
       expect($.parseJSON($.cookie('_fc_activeColumns')).value).to.eql(
           ["ModificationDate", "EffectiveDate", "review_state", "getObjSize"]);
 
@@ -806,15 +809,13 @@ define([
       // folder
       var folder = this.$el.find('.itemRow').eq(0);
       expect(folder.data().id).to.equal('folder');
-      expect($('.actionmenu ul li a', folder).length).to.equal(6);
+      expect($('.actionmenu a.action', folder).length).to.equal(7);
       // no pasting (see next test
-      expect($('.actionmenu ul li.pasteItem', folder).length).to.equal(0);
+      expect($('.actionmenu a.pasteItem', folder).length).to.equal(0);
       // no set default page
-      expect($('.actionmenu ul li.set-default-page a', folder).length
-        ).to.equal(0);
+      expect($('.actionmenu a.set-default-page', folder).length).to.equal(0);
       // can select all
-      expect($('.actionmenu ul li.selectAll', folder).text()).to.equal(
-        'Select all contained items');
+      expect($('.actionmenu a.selectAll', folder).text().trim()).to.equal('Select all contained items');
     });
 
     it('test itemRow default actionmenu item', function() {
@@ -823,13 +824,13 @@ define([
 
       var item = this.$el.find('.itemRow').eq(10);
       expect(item.data().id).to.equal('item9');
-      expect($('.actionmenu ul li a', item).length).to.equal(6);
+      expect($('.actionmenu a.action', item).length).to.equal(7);
       // cannot select all
-      expect($('.actionmenu ul li.selectAll a', item).length).to.equal(0);
+      expect($('a.selectAll', item).length).to.equal(0);
       // can set default page
-      expect($('.actionmenu ul li.set-default-page', item).text()).to.equal(
+      expect($('a.set-default-page', item).text().trim()).to.equal(
         'Set as default page');
-      $('.actionmenu ul li.set-default-page a', item).click();
+      $('a.set-default-page', item).click();
       this.clock.tick(1000);
       expect(this.$el.find('.order-support .status').html()).to.contain(
         'defaulted');
@@ -844,9 +845,9 @@ define([
       // top item
       var item0 = this.$el.find('.itemRow').eq(0);
       expect(item0.data().id).to.equal('folder');
-      expect($('.actionmenu ul li a', item0).length).to.equal(7);
-      expect($('.actionmenu ul li.pasteItem', item0).text()).to.equal('Paste');
-      $('.actionmenu ul li.pasteItem a', item0).click();
+      expect($('.actionmenu a.action', item0).length).to.equal(8);
+      expect($('a.pasteItem', item0).text().trim()).to.equal('Paste');
+      $('a.pasteItem', item0).click();
       this.clock.tick(1000);
       expect(this.$el.find('.order-support .status').html()).to.contain(
         'Pasted into "Folder"');
@@ -861,9 +862,8 @@ define([
       var item10 = this.$el.find('.itemRow').eq(10);
       expect(item10.data().id).to.equal('item9');
 
-      expect($('.actionmenu ul li.move-top', item10).text()).to.equal(
-        'Move to top of folder');
-      $('.actionmenu ul li.move-top a', item10).trigger('click');
+      expect($('.actionmenu a.move-top', item10).text().trim()).to.equal('Move to top of folder');
+      $('.actionmenu a.move-top', item10).trigger('click');
       this.clock.tick(1000);
 
       expect(this.$el.find('.order-support .status').html()).to.contain(
@@ -880,10 +880,9 @@ define([
       this.clock.tick(1000);
 
       var folder = this.$el.find('.itemRow').eq(0);
-      $('.actionmenu ul li.selectAll a', folder).trigger('click');
+      $('.actionmenu a.selectAll', folder).trigger('click');
       this.clock.tick(1000);
-      expect($('table tbody .selection input:checked', this.$el).length
-        ).to.equal(0);
+      expect($('table tbody .selection input:checked', this.$el).length).to.equal(0);
       // all items in the folder be populated within the selection well.
       expect(this.$el.find('#btn-selected-items').html()).to.contain('101');
     });
@@ -896,11 +895,11 @@ define([
       expect(item.data().id).to.equal('item9');
       $('.title a.manage', item).trigger('click');
       this.clock.tick(1000);
-      expect(dummyWindow.location).to.equal('http://localhost:8081/item9/view');
+      expect(dummyWindow.location).to.equal('http://localhost:8081/item9');
 
-      $('.actionmenu ul li.editItem a', item).trigger('click');
+      $('.actionmenu a.editItem', item).trigger('click');
       this.clock.tick(1000);
-      expect(dummyWindow.location).to.equal('http://localhost:8081/item9/edit');
+      expect(dummyWindow.location).to.equal('http://localhost:8081/item9/@@edit');
     });
 
     it('test navigate to folder push states', function() {
@@ -1070,7 +1069,7 @@ define([
       this.clock.tick(500);
       var $row = this.$el.find('table thead tr').eq(1);
       expect($row.find('th').length).to.equal(6);
-      expect($row.find('th').eq(5).text()).to.equal('Actions');
+      expect($row.find('th').eq(5).text().trim()).to.equal('Actions');
 
       expect($.cookie('_fc_activeColumnsCustom')).to.be(undefined);
 
@@ -1084,14 +1083,14 @@ define([
       this.clock.tick(500);
 
       var $popover = this.$el.find('.popover.attribute-columns');
-      expect($popover.find('button').text()).to.equal('Save');
+      expect($popover.find('button').text().trim()).to.equal('Save');
       $popover.find('button').trigger('click');
       this.clock.tick(500);
 
       $row = this.$el.find('table thead tr').eq(1);
       expect($row.find('th').length).to.equal(7);
-      expect($row.find('th').eq(5).text()).to.equal('Type');
-      expect($row.find('th').eq(6).text()).to.equal('Actions');
+      expect($row.find('th').eq(5).text().trim()).to.equal('Type');
+      expect($row.find('th').eq(6).text().trim()).to.equal('Actions');
       expect($.parseJSON($.cookie('_fc_activeColumnsCustom')).value).to.eql(
           ["ModificationDate", "EffectiveDate", "review_state", "portal_type"]);
       // standard cookie unchanged.
@@ -1206,9 +1205,9 @@ define([
       this.clock.tick(500);
       var $row = this.$el.find('table thead tr').eq(1);
       expect($row.find('th').length).to.equal(4);
-      expect($row.find('th').eq(1).text()).to.equal('Title');
-      expect($row.find('th').eq(2).text()).to.equal('Object Size');
-      expect($row.find('th').eq(3).text()).to.equal('Actions');
+      expect($row.find('th').eq(1).text().trim()).to.equal('Title');
+      expect($row.find('th').eq(2).text().trim()).to.equal('Object Size');
+      expect($row.find('th').eq(3).text().trim()).to.equal('Actions');
     });
 
   });
@@ -1462,18 +1461,20 @@ define([
         },
         "buttons": [],
         "menuOptions": {
-          'action1': [
-            'dummytestaction',
-            'option1',
-            '#',
-            'Option 1',
-          ],
-          'action2': [
-            'dummytestaction',
-            'option2',
-            '#',
-            'Option 2',
-          ],
+          'action1': {
+            'library':  'dummytestaction',
+            'method':   'option1',
+            'url':      '#',
+            'title':    'Option 1',
+            'category': 'dropdown',
+          },
+          'action2': {
+            'library':  'dummytestaction',
+            'method':   'option2',
+            'url':      '#',
+            'title':    'Option 2',
+            'category': 'dropdown',
+          },
         },
         'tableRowItemAction': {
           'other': ['dummytestaction', 'handleOther'],
@@ -1568,8 +1569,8 @@ define([
       var item = this.$el.find('.itemRow').eq(0);
       // Check for complete new options
       expect($('.actionmenu * a', item).length).to.equal(2);
-      expect($('.actionmenu .action1 a', item).text()).to.equal('Option 1');
-      expect($('.actionmenu .action2 a', item).text()).to.equal('Option 2');
+      expect($('.actionmenu a.action1', item).text().trim()).to.equal('Option 1');
+      expect($('.actionmenu a.action2', item).text().trim()).to.equal('Option 2');
 
       define('dummytestaction', ['backbone'], function(Backbone) {
         var Actions = Backbone.Model.extend({
@@ -1594,12 +1595,12 @@ define([
       require(['dummytestaction'], function(){});
       this.clock.tick(1000);
 
-      $('.actionmenu .action1 a', item).trigger('click');
+      $('.actionmenu a.action1', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
       expect($('.status').text()).to.contain('Status: option1 selected');
 
-      $('.actionmenu .action2 a', item).trigger('click');
+      $('.actionmenu a.action2', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
       expect($('.status').text()).to.contain('Status: option2 selected');
@@ -1955,21 +1956,21 @@ define([
         var ActionMenu = function(menu) {
           if (menu.model.attributes.id === 'item') {
             return {
-              'itemClicker': [
-                'dummytestaction',
-                'itemClicker',
-                '#',
-                'Item Clicker'
-              ]
+              'itemClicker': {
+                'library':  'dummytestaction',
+                'method':   'itemClicker',
+                'url':      '#',
+                'title':    'Item Clicker'
+              }
             };
           } else {
             return {
-              'folderClicker': [
-                'dummytestaction',
-                'folderClicker',
-                '#',
-                'Folder Clicker'
-              ]
+              'folderClicker': {
+                'library':  'dummytestaction',
+                'method':   'folderClicker',
+                'url':      '#',
+                'title':    'Folder Clicker'
+              }
             };
           }
         };
@@ -1987,9 +1988,8 @@ define([
 
       // Check for complete new options
       expect($('.actionmenu * a', folder).length).to.equal(1);
-      expect($('.actionmenu .folderClicker a', folder).text()).to.equal(
-        'Folder Clicker');
-      $('.actionmenu .folderClicker a', folder).trigger('click');
+      expect($('.actionmenu a.folderClicker', folder).text().trim()).to.equal('Folder Clicker');
+      $('.actionmenu a.folderClicker', folder).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
       expect($('.status').text()).to.contain('Status: folder clicked');
@@ -1997,9 +1997,9 @@ define([
       var item = this.$el.find('.itemRow').eq(1);
       // Check for complete new options
       expect($('.actionmenu * a', item).length).to.equal(1);
-      expect($('.actionmenu .itemClicker a', item).text()).to.equal(
+      expect($('.actionmenu a.itemClicker', item).text().trim()).to.equal(
         'Item Clicker');
-      $('.actionmenu .itemClicker a', item).trigger('click');
+      $('.actionmenu a.itemClicker', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
       expect($('.status').text()).to.contain('Status: item clicked');
@@ -2078,7 +2078,6 @@ define([
         items.push({
           UID: '123sdfasdfFolder',
           getURL: 'http://localhost:8081/folder',
-          viewURL: 'http://localhost:8081/folder',
           path: '/folder',
           portal_type: 'Folder',
           Description: 'folder',
@@ -2092,7 +2091,6 @@ define([
           items.push({
             UID: '123sdfasdf' + i,
             getURL: 'http://localhost:8081/item' + i,
-            viewURL: 'http://localhost:8081/item' + i + '/item_view',
             path: '/item' + i,
             portal_type: 'Document ' + i,
             Description: 'document',
@@ -2163,14 +2161,14 @@ define([
       expect($content_row.find('td').eq(2).text().trim()).to.equal('');
       expect($content_row.find('td').eq(3).text().trim()).to.equal('');
       expect($content_row.find('td').eq(4).text().trim()).to.equal('published');
-      expect($content_row.find('td .icon-group-right a').attr('href')
+      expect($content_row.find('.actionmenu a.openItem').attr('href')
         ).to.equal('http://localhost:8081/folder');
 
       var $content_row1 = this.$el.find('table tbody tr').eq(1);
       expect($content_row1.find('td').eq(1).text().trim()).to.equal(
         'Document 0');
-      expect($content_row1.find('td .icon-group-right a').attr('href')
-        ).to.equal('http://localhost:8081/item0/item_view');
+      expect($content_row1.find('.actionmenu a.openItem').attr('href')
+        ).to.equal('http://localhost:8081/item0');
     });
 
   });

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -205,7 +205,6 @@ define([
       $('a.cutItem', el).click();
       this.clock.tick(500);
       expect(this.app.$('.status').text().trim()).to.equal('Cut "Dummy Object"');
-
     });
 
     it('custom action menu items and actions.', function() {
@@ -423,6 +422,108 @@ define([
         expect($('.title a', el).attr('href')).to.equal(item.model.getURL + item.expect);
       }
 
+    });
+
+    it('custom action menu items in dropdown only', function() {
+      var model = new Result({});
+      var menu = new ActionMenuView({
+        app: this.app,
+        model: model,
+        menuOptions: {
+          'item1': {
+            'url': '#',
+            'title': 'Item 1',
+            'category': 'dropdown',
+          },
+          'item2': {
+            'url': '#',
+            'title': 'Item 2',
+            'category': 'dropdown',
+          },
+        },
+      });
+
+      var el = menu.render().el;
+      expect($('ul.dropdown-menu a.action', el).length).to.equal(2);
+      expect($('a.action', el).length).to.equal(2);
+    });
+
+    it('custom action menu items as buttons only /wout icons', function() {
+      var model = new Result({});
+      var menu = new ActionMenuView({
+        app: this.app,
+        model: model,
+        menuOptions: {
+          'item1': {
+            'url': '#',
+            'title': 'Item 1',
+            'category': 'button',
+          },
+          'item2': {
+            'url': '#',
+            'title': 'Item 2',
+            'category': 'button',
+          },
+        },
+      });
+
+      var el = menu.render().el;
+      expect($('ul.dropdown-menu', el).length).to.equal(0);
+      expect($('a.action', el).length).to.equal(2);
+      expect($($('a.action', el)[0]).text().trim()).to.equal('Item 1');
+      expect($($('a.action', el)[0]).find('span').length).to.equal(0);
+    });
+
+    it('custom action menu items as buttons only /w icons', function() {
+      var model = new Result({});
+      var menu = new ActionMenuView({
+        app: this.app,
+        model: model,
+        menuOptions: {
+          'item1': {
+            'url': '#',
+            'title': 'Item 1',
+            'category': 'button',
+            'iconCSS': 'supericon'
+          },
+          'item2': {
+            'url': '#',
+            'title': 'Item 2',
+            'category': 'button',
+            'iconCSS': 'supericon'
+          },
+        },
+      });
+
+      var el = menu.render().el;
+      expect($('ul.dropdown-menu', el).length).to.equal(0);
+      expect($('a.action', el).length).to.equal(2);
+      expect($($('a.action', el)[0]).text().trim()).to.equal('');
+      expect($($('a.action', el)[0]).find('span').length).to.equal(1);
+    });
+
+    it('custom action menu items as buttons and dropdown mixed', function() {
+      var model = new Result({});
+      var menu = new ActionMenuView({
+        app: this.app,
+        model: model,
+        menuOptions: {
+          'item1': {
+            'url': '#',
+            'title': 'Item 1',
+            'category': 'button',
+          },
+          'item2': {
+            'url': '#',
+            'title': 'Item 2',
+            'category': 'dropdown',
+          },
+        },
+      });
+
+      var el = menu.render().el;
+      expect($('ul.dropdown-menu a.action', el).length).to.equal(1);
+      expect($('a.action', el).length).to.equal(2);
     });
 
   });

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -6,10 +6,10 @@ define([
   'mockup-patterns-structure-url/js/views/actionmenu',
   'mockup-patterns-structure-url/js/views/app',
   'mockup-patterns-structure-url/js/models/result',
+  'mockup-patterns-structure-url/js/views/tablerow',
   'mockup-utils',
   'sinon',
-], function(expect, $, registry, Structure, ActionMenuView, AppView, Result,
-            utils, sinon) {
+], function(expect, $, registry, Structure, ActionMenuView, AppView, Result, TableRowView, utils, sinon) {
   'use strict';
 
   window.mocha.setup('bdd');
@@ -132,8 +132,12 @@ define([
         'availableColumns': [],
         'indexOptionsUrl': '',
         'setDefaultPageUrl': '',
-        'collectionConstructor':
-          'mockup-patterns-structure-url/js/collections/result',
+        'collectionConstructor': 'mockup-patterns-structure-url/js/collections/result',
+        'typeToViewAction': {
+          'File': '/view',
+          'Image': '/view',
+          'Blob': '/view'
+        },
       });
       this.app.render();
     });
@@ -358,6 +362,67 @@ define([
       $('a.barbaz', el).click();
       this.clock.tick(500);
       expect(this.app.$('.status').text().trim()).to.equal('Status: barbaz clicked');
+    });
+
+    it('use special view action for special types', function() {
+      // Test if special view actions for types are used in action .openItem
+      // and title link.
+
+      var items = [
+        {
+          model: {
+            'Title': "Dummy Image",
+            'is_folderish': false,
+            'portal_type': "Image",
+            'getURL': 'http://nohost/dummy_image'
+          },
+          expect: '/view'
+        }, {
+          model: {
+            Title: "Dummy File",
+            is_folderish: false,
+            portal_type: "File",
+            getURL: 'http://nohost/dummy_file'
+          },
+          expect: '/view'
+        }, {
+          model: {
+            Title: "Dummy Blob",
+            is_folderish: false,
+            portal_type: "Blob",
+            getURL: 'http://nohost/dummy_blob'
+          },
+          expect: '/view'
+        }, {
+          model: {
+            Title: "Dummy Document",
+            is_folderish: false,
+            portal_type: "Document",
+            getURL: 'http://nohost/dummy_document'
+          },
+          expect: ''
+        },
+      ];
+
+      for (var i = 0, len = items.length; i < len; i = i + 1) {
+        var item = items[i];
+        var model = new Result(item.model);
+        var menu = new ActionMenuView({
+          app: this.app,
+          model: model,
+          header: 'Menu Header'
+        });
+        var el = menu.render().el;
+        expect($('a.openItem', el).attr('href')).to.equal(item.model.getURL + item.expect);
+
+        var row = new TableRowView({
+          model: model,
+          app: this.app
+        });
+        el = row.render().el;
+        expect($('.title a', el).attr('href')).to.equal(item.model.getURL + item.expect);
+      }
+
     });
 
   });

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -1175,6 +1175,7 @@ define([
     });
 
     it('test navigate to folder pop states', function() {
+      this.timeout(15000);  // need more than standard 2000ms here... :(
       registry.scan(this.$el);
       this.clock.tick(1000);
       // Need to inject this to the mocked window location attribute the

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -82,7 +82,7 @@ define([
         'availableColumns': [],
         'indexOptionsUrl': '',
         'setDefaultPageUrl': '',
-        'url': 'http://localhost:8081/vocab',
+        'url': 'http://localhost:9876/vocab',
         'collectionConstructor':
           'mockup-patterns-structure-url/js/collections/result'
       });
@@ -639,7 +639,7 @@ define([
         "contextInfoUrl": "{path}/contextInfo",
         "setDefaultPageUrl": "/setDefaultPage",
         "urlStructure": {
-          "base": "http://localhost:8081",
+          "base": "http://localhost:9876",
           "appended": "/folder_contents"
         }
       };
@@ -672,7 +672,7 @@ define([
         var items = [];
         items.push({
           UID: '123sdfasdf' + path + 'Folder',
-          getURL: 'http://localhost:8081' + path + '/folder',
+          getURL: 'http://localhost:9876' + path + '/folder',
           path: path + '/folder',
           portal_type: 'Folder',
           Description: 'folder',
@@ -685,7 +685,7 @@ define([
         for (var i = start; i < end; i = i + 1) {
           items.push({
             UID: '123sdfasdf' + path + i,
-            getURL: 'http://localhost:8081' + path + '/item' + i,
+            getURL: 'http://localhost:9876' + path + '/item' + i,
             path: path + '/item' + i,
             portal_type: 'Document ' + i,
             Description: 'document',
@@ -744,7 +744,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -766,6 +766,7 @@ define([
 
       this.sandbox = sinon.sandbox.create();
       this.sandbox.stub(window, 'history', history);
+      this.sandbox.stub(window.history, 'pushState', history.pushState);
     });
 
     afterEach(function() {
@@ -803,7 +804,7 @@ define([
     it('test selection well label', function() {
       extraDataJsonItem = {
         UID: 'XSS" data-xss="bobby',
-        getURL: 'http://localhost:8081/xss',
+        getURL: 'http://localhost:9876/xss',
         path: '/xss',
         portal_type: 'Folder',
         Description: 'XSS test item',
@@ -977,11 +978,11 @@ define([
       expect($content_row.find('td').eq(2).text().trim()).to.equal('');
       expect($content_row.find('td').eq(3).text().trim()).to.equal('');
       expect($content_row.find('td').eq(4).text().trim()).to.equal('published');
-      expect($content_row.find('a.openItem').attr('href')).to.equal('http://localhost:8081/folder');
+      expect($content_row.find('a.openItem').attr('href')).to.equal('http://localhost:9876/folder');
 
       var $content_row1 = this.$el.find('table tbody tr').eq(1);
       expect($content_row1.find('td').eq(1).text().trim()).to.equal('Document 0');
-      expect($content_row1.find('a.openItem').attr('href')).to.equal('http://localhost:8081/item0');
+      expect($content_row1.find('a.openItem').attr('href')).to.equal('http://localhost:9876/item0');
     });
 
     it('test select all contained item action', function() {
@@ -1150,9 +1151,9 @@ define([
       var pattern = this.$el.data('patternStructure');
       var item = this.$el.find('.itemRow').eq(10);
       expect(item.data().id).to.equal('item9');
-      expect($('.title a.manage', item).attr('href')).to.equal('http://localhost:8081/item9');
-      expect($('.actionmenu a.openItem', item).attr('href')).to.equal('http://localhost:8081/item9');
-      expect($('.actionmenu a.editItem', item).attr('href')).to.equal('http://localhost:8081/item9/@@edit');
+      expect($('.title a.manage', item).attr('href')).to.equal('http://localhost:9876/item9');
+      expect($('.actionmenu a.openItem', item).attr('href')).to.equal('http://localhost:9876/item9');
+      expect($('.actionmenu a.editItem', item).attr('href')).to.equal('http://localhost:9876/item9/@@edit');
     });
 
     it('test navigate to folder push states', function() {
@@ -1164,13 +1165,13 @@ define([
       $('.title a.manage', item).trigger('click');
       this.clock.tick(1000);
       expect(history.pushed.url).to.equal(
-        'http://localhost:8081/folder/folder_contents');
+        'http://localhost:9876/folder/folder_contents');
       expect(structureUrlChangedPath).to.eql('/folder');
 
       $('.fc-breadcrumbs a', this.$el).eq(0).trigger('click');
       this.clock.tick(1000);
       expect(history.pushed.url).to.equal(
-        'http://localhost:8081/folder_contents');
+        'http://localhost:9876/folder_contents');
       expect(structureUrlChangedPath).to.eql('');
     });
 
@@ -1181,7 +1182,7 @@ define([
       // Need to inject this to the mocked window location attribute the
       // code will check against.  This url is set before the trigger.
       dummyWindow.location = {
-          'href': 'http://localhost:8081/folder/folder/folder_contents'};
+          'href': 'http://localhost:9876/folder/folder/folder_contents'};
       // then trigger off the real window.
       $(window).trigger('popstate');
       this.clock.tick(1000);
@@ -1239,7 +1240,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -1424,7 +1425,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -1507,13 +1508,13 @@ define([
         var items = [];
         items.push({
           /*
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           id: 'folder'
           */
           // 'portal_type', 'review_state', 'getURL'
 
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           // Other required fields.
           id: 'folder',
@@ -1522,11 +1523,11 @@ define([
         for (var i = start; i < end; i = i + 1) {
           items.push({
             /*
-            getURL: 'http://localhost:8081/item' + i,
+            getURL: 'http://localhost:9876/item' + i,
             Title: 'Document ' + i,
             */
 
-            getURL: 'http://localhost:8081/item' + i,
+            getURL: 'http://localhost:9876/item' + i,
             Title: 'Document ' + i,
             // Other required fields.
             id: 'item' + i,
@@ -1546,7 +1547,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -1634,14 +1635,14 @@ define([
         }
         var items = [];
         items.push({
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           id: 'folder',
           UID: 'folder',
         });
         for (var i = start; i < end; i = i + 1) {
           items.push({
-            getURL: 'http://localhost:8081/item' + i,
+            getURL: 'http://localhost:9876/item' + i,
             Title: 'Document ' + i,
             id: 'item' + 1,
             UID: 'item' + 1,
@@ -1660,7 +1661,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -1759,13 +1760,13 @@ define([
           end = start + batch.size;
         }
         var items = [{
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           'is_folderish': true,
           path: '/folder',
           id: 'folder'
         }, {
-          getURL: 'http://localhost:8081/item',
+          getURL: 'http://localhost:9876/item',
           Title: 'Item',
           'is_folderish': false,
           path: '/item',
@@ -1784,7 +1785,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -1922,10 +1923,10 @@ define([
           'Title', 'getURL'
         ],
         "urlStructure": {
-          "base": "http://localhost:8081/traverse_view",
+          "base": "http://localhost:9876/traverse_view",
           "appended": ""
         },
-        "pushStateUrl": "http://localhost:8081/traverse_view{path}",
+        "pushStateUrl": "http://localhost:9876/traverse_view{path}",
         "traverseView": true
       };
 
@@ -1947,13 +1948,13 @@ define([
           end = start + batch.size;
         }
         var items = [{
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           'is_folderish': true,
           path: '/folder',
           id: 'folder'
         }, {
-          getURL: 'http://localhost:8081/item',
+          getURL: 'http://localhost:9876/item',
           Title: 'Item',
           'is_folderish': false,
           path: '/item',
@@ -1972,7 +1973,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -1989,6 +1990,7 @@ define([
       this.clock = sinon.useFakeTimers();
       this.sandbox = sinon.sandbox.create();
       this.sandbox.stub(window, 'history', history);
+      this.sandbox.stub(window.history, 'pushState', history.pushState);
 
       sinon.stub(utils, 'getWindow', function() {
         return dummyWindow;
@@ -2017,13 +2019,13 @@ define([
       $('.title a.manage', item).trigger('click');
       this.clock.tick(1000);
       expect(history.pushed.url).to.equal(
-        'http://localhost:8081/traverse_view/folder');
+        'http://localhost:9876/traverse_view/folder');
       expect(structureUrlChangedPath).to.eql('');
 
       $('.fc-breadcrumbs a', this.$el).eq(0).trigger('click');
       this.clock.tick(1000);
       expect(history.pushed.url).to.equal(
-        'http://localhost:8081/traverse_view');
+        'http://localhost:9876/traverse_view');
     });
 
     it('test navigate to folder pop states - urlStructure', function() {
@@ -2035,7 +2037,7 @@ define([
       // Need to inject this to the mocked window location attribute the
       // code will check against.  This url is set before the trigger.
       dummyWindow.location = {
-          'href': 'http://localhost:8081/traverse_view/folder/folder'};
+          'href': 'http://localhost:9876/traverse_view/folder/folder'};
       // then trigger off the real window.
       $(window).trigger('popstate');
       this.clock.tick(1000);
@@ -2054,13 +2056,13 @@ define([
       $('.title a.manage', item).trigger('click');
       this.clock.tick(1000);
       expect(history.pushed.url).to.equal(
-        'http://localhost:8081/traverse_view/folder');
+        'http://localhost:9876/traverse_view/folder');
       expect(structureUrlChangedPath).to.eql('');
 
       $('.fc-breadcrumbs a', this.$el).eq(0).trigger('click');
       this.clock.tick(1000);
       expect(history.pushed.url).to.equal(
-        'http://localhost:8081/traverse_view');
+        'http://localhost:9876/traverse_view');
     });
 
     it('test navigate to folder pop states - pushStateUrl', function() {
@@ -2072,7 +2074,7 @@ define([
       // Need to inject this to the mocked window location attribute the
       // code will check against.  This url is set before the trigger.
       dummyWindow.location = {
-          'href': 'http://localhost:8081/traverse_view/folder/folder'};
+          'href': 'http://localhost:9876/traverse_view/folder/folder'};
       // then trigger off the real window.
       $(window).trigger('popstate');
       this.clock.tick(1000);
@@ -2131,13 +2133,13 @@ define([
           end = start + batch.size;
         }
         var items = [{
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           'is_folderish': true,
           path: '/folder',
           id: 'folder'
         }, {
-          getURL: 'http://localhost:8081/item',
+          getURL: 'http://localhost:9876/item',
           Title: 'Item',
           'is_folderish': false,
           path: '/item',
@@ -2156,7 +2158,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -2331,7 +2333,7 @@ define([
         var items = [];
         items.push({
           UID: '123sdfasdfFolder',
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           path: '/folder',
           portal_type: 'Folder',
           Description: 'folder',
@@ -2344,7 +2346,7 @@ define([
         for (var i = start; i < end; i = i + 1) {
           items.push({
             UID: '123sdfasdf' + i,
-            getURL: 'http://localhost:8081/item' + i,
+            getURL: 'http://localhost:9876/item' + i,
             path: '/item' + i,
             portal_type: 'Document ' + i,
             Description: 'document',
@@ -2376,7 +2378,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',
@@ -2416,13 +2418,13 @@ define([
       expect($content_row.find('td').eq(3).text().trim()).to.equal('');
       expect($content_row.find('td').eq(4).text().trim()).to.equal('published');
       expect($content_row.find('.actionmenu a.openItem').attr('href')
-        ).to.equal('http://localhost:8081/folder');
+        ).to.equal('http://localhost:9876/folder');
 
       var $content_row1 = this.$el.find('table tbody tr').eq(1);
       expect($content_row1.find('td').eq(1).text().trim()).to.equal(
         'Document 0');
       expect($content_row1.find('.actionmenu a.openItem').attr('href')
-        ).to.equal('http://localhost:8081/item0');
+        ).to.equal('http://localhost:9876/item0');
     });
 
   });
@@ -2444,7 +2446,7 @@ define([
         "contextInfoUrl": "{path}/contextInfo",
         "setDefaultPageUrl": "/setDefaultPage",
         "urlStructure": {
-          "base": "http://localhost:8081",
+          "base": "http://localhost:9876",
           "appended": "/folder_contents"
         }
       };
@@ -2464,14 +2466,14 @@ define([
           end = start + batch.size;
         }
         var items = [{
-          getURL: 'http://localhost:8081/folder',
+          getURL: 'http://localhost:9876/folder',
           Title: 'Folder',
           'is_folderish': true,
           path: '/folder',
           UID: 'folder',
           id: 'folder'
         }, {
-          getURL: 'http://localhost:8081/item',
+          getURL: 'http://localhost:9876/item',
           Title: 'Item',
           'is_folderish': false,
           path: '/item',
@@ -2491,7 +2493,7 @@ define([
         if (xhr.url.indexOf('folder') !== -1){
           data.object = {
             UID: '123sdfasdfFolder',
-            getURL: 'http://localhost:8081/folder',
+            getURL: 'http://localhost:9876/folder',
             path: '/folder',
             portal_type: 'Folder',
             Description: 'folder',

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -526,6 +526,50 @@ define([
       expect($('a.action', el).length).to.equal(2);
     });
 
+    it('should display an icon for contents with images', function() {
+
+      this.app.iconSize = 'largest_possible';
+
+      var model = new Result({
+          'Title': "Dummy Document",
+          'is_folderish': false,
+          'portal_type': "Document",
+          'getURL': 'http://nohost/dummy_image',
+          'getIcon': true
+      });
+
+      var row = new TableRowView({
+        model: model,
+        app: this.app
+      });
+      var el = row.render().el;
+
+      expect($('.title img', el).length).to.equal(1);
+      expect($('.title img', el).attr('class')).to.have.string('image-largest_possible');
+    });
+
+    it('should display no icon for contents without images', function() {
+
+      this.app.iconSize = 'largest_possible';
+
+      var model = new Result({
+          'Title': "Dummy Document",
+          'is_folderish': false,
+          'portal_type': "Document",
+          'getURL': 'http://nohost/dummy_image',
+          'getIcon': false
+      });
+
+      var row = new TableRowView({
+        model: model,
+        app: this.app
+      });
+      var el = row.render().el;
+
+      expect($('.title img', el).length).to.equal(0);
+      expect($('.title .icon-group-right', el).length).to.have.equal(0);
+    });
+
   });
 
 

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -958,13 +958,9 @@ define([
       var pattern = this.$el.data('patternStructure');
       var item = this.$el.find('.itemRow').eq(10);
       expect(item.data().id).to.equal('item9');
-      $('.title a.manage', item).trigger('click');
-      this.clock.tick(1000);
-      expect(dummyWindow.location).to.equal('http://localhost:8081/item9');
-
-      $('.actionmenu a.editItem', item).trigger('click');
-      this.clock.tick(1000);
-      expect(dummyWindow.location).to.equal('http://localhost:8081/item9/@@edit');
+      expect($('.title a.manage', item).attr('href')).to.equal('http://localhost:8081/item9');
+      expect($('.actionmenu a.openItem', item).attr('href')).to.equal('http://localhost:8081/item9');
+      expect($('.actionmenu a.editItem', item).attr('href')).to.equal('http://localhost:8081/item9/@@edit');
     });
 
     it('test navigate to folder push states', function() {

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -1007,35 +1007,6 @@ define([
         ).to.equal(0);
     });
 
-    it('test current folder buttons do not show on root', function() {
-      registry.scan(this.$el);
-      this.clock.tick(1000);
-      expect(this.$el.find('.context-buttons').length).to.equal(0);
-    });
-
-    it('test current folder buttons do show on subfolder', function() {
-      registry.scan(this.$el);
-      this.clock.tick(1000);
-      var $item = this.$el.find('.itemRow').eq(0);
-      $('.title a', $item).trigger('click');
-      this.clock.tick(1000);
-      expect(this.$el.find('.context-buttons').length).to.equal(1);
-    });
-
-    it('test select current folder', function() {
-      registry.scan(this.$el);
-      var pattern = this.$el.data('patternStructure');
-      this.clock.tick(1000);
-      var $item = this.$el.find('.itemRow').eq(0);
-      $('.title a', $item).trigger('click');
-      this.clock.tick(1000);
-      var $checkbox = $('.fc-breadcrumbs-container input[type="checkbox"]', this.$el);
-      $checkbox[0].checked = true;
-      $checkbox.trigger('change');
-      this.clock.tick(1000);
-      expect(this.$el.find('#btn-selected-items').html()).to.contain('1');
-    });
-
     it('test displayed content', function() {
       registry.scan(this.$el);
       this.clock.tick(500);
@@ -1051,29 +1022,6 @@ define([
       var $content_row1 = this.$el.find('table tbody tr').eq(1);
       expect($content_row1.find('td').eq(1).text().trim()).to.equal('Document 0');
       expect($content_row1.find('a.openItem').attr('href')).to.equal('http://localhost:9876/item0');
-    });
-
-    it('test select all contained item action', function() {
-      registry.scan(this.$el);
-      this.clock.tick(1000);
-
-      // Since the top level view doesn't currently provide 'Actions
-      // on current folder' action menu, go down one level.
-      var $item = this.$el.find('.itemRow').eq(0);
-      $('.title a', $item).trigger('click');
-      this.clock.tick(1000);
-
-      var menu = $('.fc-breadcrumbs-container .actionmenu', this.$el);
-      var options = $('a.action', menu);
-      expect(options.length).to.equal(5);
-
-      var selectAll = $('a.selectAll', menu);
-      expect(selectAll.text().trim()).to.eql('Select all contained items');
-      selectAll.trigger('click');
-      this.clock.tick(1000);
-      expect($('table tbody .selection input:checked', this.$el).length
-        ).to.equal(16);
-      expect(this.$el.find('#btn-selected-items').html()).to.contain('101');
     });
 
     it('test select displayed columns', function() {
@@ -1927,16 +1875,6 @@ define([
       this.clock.tick(1000);
       // status will be set as defined.
       expect($('.status').text()).to.contain('Status: option2 selected');
-    });
-
-    it('folder link not overriden', function() {
-      registry.scan(this.$el);
-      this.clock.tick(1000);
-      var item = this.$el.find('.itemRow').eq(0);
-      $('.title a.manage', item).trigger('click');
-      this.clock.tick(1000);
-      // default action will eventually trigger this.
-      expect(this.$el.find('.context-buttons').length).to.equal(1);
     });
 
     it('item link triggered', function() {

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -145,6 +145,8 @@ define([
     afterEach(function() {
       this.clock.restore();
       this.server.restore();
+      $('body').removeAttr('class');
+      $('body').html('');
       requirejs.undef('dummytestactions');
       requirejs.undef('dummytestactionmenu');
     });
@@ -568,6 +570,51 @@ define([
 
       expect($('.title img', el).length).to.equal(0);
       expect($('.title .icon-group-right', el).length).to.have.equal(0);
+    });
+
+    // MODAL ACTIONS
+
+    it('modal button true opens in modal', function() {
+      var model = new Result({});
+      var menu = new ActionMenuView({
+        app: this.app,
+        model: model,
+        menuOptions: {
+          'button': {
+            'title': 'Modal',
+            'category': 'button',
+            'modal': true
+          }
+        }
+      });
+
+      var $el = $(menu.render().el).appendTo('body');
+      var $body = $('body');
+      expect($('.plone-modal-wrapper', $body).size()).to.equal(0);
+      $('a.button', $el).trigger('click');
+      expect($('.plone-modal-wrapper', $body).size()).to.equal(1);
+    });
+
+    it('modal dropdown true opens in modal', function() {
+
+      var model = new Result({});
+      var menu = new ActionMenuView({
+        app: this.app,
+        model: model,
+        menuOptions: {
+          'button': {
+            'title': 'Modal',
+            'category': 'dropdown',
+            'modal': true
+          }
+        }
+      });
+
+      var $el = $(menu.render().el).appendTo('body');
+      var $body = $('body');
+      expect($('.plone-modal-wrapper', $body).size()).to.equal(0);
+      $('a.button', $el).trigger('click');
+      expect($('.plone-modal-wrapper', $body).size()).to.equal(1);
     });
 
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockup",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A collection of client side patterns for faster and easier web development",
   "homepage": "http://plone.github.io/mockup",
   "devDependencies": {


### PR DESCRIPTION
Here is a pull request with changes to structure pattern for some more config options (action menu, icon size), code cleanup, better view url support:

- Allow definition of action menu items not only as dropdowns but also as buttons.
- Add ``openItem`` and ``editItem`` actions as buttons and remove the open icon from the title column.
- Open ``openItem`` links according to ``typeToViewAction`` instead of default with the ``/view`` postfix.
- Open ``editItem`` under ``/@@edit`` instead ``/edit``.
- Remove JS event handlers for externally opening simple URLs and use the href attribute instead.
- Add ``iconCSS`` option for action menus items to add icons.
- Add ``modal`` option for action menus items to allow links open in a modal.
- Add ``iconSize`` option to set the icon size if a item has an image.
- Use icons for all actionmenu entries.
- Use the tooltip pattern for all actionmenu buttons.
- Use pat-moment also for ``start``, ``end`` and ``last_comment_date`` columns.
- For columns with date fields, show an empty column if the date value is 'None'.
- Remove the checkbox and the actionmenu from the breadcrumbs bar for the current active folder to simplify the structure pattern.
  The actionmenu contained redundant actions (cut, copy, paste) and selecting the current folder is possible one level up.

The ``typeToViewAction`` configuration option uses sane defaults - the same as in a standard Plone installation. ``File``, ``Image`` and ``Blob`` are all mapped to ``/view``. ``plone.app.z3cform`` et al has to be changed to spit out these config options according to the ``plone.types_use_view_action_in_listings`` registry entries.

``typeToViewAction`` is an object in the form ``{'TYPE': 'VIEW_URL'}``, e.g. ``{'File': '/view'}``. Currently Plone uses only ``/view``. I thought making the view url configurable for each type makes the whole structure pattern a bit more generic. Maybe that's nonsense, comments welcome like for everything else.

Here are two screenshots showing the difference between old and new default action items.
Old:
![folder_contents_old](https://cloud.githubusercontent.com/assets/170891/13986005/479914a0-f100-11e5-8eaa-389013b3ebdd.png)

New:
![folder_contents_new](https://cloud.githubusercontent.com/assets/170891/13986013/4dba952a-f100-11e5-9600-a5f15ac84d01.png)
