### PR TITLE
Query from portal path rather than from navigation root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -133,6 +133,9 @@ Fixes:
 - Fix conflict between upload and relateditem browse button.
   [Gagaro]
 
+- Query from portal path rather than from navigation root.
+  [Gagaro]
+
 
 2.3.0 (2016-08-19)
 ------------------

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -102,13 +102,13 @@ define([
       if (searchOptions.searchPath) {
         criterias.push({
           i: 'path',
-          o: 'plone.app.querystring.operation.string.path',
+          o: 'plone.app.querystring.operation.string.absolutePath',
           v: searchOptions.searchPath + '::' + self.options.pathDepth
         });
       } else if (self.pattern.browsing) {
         criterias.push({
           i: 'path',
-          o: 'plone.app.querystring.operation.string.path',
+          o: 'plone.app.querystring.operation.string.absolutePath',
           v: self.getCurrentPath() + '::' + self.options.pathDepth
         });
       }

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -191,7 +191,7 @@ define([
 
         baseCriteria.push({
           i: 'path',
-          o: 'plone.app.querystring.operation.string.path',
+          o: 'plone.app.querystring.operation.string.absolutePath',
           v: this.options.rootPath + this.currentPath
         });
 

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -98,7 +98,7 @@ define([
       expect(JSON.parse(app.collection.queryParser())).to.eql({
         "criteria": [{
           "i":"path",
-          "o":"plone.app.querystring.operation.string.path",
+          "o":"plone.app.querystring.operation.string.absolutePath",
           "v":"/::1"
         }],
         "sort_on":"getObjPositionInParent",

--- a/mockup/tests/utils-test.js
+++ b/mockup/tests/utils-test.js
@@ -151,7 +151,7 @@ define([
       it('browsing adds path criteria', function() {
         var qh = new utils.QueryHelper({vocabularyUrl: 'http://foobar.com/?foo=bar'});
         qh.pattern.browsing = true;
-        expect(qh.getQueryData('foobar').query).to.contain('plone.app.querystring.operation.string.path');
+        expect(qh.getQueryData('foobar').query).to.contain('plone.app.querystring.operation.string.absolutePath');
       });
 
 


### PR DESCRIPTION
Related to #734.

The `rootPath` is actually already set by default on the navigation root, so the query can be made on the portal root without issue to allow for more customization if needed :
https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/patterns/settings.py#L118-L119