### PR TITLE
fix: conflict between upload and relateditem browse button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,9 @@ Fixes:
 - Fixes issue when HTML escaping select2 values. Now removing HTML completely and leave the input unescaped.
   [petschki]
 
+- Fix conflict between upload and relateditem browse button.
+  [Gagaro]
+
 
 2.3.0 (2016-08-19)
 ------------------

--- a/mockup/patterns/upload/pattern.js
+++ b/mockup/patterns/upload/pattern.js
@@ -157,7 +157,7 @@ define([
 
       self.$dropzone = $('.upload-area', self.$el);
 
-      $('button.browse', self.$el).click(function(e) {
+      $('div.browse-select button.browse', self.$el).click(function(e) {
         e.preventDefault();
         e.stopPropagation();
         if(!self.options.maxFiles || self.dropzone.files.length < self.options.maxFiles){


### PR DESCRIPTION
A click on the browse button of the related item widget currently opens the file browser for the file input.