### PR TITLE
Minor related items fixes: Plone 4 icon compat; result button style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Incompatibilities:
 
 New:
 
+- Related items pattern: result button style allow for more room
+  for scrollbar, and have subltle color change on hover to deliniate
+  user-expected behavior of browsing vs. selecting item.
+  [seanupton]
+
 - Fix urls in modals not opening in new window
   [vangheem]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,14 @@ New:
 
 Fixes:
 
+- Related Items pattern: content icon cross-compatibility with Plone
+  5.x and 4.x (via plone.app.widgets 1.x); in Plone 5 getIcon returned
+  from brain is a boolean, in Plone 4, it is a string -- use this to
+  show content icons in Plone 5 as previous, but also show image scale
+  in Plone 4, but only for images.  This is the most reasonable
+  solution to avoid requesting many broken image scales (404) in Plone 4.
+  [seanupton]
+
 - Upload pattern LESS: included omitted styles for progress bar
   in upload patttern by importing seletected styles from Bootstrap LESS.
   Fixes incorrect/omitted display of progress bar in plone.app.widgets 1.x.

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -112,7 +112,7 @@ define([
       resultTemplate: '' +
         '<div class="   pattern-relateditems-result  <% if (selected) { %>pattern-relateditems-active<% } %>">' +
         '  <a href="#" class=" pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %>">' +
-        '    <% if (typeof getIcon !== "undefined" && getIcon) { %><img src="<%- getURL %>/@@images/image/icon "> <% } %>' +
+        '    <% if (getIcon === true || portal_type === "Image") { %><img src="<%- getURL %>/@@images/image/icon "> <% } %>' +
         '    <span class="pattern-relateditems-result-title  <% if (typeof review_state !== "undefined") { %> state-<%- review_state %> <% } %>  " /span>' +
         '    <span class="pattern-relateditems contenttype-<%- portal_type.toLowerCase() %>"><%- Title %></span>' +
         '    <span class="pattern-relateditems-result-path"><%- path %></span>' +
@@ -126,7 +126,7 @@ define([
       resultTemplateSelector: null,
       selectionTemplate: '' +
         '<span class="pattern-relateditems-item">' +
-        ' <% if (typeof getIcon !== "undefined" && getIcon) { %> <img src="<%- getURL %>/@@images/image/icon"> <% } %>' +
+        ' <% if (getIcon === true || portal_type === "Image") { %> <img src="<%- getURL %>/@@images/image/icon"> <% } %>' +
         ' <span class="pattern-relateditems-item-title contenttype-<%- portal_type.toLowerCase() %> <% if (typeof review_state !== "undefined") { %> state-<%- review_state  %> <% } %>" ><%- Title %></span>' +
         ' <span class="pattern-relateditems-item-path"><%- path %></span>' +
         '</span>',

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -60,12 +60,16 @@
   right: 0;
   top: 50%;
   margin-top: -16px;
+  margin-right: 8px;
   a {
     display: block;
     height: 36px;
     line-height: 36px;
     .glyphicon();
     .glyphicon-chevron-right();
+  }
+  a:hover:before {
+    color:purple;
   }
 }
 


### PR DESCRIPTION
See changelog. 

Justification(s):

(1) Most reasonable way to get icon compatibility on Plone 4 without breaking forward-compatibility with content icons in Plone 5 is to leverage the fact that Plone 5 getIcon returns a boolean in the JSON.  We can use this, and only serve image scale for Image portal_type as fallback (for Plone 4, this won't be issue for Plone 5).

(2) Scrollbar covers result buttons on Mac firefox.  Margin improves this.  Also, having on-hover color change for button helps delineate the expected action for the user vs. selecting the item.

@thet -- I'm pretty sure these minor changes do not conflict with your PR?