### PR TITLE
fix related items upload + related items template opt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ New:
     - Adapt TinyMCE pattern to related item changes and remove now obsolete selection and result templates.
 
     - Calculate all paths relative to the ``rootPath``, so that breadcrumbs navigation and favorites do not show paths outside the rootPath.
+
+    - For results and selected items with images, add a line break after the image.
   [thet]
 
 

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -12,6 +12,7 @@
  *    minimumInputLength: Select2 option. Number of characters necessary to start a search. Default: 0.
  *    orderable(boolean): Whether or not items should be drag-and-drop sortable. (true)
  *    rootPath(string): Only display breadcrumb path elements deeper than this path. Default: "/"
+ *    rootUrl(string): Visible URL up to the rootPath. This is prepended to the currentPath to generate submission URLs.
  *    selectableTypes(array): If the value is null all types are selectable. Otherwise, provide a list of strings to match item types that are selectable. (null)
  *    separator(string): Select2 option. String which separates multiple items. (',')
  *    tokenSeparators(array): Select2 option, refer to select2 documentation. ([",", " "])
@@ -132,6 +133,7 @@ define([
       browsing: undefined,
       orderable: true,  // mockup-patterns-select2
       rootPath: '/',
+      rootUrl: '',  // default to be relative.
       selectableTypes: null, // null means everything is selectable, otherwise a list of strings to match types that are selectable
       separator: ',',
       tokenSeparators: [',', ' '],

--- a/mockup/patterns/relateditems/templates/result.xml
+++ b/mockup/patterns/relateditems/templates/result.xml
@@ -1,6 +1,6 @@
 <div class="pattern-relateditems-result">
   <a href="#" class=" pattern-relateditems-result-select <% if (selectable) { %>selectable<% } %>">
-    <% if (typeof getURL !== 'undefined' && ((typeof getIcon !== 'undefined' && getIcon === true) || portal_type === "Image")) { %><img src="<%- getURL %>/@@images/image/icon "> <% } %>
+    <% if (typeof getURL !== 'undefined' && ((typeof getIcon !== 'undefined' && getIcon === true) || portal_type === "Image")) { %><img src="<%- getURL %>/@@images/image/icon "><br><% } %>
     <span class="pattern-relateditems-result-title <% if (typeof review_state !== "undefined") { %> state-<%- review_state %> <% } %>  " /span>
     <span class="pattern-relateditems contenttype-<%- portal_type.toLowerCase() %>"><%- Title %></span>
     <span class="pattern-relateditems-result-path"><%- path %></span>

--- a/mockup/patterns/relateditems/templates/selection.xml
+++ b/mockup/patterns/relateditems/templates/selection.xml
@@ -1,5 +1,5 @@
 <span class="pattern-relateditems-item">
-  <% if (typeof getURL !== 'undefined' && ((typeof getIcon !== 'undefined' && getIcon === true) || portal_type === "Image")) { %> <img src="<%- getURL %>/@@images/image/icon"> <% } %>
+  <% if (typeof getURL !== 'undefined' && ((typeof getIcon !== 'undefined' && getIcon === true) || portal_type === "Image")) { %><img src="<%- getURL %>/@@images/image/icon"><br><% } %>
   <span class="pattern-relateditems-item-title contenttype-<%- portal_type.toLowerCase() %> <% if (typeof review_state !== "undefined") { %> state-<%- review_state  %> <% } %>" ><%- Title %></span>
   <span class="pattern-relateditems-item-path"><%- path %></span>
 </span>

--- a/mockup/patterns/relateditems/upload.js
+++ b/mockup/patterns/relateditems/upload.js
@@ -52,7 +52,7 @@ define([
       options.uploadMultiple = true;
       options.allowPathSelection = false;
       options.relativePath = 'fileUpload';
-      options.baseUrl = self.app.currentPath;
+      options.baseUrl = self.app.options.rootUrl;
       self.upload = new Upload(self.$('.uploadify-me').addClass('pat-upload'), options);
       return this;
     },


### PR DESCRIPTION
- For results and selected items with images, add a line break after the image.

- Add option to pass rootUrl for relateditems pattern to make upload view work in virtual hosting environments. Necessary since c7c14b6 . Goes together with: plone/plone.app.widgets#148

for the second one, there is no extra changelog entry as it is a bugfix for a feature which is not released yet.
