### PR TITLE
Add better support for TinyMCE importcss-plugin configuration through pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,11 @@ New:
 - Add select2 result class based on value of option so it can be styled
   [vangheem]
 
+- Add to interpret TinyMCE ``importcss_selector_filter`` and ``filter`` value
+  of each ``importcss_groups`` configuration value as RegExp value instead
+  of plain string to make importcss-plugin more configurable through pattern
+  [datakurre]
+
 Fixes:
 
 - Make ``pat-tooltip`` useable by it's own by including the necessary less files and reuse that one in other patterns.

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -391,6 +391,23 @@ define([
           };
         }
 
+        if (tinyOptions.importcss_selector_filter &&
+            tinyOptions.importcss_selector_filter.length) {
+          tinyOptions.importcss_selector_filter =
+            new RegExp(tinyOptions.importcss_selector_filter);
+        }
+
+        if (tinyOptions.importcss_groups &&
+            tinyOptions.importcss_groups.length) {
+          for(var i=0; i<tinyOptions.importcss_groups.length; i++){
+            if (tinyOptions.importcss_groups[i].filter &&
+                tinyOptions.importcss_groups[i].filter.length) {
+              tinyOptions.importcss_groups[i].filter =
+                new RegExp(tinyOptions.importcss_groups[i].filter);
+            }
+          }
+        }
+
         tinymce.init(tinyOptions);
         self.tiny = tinymce.get(self.tinyId);
 


### PR DESCRIPTION
Currently configuring importcss-plugin is very limited, because even the plugin supports regexp filters here and there, those cannot be passed through pattern configuration. Therefore, I suspect, that almost nobody else has used importcss_groups and importcss_selector_filter -options.

This change would add implicit RegExp support for importcsss_selector_filter and filter part of each importcss_groups-value. I believe, this is backwards compatible, because replacing "myprefix" with RegExp("myprefix") should not have much effect.

http://archive.tinymce.com/wiki.php/Configuration:importcss_selector_filter
http://archive.tinymce.com/wiki.php/Configuration:importcss_groups