### PR TITLE
relatedItems enhancements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ New:
 
     - Adapt TinyMCE pattern to related item changes and remove now obsolete selection and result templates.
 
+    - Calculate all paths relative to the ``rootPath``, so that breadcrumbs navigation and favorites do not show paths outside the rootPath.
   [thet]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ New:
 
     - Let "browse" mode start from current path.
 
-    - Immediately open select2 results when clicking on "Browse" or "Search".
+    - Immediately open select2 results when clicking on "Browse" or "Search" or browsing somewhere.
 
     - Show only selectable items in "search" mode, if defined.
 

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -358,10 +358,10 @@ define([
       self.emit('before-browse');
       self.currentPath = path;
       self.$el.select2('close');
-      self.$el.select2('open');
-      self.emit('after-browse');
       self.setBreadCrumbs();
       self.setQuery();
+      self.$el.select2('open');
+      self.emit('after-browse');
     },
 
     selectItem: function(item) {

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -29,10 +29,8 @@
 
     .btn:extend(.btn all){}
     .btn-default:extend(.btn-default all){}
-    .btn-danger:extend(.btn-danger all){}
     .btn-primary:extend(.btn-primary all){}
     .btn-group:extend(.btn-group all){}
-    .btn-success:extend(.btn-success all){}
     .input-group:extend(.input-group all){}
     .input-group-addon:extend(.input-group-addon all){}
     .input-group-btn:extend(.input-group-btn all){}

--- a/mockup/patterns/relateditems/templates/toolbar.xml
+++ b/mockup/patterns/relateditems/templates/toolbar.xml
@@ -4,7 +4,7 @@
 </div>
 <div class="path-wrapper">
   <span class="pattern-relateditems-path-label"><%- searchText %></span>
-  <a class="crumb" href="<%- rootPath %>"><span class="glyphicon glyphicon-home"/></a>
+  <a class="crumb" href="/"><span class="glyphicon glyphicon-home"/></a>
   <%= items %>
 </div>
 <div class="controls pull-right">

--- a/mockup/patterns/relateditems/templates/toolbar.xml
+++ b/mockup/patterns/relateditems/templates/toolbar.xml
@@ -10,7 +10,7 @@
 <div class="controls pull-right">
   <% if (favorites.length > 0) { %>
   <div class="favorites dropdown pull-right">
-    <button class="favorites dropdown-toggle btn btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" class="favorites dropdown-toggle btn btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <span class="glyphicon glyphicon-star"/>
       <%- favText %>
       <span class="caret"/>

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -8,7 +8,6 @@
  *    targetList(array): TODO ([ {text: "Open in this window / frame", value: ""}, {text: "Open in new window", value: "_blank"}, {text: "Open in parent window / frame", value: "_parent"}, {text: "Open in top frame (replaces all frames)", value: "_top"}])
  *    imageTypes(string): TODO ('Image')
  *    folderTypes(string): TODO ('Folder,Plone Site')
- *    linkableTypes(string): TODO ('Document,Event,File,Folder,Image,News Item,Topic')
  *    tiny(object): TODO ({ plugins: [ "advlist autolink lists charmap print preview anchor", "usearchreplace visualblocks code fullscreen autoresize", "insertdatetime media table contextmenu paste plonelink ploneimage" ], menubar: "edit table format tools view insert",
  toolbar: "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | unlink plonelink ploneimage", autoresize_max_height: 1500 })
  *    prependToUrl(string): Text to prepend to generated internal urls. ('')

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -63,7 +63,6 @@ define([
       }
       this.server.respondWith(/relateditems-test.json/, function(xhr, id) {
 
-
         var addUrls = function(list) {
           /* add getURL value */
           for (var i = 0; i < list.length; i = i + 1) {
@@ -349,7 +348,6 @@ define([
     it('use favorites', function () {
       var pattern = initializePattern({'favorites': [{'title': 'root', 'path': '/'}, {'title': 'folder1', 'path': '/folder1'}]});
       var clock = sinon.useFakeTimers();
-      var $input;
 
       // open up result list by clicking on "browse"
       $('button.favorites', $container).click();


### PR DESCRIPTION
- Calculate all paths relative to the ``rootPath``, so that breadcrumbs navigation and favorites do not show paths outside the rootPath.

- Dont open related items favorites dropdown when hitting enter anywhere in the form.
