### PR TITLE
Moment Updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Incompatibilities:
 
 New:
 
+- Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
+  This resolves a moment deprecation warning in structure examples.
+  [thet]
+
 - set XML syntax coloring for .pt files in text editor
   [ebrehault]
 

--- a/mockup/tests/fakeserver.js
+++ b/mockup/tests/fakeserver.js
@@ -240,11 +240,11 @@ define([
     var addSomeData = function(list) {
       /* add getURL value, review_state, modification, creation */
       var dates = [
-        'January 1, 2011',
-        'February 10, 2012',
-        'March 12, 2013',
-        'April 1, 2012',
-        'May 20, 2013'
+        '2011-01-01T10:10:10+02:00',
+        '2012-02-10T10:10:10+02:00',
+        '2013-03-12T10:10:10+02:00',
+        '2012-04-01T10:10:10+02:00',
+        '2013-03-20T10:10:10+02:00',
       ];
       for (var i = 0; i < list.length; i = i + 1) {
         var data = list[i];


### PR DESCRIPTION
~~- Update the moment library to ``2.12.0``.~~
- Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
  This resolves a moment deprecation warning in structure examples.