### PR TITLE
update bower dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Incompatibilities:
 
 New:
 
+- Update safe bower.json dependencies except backbone which tests would fail.
+  [thet]
+
 - Update package.json dependencies, except less which has incompatible changes since 2.0 (less.parse).
   [thet]
 

--- a/bower.json
+++ b/bower.json
@@ -2,37 +2,37 @@
   "name": "mockup",
   "description": "A collection of client side patterns for faster and easier web development",
   "dependencies": {
-    "ace-builds": "1.1.9",
+    "ace-builds": "1.2.3",
     "backbone": "1.1.2",
     "backbone.paginator": "0.8.1",
-    "bootstrap": "3.3.4",
-    "console-polyfill": "0.1.2",
-    "dropzone": "4.0.1",
-    "es5-shim": "4.0.3",
-    "marked": "0.3.3",
-    "jqtree": "0.22.0",
-    "jquery": "1.11.3",
+    "bootstrap": "3.3.6",
+    "console-polyfill": "0.2.2",
+    "dropzone": "4.3.0",
+    "es5-shim": "4.5.8",
+    "marked": "0.3.5",
+    "jqtree": "1.3.3",
+    "jquery": "1.12.4",
     "jquery-form": "3.46.0",
     "jquery.cookie": "1.4.1",
     "jquery.recurrenceinput.js": "v1.5.2",
     "logging": "",
-    "moment": "2.10.3",
-    "patternslib": "2.0.11",
+    "moment": "2.10.6",
+    "patternslib": "2.0.13",
     "pickadate": "3.5.6",
     "react": "0.10.0",
-    "requirejs-text": "2.0.12",
+    "requirejs-text": "2.0.15",
     "selectivizr": "1.0.2",
-    "select2": "3.5.1",
-    "tinymce-builded": "4.3.4"
+    "select2": "3.5.4",
+    "tinymce-builded": "4.3.12"
   },
   "devDependencies": {
     "expect": "0.3.1",
-    "sinonjs": "1.14.1"
+    "sinonjs": "1.17.1"
   },
   "resolutions": {
-    "bootstrap": "3.3.4",
-    "jquery": "1.11.3",
-    "select2": "3.5.1",
-    "moment": "2.10.3"
+    "bootstrap": "3.3.6",
+    "jquery": "1.12.4",
+    "select2": "3.5.4",
+    "moment": "2.10.6"
   }
 }

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -36,6 +36,7 @@
       'expect': 'bower_components/expect/index',
       'jqtree': 'bower_components/jqtree/tree.jquery',
       'jquery': 'bower_components/jquery/dist/jquery',
+      'jquery.browser': 'bower_components/jquery.browser/dist/jquery.browser',
       'jquery.cookie': 'bower_components/jquery.cookie/jquery.cookie',
       'jquery.event.drag': 'lib/jquery.event.drag',
       'jquery.event.drop': 'lib/jquery.event.drop',

--- a/mockup/tests/pattern-pickadate-test.js
+++ b/mockup/tests/pattern-pickadate-test.js
@@ -394,7 +394,7 @@ define([
         var $results = $('li.select2-result-selectable');
         expect($results.size()).to.equal(0);
 
-        var $pattern = $('input.pattern-pickadate-timezone.select2-offscreen');
+        var $pattern = $('input.pattern-pickadate-timezone');
         $pattern.on('select2-open', function() {
           // timezone elements should be available
           $results = $('li.select2-result-selectable');
@@ -438,7 +438,7 @@ define([
 
         // check if data values are set to default
         expect($('.pattern-pickadate-timezone .select2-chosen').text()).to.equal('Europe/Vienna');
-        expect($('input.pattern-pickadate-timezone.select2-offscreen').attr('data-value')).to.equal('Europe/Vienna');
+        expect($('input.pattern-pickadate-timezone').attr('data-value')).to.equal('Europe/Vienna');
 
       });
 
@@ -455,7 +455,7 @@ define([
 
         // check if visible and data value are set to default
         expect($('.pattern-pickadate-timezone .select2-chosen').text()).to.equal('Enter timezone...');
-        expect($('input.pattern-pickadate-timezone.select2-offscreen').attr('data-value')).to.equal(undefined);
+        expect($('input.pattern-pickadate-timezone').attr('data-value')).to.equal(undefined);
 
       });
 
@@ -473,7 +473,7 @@ define([
 
         // check if data values are set to default
         expect($('.select2-chosen', $time).text()).to.equal('Europe/Berlin');
-        expect($('input.pattern-pickadate-timezone.select2-offscreen').attr('data-value')).to.equal('Europe/Berlin');
+        expect($('input.pattern-pickadate-timezone').attr('data-value')).to.equal('Europe/Berlin');
 
         expect($('.pattern-pickadate-timezone').data('select2')._enabled).to.equal(false);
         expect($('.select2-container-disabled').size()).to.equal(1);

--- a/mockup/tests/pattern-select2-test.js
+++ b/mockup/tests/pattern-select2-test.js
@@ -259,7 +259,7 @@ define([
       registry.scan($el);
       expect($('#test-select2', $el).is('input')).to.equal(true);
       expect($('#test-select2', $el).attr('type')).to.equal('hidden');
-      expect($('#test-select2', $el).attr('class')).to.equal('pat-select2 select2-offscreen');
+      expect($('#test-select2', $el).attr('class')).to.equal('pat-select2');
       expect($('#test-select2', $el).attr('name')).to.equal('test-name');
       expect($('#test-select2', $el).val()).to.equal('1;3');
       var $results = $('li.select2-search-choice', $el);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "karma-spec-reporter": "0.0.26",
     "lcov-result-merger": "~1.2.0",
     "less": "~1.7.0",
-    "mocha": "~2.4.5",
+    "mocha": "~2.5.3",
     "phantomjs-prebuilt": "^2.1.7",
     "requirejs": "~2.2.0"
   },


### PR DESCRIPTION
Update safe bower.json dependencies except backbone which tests would fail.

Reason was to update tinymce....