### PR TITLE
Re-add missing pattern dependencies in TinyMCE.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ New:
 
 Fixes:
 
+- Re-add missing ``mockup-patterns-autotoc`` and ``mockup-patterns-modal`` dependencies to TinyMCE link modal.
+  [thet]
+
 - Fix tests and mocks on real browsers for structure pattern test, which threw CSRF errors.
   [metatoaster]
 

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -4,11 +4,13 @@ define([
   'pat-registry',
   'pat-base',
   'tinymce',
-  'mockup-patterns-relateditems',
   'text!mockup-patterns-tinymce-url/templates/link.xml',
   'text!mockup-patterns-tinymce-url/templates/image.xml',
+  'mockup-patterns-relateditems',
+  'mockup-patterns-autotoc',
+  'mockup-patterns-modal',
   'mockup-patterns-upload'
-], function($, _, registry, Base, tinymce, RelatedItems, LinkTemplate, ImageTemplate) {
+], function($, _, registry, Base, tinymce, LinkTemplate, ImageTemplate, RelatedItems) {
   'use strict';
 
   var LinkType = Base.extend({


### PR DESCRIPTION
mockup-patterns-autotoc was missing.