### PR TITLE
Fixing problems with wrong relative date translations for norwegian sites

### DIFF
--- a/mockup/patterns/moment/pattern.js
+++ b/mockup/patterns/moment/pattern.js
@@ -109,7 +109,12 @@ define([
       if (!date || date === 'None') {
         return;
       }
-      moment.locale([(new i18n()).currentLanguage, 'en']);
+      MOMENT_i18n_MAP = {'no', 'nb'};
+      currentLanguage = (new i18n()).currentLanguage;
+      if (currentLanguage in MOMENT_i18n_MAP){
+        currentLanguage = MOMENT_i18n_MAP[currentLanguage];
+      }
+      moment.locale([currentLanguage, 'en']);
       date = moment(date);
       if (!date.isValid()) {
         return;

--- a/mockup/patterns/moment/pattern.js
+++ b/mockup/patterns/moment/pattern.js
@@ -109,7 +109,7 @@ define([
       if (!date || date === 'None') {
         return;
       }
-      MOMENT_i18n_MAP = {'no', 'nb'};
+      MOMENT_i18n_MAP = {'no': 'nb'};
       currentLanguage = (new i18n()).currentLanguage;
       if (currentLanguage in MOMENT_i18n_MAP){
         currentLanguage = MOMENT_i18n_MAP[currentLanguage];


### PR DESCRIPTION
moment.js has a different language code for Norway then Plone uses. Pat uses nb, but Plone uses no for most Norwegian translations. This causes a problem with the relative dates showing as Asian characters. This is a possible solution, but my knowledge of mockup development is limited, so I have not been able to test this. 

This pull request is mostly for discussion and not meant to be merged as is.
