### PR TITLE
Structure pattern: Alert design

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ New:
   - For columns with date fields, show an empty column if the date value is 'None'.
   - Remove the checkbox and the actionmenu from the breadcrumbs bar for the current active folder to simplify the structure pattern.
     The actionmenu contained redundant actions (cut, copy, paste) and selecting the current folder is possible one level up.
+  - Don't show empty alerts with ``alert-warning`` CSS class.
+    Show them transparent but in the same height as if they were not empty.
+    Align HTML structue with bootstrap ones and use ``<strong>`` for alert labels.
 
   [thet]
 

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -32,7 +32,7 @@ define([
   var AppView = BaseView.extend({
     tagName: 'div',
     status: {
-      type: 'warning',
+      type: 'none',
       text: '',
       label: ''
     },
@@ -455,7 +455,7 @@ define([
         // clear it
         this.status.text = '';
         this.status.label = '';
-        this.status.type = 'warning';
+        this.status.type = 'none';
       } else if (typeof(msg) === 'string') {
         this.status.text = msg;
         this.status.label = '';
@@ -471,7 +471,7 @@ define([
       $status[0].className = 'alert alert-' + this.status.type + ' status';
       var $text = $('<span></span>');
       $text.text(this.status.text);
-      var $label = $('<b></b>');
+      var $label = $('<strong></strong>');
       $label.text(this.status.label);
       $status.empty().append($label).append($text);
     },

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -1,6 +1,6 @@
 <div class="alert alert-<%- status.type %> status">
-  <b><%- status.label %></b>
-  <%- status.text %>
+  <strong><%- status.label %></strong>
+  <span><%- status.text %></span>&nbsp;<% // &nbsp; to get correct height for empty alerts %>
 </div>
 
 <table class="table table-striped table-bordered">


### PR DESCRIPTION
Don't show empty alerts with ``alert-warning`` CSS class.
Show them transparent but in the same height as if they were not empty.
Align HTML structue with bootstrap ones and use ``<strong>`` for alert labels.nd an empty message aborts the commit.