### PR TITLE
feat: add defaultSortOn option in livesearch pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,9 @@ New:
   of plain string to make importcss-plugin more configurable through pattern
   [datakurre]
 
+- Add ``defaultSortOn`` option in ``livesearch`` pattern.
+  [Gagaro]
+
 Fixes:
 
 - Fix jquery.event.drag to work with HTML5 drag

--- a/mockup/patterns/livesearch/pattern.js
+++ b/mockup/patterns/livesearch/pattern.js
@@ -41,6 +41,7 @@ define([
     resultsClass: 'livesearch-results',
     defaults: {
       ajaxUrl: null,
+      defaultSortOn: '',
       perPage: 7,
       quietMillis: 350,
       minimumInputLength: 4,
@@ -68,7 +69,7 @@ define([
           if($searchResults.length > 0){
             return $searchResults.attr('data-default-sort');
           }
-          return '';
+          return self.options.defaultSortOn;
         }
         // cut string before sort_on parameter
         var sort_on = parameters.substring(sorton_position);


### PR DESCRIPTION
For the searchbox, it is not possible to set `data-default-sort`.