### PR TITLE
Moment: Don't parse invalid dates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,16 +10,15 @@ New:
 
 Fixes:
 
+- Moment pattern: Don't try to parse obvious invalid dates ("None", "").
+  Avoids Moment.js deprecation warnings.
+  [thet]
 
 
 2.2.0 (2016-03-31)
 ------------------
 
 New:
-
-- Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
-  This resolves a moment deprecation warning in structure examples.
-  [thet]
 
 - set XML syntax coloring for .pt files in text editor
   [ebrehault]
@@ -51,6 +50,10 @@ New:
   [metatoaster]
 
 Fixes:
+
+- Fix fakeserver ``relateditems-test.json`` response to return ISO dates for ``CreationDate``, ``ModificationDate`` and ``EffectiveDate``, as they really do in Plone.
+  This resolves a moment deprecation warning in structure examples.
+  [thet]
 
 - JSHint fixes and jscs formatings for structure pattern.
   [thet]

--- a/mockup/patterns/moment/pattern.js
+++ b/mockup/patterns/moment/pattern.js
@@ -106,6 +106,9 @@ define([
       if (!date) {
         date = $.trim($el.html());
       }
+      if (!date || date === 'None') {
+        return;
+      }
       moment.locale([(new i18n()).currentLanguage, 'en']);
       date = moment(date);
       if (!date.isValid()) {

--- a/mockup/tests/pattern-moment-test.js
+++ b/mockup/tests/pattern-moment-test.js
@@ -43,6 +43,11 @@ define([
       registry.scan($el);
       expect($el.find('div').html()).to.equal('');
     });
+    it('test parse "None" date', function() {
+      var $el = $('<div class="pat-moment" data-pat-moment="format:calendar"><div>None</div></div>');
+      registry.scan($el);
+      expect($el.find('div').html()).to.equal('None');
+    });
     it('test setTitle true', function() {
       var $el = $('<div class="pat-moment" data-pat-moment="format:relative;setTitle:true">2012-10-02 14:30</div>');
       registry.scan($el);


### PR DESCRIPTION
Moment pattern: Don't try to parse obvious invalid dates ("None", "").
Avoids Moment.js deprecation warnings.