### PR TITLE
Use fork of grunt-sed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Fixes:
 - Update outdated links in Learn.md  
   [staeff]
 
+- Use github fork of grunt-sed and remove unused task.
+  [gforcada]
 
 2.3.0 (2016-08-19)
 ------------------

--- a/mockup/js/grunt.js
+++ b/mockup/js/grunt.js
@@ -421,13 +421,6 @@
             ieCompat: true,
             paths: ['less']
           }
-        },
-        sed: {
-          'bootstrap': {
-            path: 'node_modules/lcov-result-merger/index.js',
-            pattern: 'throw new Error\\(\'Unknown Prefix ',
-            replacement: '//throw// new Error(\'Unknown Prefix '
-          }
         }
       }, this.gruntConfig));
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-karma": "~1.0.0",
-    "grunt-sed": "~0.1.1",
+    "grunt-sed": "collective/grunt-sed#e625902539f5c29f1246228270a0330c1097b1e4",
     "karma": "~0.13.22",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "~1.0.1",


### PR DESCRIPTION
So seems that grunt-sed is used in quite some places, so it can not be removed as my original idea was.

Fortunately there is a pull request to fix the dependency problems https://github.com/jharding/grunt-sed/pull/17 *and* npm allows to define versions as github URLs  (even so short that you don't need to say that they come from github).

Long story short: I forked the pull request's fork on collective (just to prevent that the fork removes the commits) so now jenkins and travis both run fine :-)