### PR TITLE
Include Upload pattern progress bar styles for use by widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,12 @@ New:
 
 Fixes:
 
+- Upload pattern LESS: included omitted styles for progress bar
+  in upload patttern by importing seletected styles from Bootstrap LESS.
+  Fixes incorrect/omitted display of progress bar in plone.app.widgets 1.x.
+  Built widgets.min.css is only 64 bytes larger, when gzipped.
+  [seanupton]
+
 - Updated the documentation in LEARN.md
   [janga1997]
 

--- a/mockup/patterns/upload/less/pattern.upload.less
+++ b/mockup/patterns/upload/less/pattern.upload.less
@@ -1,4 +1,6 @@
 @import (less) "@{bowerPath}/dropzone/dist/dropzone.css";
+@import (reference) "@{bowerPath}/bootstrap/less/progress-bars.less";
+@import (reference) "@{bowerPath}/bootstrap/less/scaffolding.less";
 
 .upload-container {
     .upload-area {
@@ -47,10 +49,12 @@
     .align-right{ text-align: right }
     .controls { display: none }
     .actions { margin-top: 0.5em };
-    .progress {
-        height: 34px;
-        margin-bottom: 0;
-    }
+
+    .progress{ .progress() }
+    .progress-striped{ .progress-bar-striped() }
+    .progress-bar{ .progress-bar() }
+    .sr-only { .sr-only() }
+
     .dz-drag-hover{
         -webkit-box-shadow: inset 0 0 20px rgba(0,0,0,.75), 0 0 0 1000px rgba(255,255,255,.85);
         -moz-box-shadow: inset 0 0 20px  rgba(0,0,0,.75), 0 0 0 1000px rgba(255,255,255,.85);


### PR DESCRIPTION
Upload pattern previously omitted any styles for progress bar, which breaks upload display of progress bar in plone.app.widgets 1.x (e.g. in TinyMCE upload tab).  

This fixes that; it also fixes lack of the bootstrap scaffolding for the .sr-only selector.

LESS Imports are done by reference to keep resulting file size low.  This style fix is very low risk: while it adds about 1.2k to the built widgets.min.css, once gzipped, the difference is only 64 additional bytes served over a compressed connection.