### PR TITLE
tooltip cleanup and fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,6 +88,10 @@ New:
 
 Fixes:
 
+- Make ``pat-tooltip`` useable by it's own by including the necessary less files and reuse that one in other patterns.
+  Allow configuration of ``placement`` parameter.
+  [thet]
+
 - Update outdated links in Learn.md
   [staeff]
 

--- a/mockup/less/ui.less
+++ b/mockup/less/ui.less
@@ -1,5 +1,6 @@
 /* ui helper less rules */
 @import "@{mockuplessPath}/base.less";
+@import "../patterns/tooltip/pattern.tooltip.less";
 
 /* loading icon animation */
 .plone-loader{

--- a/mockup/patterns/filemanager/pattern.filemanager.less
+++ b/mockup/patterns/filemanager/pattern.filemanager.less
@@ -15,7 +15,6 @@
 @import (reference) "@{bowerPath}/bootstrap/less/forms.less";
 @import (reference) "@{bowerPath}/bootstrap/less/navbar.less";
 @import (reference) "@{bowerPath}/bootstrap/less/navs.less";
-@import (reference) "@{bowerPath}/bootstrap/less/tooltip.less";
 @import (reference) "@{bowerPath}/bootstrap/less/component-animations.less";
 @import (reference) "@{mockuplessPath}/popover.less";
 
@@ -29,9 +28,6 @@
     .popover-title:extend(.popover-title all){}
     .popover-content:extend(.popover-content all){}
     .arrow:extend(.arrow all){}
-    .tooltip:extend(.tooltip all){}
-    .tooltip-arrow:extend(.tooltip-arrow all){}
-    .tooltip-inner:extend(.tooltip-inner all){}
 
     .table:extend(.table all){}
     .pagination:extend(.pagination all){}

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -8,7 +8,6 @@
 @import (reference) '@{bowerPath}/bootstrap/less/buttons.less';
 @import (reference) '@{bowerPath}/bootstrap/less/button-groups.less';
 @import (reference) '@{bowerPath}/bootstrap/less/popovers.less';
-@import (reference) '@{bowerPath}/bootstrap/less/tooltip.less';
 @import (reference) '@{mockuplessPath}/popover.less';
 
 @import '@{mockupPath}/select2/pattern.select2.less';
@@ -24,9 +23,6 @@
     .popover-title:extend(.popover-title all){}
     .popover-content:extend(.popover-content all){}
     .arrow:extend(.arrow all){}
-    .tooltip:extend(.tooltip all){}
-    .tooltip-arrow:extend(.tooltip-arrow all){}
-    .tooltip-inner:extend(.tooltip-inner all){}
 
     .table:extend(.table all){}
     .pagination:extend(.pagination all){}

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -2,6 +2,7 @@
 @icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 @import "@{bowerPath}/bootstrap/less/glyphicons.less";
 @import "@{mockuplessPath}/ui.less";
+@import "@{mockuplessPath}/../patterns/tooltip/pattern.tooltip.less";
 
 @import "@{bowerPath}/bootstrap/less/mixins.less";
 @import "@{bowerPath}/bootstrap/less/utilities.less";
@@ -16,14 +17,9 @@
 @import (reference) "@{bowerPath}/bootstrap/less/forms.less";
 @import (reference) "@{bowerPath}/bootstrap/less/navbar.less";
 @import (reference) "@{bowerPath}/bootstrap/less/navs.less";
-@import (reference) "@{bowerPath}/bootstrap/less/tooltip.less";
 @import (reference) "@{bowerPath}/bootstrap/less/component-animations.less";
 @import (reference) "@{mockuplessPath}/popover.less";
 
-
-/*
-@import "@{bowerPath}bootstrap/less/tooltip.less";
-*/
 
 .pat-structure {
 
@@ -35,9 +31,6 @@
     .popover-title:extend(.popover-title all){}
     .popover-content:extend(.popover-content all){}
     .arrow:extend(.arrow all){}
-    .tooltip:extend(.tooltip all){}
-    .tooltip-arrow:extend(.tooltip-arrow all){}
-    .tooltip-inner:extend(.tooltip-inner all){}
 
     .table:extend(.table all){}
     .pagination:extend(.pagination all){}

--- a/mockup/patterns/tooltip/pattern.js
+++ b/mockup/patterns/tooltip/pattern.js
@@ -46,7 +46,8 @@ define([
     trigger: '.pat-tooltip',
     parser: 'mockup',
     defaults: {
-      html: false
+      html: false,
+      placement: 'top'
     },
     init: function() {
         if (this.options.html === 'true') {
@@ -56,7 +57,7 @@ define([
           this.options.html = false;
         }
         this.data = new bootstrapTooltip(this.$el[0], this.options);
-    },
+      },
   });
 
   //This is pulled almost directly from the Bootstrap Tooltip
@@ -78,7 +79,7 @@ define([
     animation: true,
     placement: 'top',
     selector: false,
-    template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',
+    template: '<div class="tooltip mockup-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',
     trigger: 'hover focus',
     title: '',
     delay: 0,

--- a/mockup/patterns/tooltip/pattern.tooltip.less
+++ b/mockup/patterns/tooltip/pattern.tooltip.less
@@ -1,13 +1,9 @@
-.tooltips {
-    display: none;
-}
-.tooltips.active {
-    background: white;
-    border: 1px solid black;
-    box-shadow: 3px 3px 3px #666666;
-    display: block;
-    max-width: 600px;
-    padding: 10px;
-    position: absolute;
-    z-index: 1000;
+@import "@{bowerPath}/bootstrap/less/variables.less";
+@import "@{bowerPath}/bootstrap/less/mixins.less";
+@import (reference) "@{bowerPath}/bootstrap/less/tooltip.less";
+
+.mockup-tooltip {
+    &.tooltip:extend(.tooltip all){}
+    .tooltip-arrow:extend(.tooltip-arrow all){}
+    .tooltip-inner:extend(.tooltip-inner all){}
 }


### PR DESCRIPTION
Make ``pat-tooltip`` useable by it's own by including the necessary less files and reuse that one in other patterns.
Allow configuration of ``placement`` parameter.

Without this fix, pat-tooltip cannot be easily used - except the bootstrap tooltip less files are also included.
What I do not fully understand is the ``tooltips`` classes from the tooltip less file, which I removed. That markup seems not to be used, although it's also used in plonetheme.barceloneta: https://github.com/plone/plonetheme.barceloneta/blob/master/plonetheme/barceloneta/theme/less/tooltip.plone.less

However, what I would really prefer is to remove the pat-tooltip from here alltogether and use instead the one from patternslib: http://patternslib.com/tooltip/
That should be an easy replacement, because It seems that mockup-patterns-tooltip wasn't exposed to be used by integrators anyways...

Any comments are welcome!
@vangheem @pilz @plone/framework-team 