### PR TITLE
More pickadate optimizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ New:
   Remove the clear buttons from the date and time picker itself, as they allowed incomplete input submission (e.g. date only when date and time were required).
   Also remove the now obsolete footer buttons as a whole from the date picker.
   Add options ``today`` and  ``clear`` to hide those buttons when set to ``false``.
+  Use ``display: inline-block`` instead of problematic ``float:left``.
+  Refs: PR #740, Fixes #732.
   [thet]
 
 - PickADate pattern: Add option to automatically set the time when changing the date.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ New:
 
 - PickADate pattern: Add a button to set the date or time to now and another to clear all inputs.
   Remove the clear buttons from the date and time picker itself, as they allowed incomplete input submission (e.g. date only when date and time were required).
+  Also remove the now obsolete footer buttons as a whole from the date picker.
+  Add options ``today`` and  ``clear`` to hide those buttons when set to ``false``.
   [thet]
 
 - PickADate pattern: Add option to automatically set the time when changing the date.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,9 @@ New:
 
 Fixes:
 
+- Change ``bool`` function in mockup-utils to allow for truthy values and match on falsy values.
+  [thet]
+
 - Fix jquery.event.drag to work with HTML5 drag
   [vangheem]
 

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -326,7 +326,7 @@ define([
     if (typeof val === 'string') {
       val = $.trim(val).toLowerCase();
     }
-    return ['true', true, 1].indexOf(val) !== -1;
+    return ['false', false, '0', 0, '', undefined, null].indexOf(val) === -1;
   };
 
   var escapeHTML = function(val) {

--- a/mockup/patterns/pickadate/pattern.js
+++ b/mockup/patterns/pickadate/pattern.js
@@ -3,6 +3,8 @@
  * Options:
  *    date(object): Date widget options described here. If false is selected date picker wont be shown. ({{selectYears: true, selectMonths: true })
  *    time(object): Time widget options described here. If false is selected time picker wont be shown. ({})
+ *    today(String/Boolean): Title text for today button. Set to a falsy value to hide the button ("Today").
+ *    clear(String/Boolean): Title text for the clear button. Set to a falsy value to hide the button ("Clear").
  *    autoSetTimeOnDateChange(string): Automatically set the time when a date is set. You can specify an offset with a special syntax - a stringified JSON Array in the form of "[H,M]" will set it to hour:minute. If you prepend an "+" or "-", this will added or subscracted to the current time. It does not go beyond 12:00am. ("+[0,0]").
  *    separator(string): Separator between date and time if both are enabled.
  *    (' ')
@@ -50,7 +52,7 @@
  *
  *    {{ example-8 }}
  *
- *    # Date and time with one timezone
+ *    # Date and time with one timezone and no today and clear buttons
  *
  *    {{ example-9 }}
  *
@@ -79,7 +81,7 @@
  *    <input class="pat-pickadate" data-pat-pickadate='{"timezone": {"default": "Europe/Vienna", "data": [{"id":"Europe/Berlin","text":"Europe/Berlin"},{"id":"Europe/Vienna","text":"Europe/Vienna"}]}}'/>
  *
  * Example: example-9
- *    <input class="pat-pickadate" data-pat-pickadate='{"timezone": {"data": [{"id":"Europe/Berlin","text":"Europe/Berlin"}]}}'/>
+ *    <input class="pat-pickadate" data-pat-pickadate='{"timezone": {"data": [{"id":"Europe/Berlin","text":"Europe/Berlin"}]}, "today": false, "clear": false}'/>
  *
  */
 
@@ -87,12 +89,13 @@
 define([
   'jquery',
   'pat-base',
+  'mockup-utils',
   'translate',
   'picker',
   'picker.date',
   'picker.time',
   'mockup-patterns-select2'
-], function($, Base, _t) {
+], function($, Base, utils, _t) {
   'use strict';
 
   var PickADate = Base.extend({
@@ -106,20 +109,21 @@ define([
         selectMonths: true,
         formatSubmit: 'yyyy-mm-dd',
         format: 'yyyy-mm-dd',
-        clear: false,
-        close: _t('Close'),
-        today: _t('Today'),
         labelMonthNext: _t('Next month'),
         labelMonthPrev: _t('Previous month'),
         labelMonthSelect: _t('Select a month'),
-        labelYearSelect: _t('Select a year')
+        labelYearSelect: _t('Select a year'),
+        // hide buttons
+        clear: false,
+        close: false,
+        today: false
       },
       time: {
-        clear: false
+        clear: false  // hide button
       },
+      today: _t('Today'),
+      clear: _t('Clear'),
       timezone: null,
-      titleClear: _t('Clear'),
-      titleNow: _t('Today'),
       autoSetTimeOnDateChange: '+[0,0]',
       classWrapperName: 'pattern-pickadate-wrapper',
       classSeparatorName: 'pattern-pickadate-separator',
@@ -334,25 +338,28 @@ define([
         }
       }
 
-      self.$now = $('<button class="btn btn-xs btn-info" title="' + self.options.titleNow + '"><span class="glyphicon glyphicon-time"></span></button>')
-        .addClass(self.options.classNowName)
-        .on('click', function (e) {
-            e.preventDefault();
-            var now = new Date();
-            if (self.$date) { self.$date.data('pickadate').set('select', now); }
-            if (self.$time) { self.$time.data('pickatime').set('select', now); }
-        })
-        .appendTo(self.$wrapper);
+      if (utils.bool(self.options.today)) {
+        self.$now = $('<button class="btn btn-xs btn-info" title="' + self.options.today + '"><span class="glyphicon glyphicon-time"></span></button>')
+          .addClass(self.options.classNowName)
+          .on('click', function (e) {
+              e.preventDefault();
+              var now = new Date();
+              if (self.$date) { self.$date.data('pickadate').set('select', now); }
+              if (self.$time) { self.$time.data('pickatime').set('select', now); }
+          })
+          .appendTo(self.$wrapper);
+      }
 
-      self.$clear = $('<button class="btn btn-xs btn-danger" title="' + self.options.titleClear + '"><span class="glyphicon glyphicon-trash"></span></button>')
-        .addClass(self.options.classClearName)
-        .on('click', function (e) {
-            e.preventDefault();
-            if (self.$date) { self.$date.data('pickadate').clear(); }
-            if (self.$time) { self.$time.data('pickatime').clear(); }
-        })
-        .appendTo(self.$wrapper);
-
+      if (utils.bool(self.options.clear)) {
+        self.$clear = $('<button class="btn btn-xs btn-danger" title="' + self.options.clear + '"><span class="glyphicon glyphicon-trash"></span></button>')
+          .addClass(self.options.classClearName)
+          .on('click', function (e) {
+              e.preventDefault();
+              if (self.$date) { self.$date.data('pickadate').clear(); }
+              if (self.$time) { self.$time.data('pickatime').clear(); }
+          })
+          .appendTo(self.$wrapper);
+      }
     },
     updateValue: function() {
       var self = this,

--- a/mockup/patterns/pickadate/pattern.js
+++ b/mockup/patterns/pickadate/pattern.js
@@ -135,12 +135,6 @@ define([
       placeholderTime: _t('Enter time...'),
       placeholderTimezone: _t('Enter timezone...')
     },
-    isFalse: function(value) {
-      if (typeof(value) === 'string' && value === 'false') {
-        return false;
-      }
-      return value;
-    },
     parseTimeOffset: function(timeOffset) {
       var op = undefined;
       if (timeOffset.indexOf('+') === 0) {
@@ -198,8 +192,12 @@ define([
         dateValue = value[0] || '',
         timeValue = value[1] || '';
 
-      self.options.date = self.isFalse(self.options.date);
-      self.options.time = self.isFalse(self.options.time);
+      if (utils.bool(self.options.date) === false) {
+        self.options.date = false;
+      }
+      if (utils.bool(self.options.time) === false) {
+        self.options.time = false;
+      }
       self.options.autoSetTimeOnDateChange = self.parseTimeOffset(self.options.autoSetTimeOnDateChange);
 
       if (self.options.date === false) {

--- a/mockup/patterns/pickadate/pattern.pickadate.less
+++ b/mockup/patterns/pickadate/pattern.pickadate.less
@@ -13,10 +13,6 @@
   position: relative;
   margin-bottom: 0.5em;
 
-  &:after {
-    clear: both;
-  }
-
   .picker{
     display: none;
     &.picker--opened{
@@ -25,7 +21,8 @@
   }
 
   .pattern-pickadate-date-wrapper {
-    float: left;
+    display: inline-block;
+    vertical-align: middle;
     .picker__input {
       width: 300px;
       margin-bottom: 0.2em;
@@ -41,13 +38,14 @@
   }
 
   .pattern-pickadate-separator {
-    float: left;
-    display: block;
+    display: inline-block;
+    vertical-align: middle;
     margin: 0 0.2em;
   }
 
   .pattern-pickadate-time-wrapper {
-    float: left;
+    display: inline-block;
+    vertical-align: middle;
     .picker__input {
       width: 180px;
       margin-bottom: 0.2em;
@@ -66,15 +64,20 @@
   }
 
   .pattern-pickadate-timezone-wrapper {
-      float: left;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   .pattern-pickadate-now {
+    display: inline-block;
+    vertical-align: middle;
     margin-left: 1em;
   }
 
   .pattern-pickadate-clear {
-      margin-left: 0.5em;
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 0.5em;
   }
 
   .picker__select--month, .picker__select--year {

--- a/mockup/tests/pattern-pickadate-test.js
+++ b/mockup/tests/pattern-pickadate-test.js
@@ -603,6 +603,14 @@ define([
         expect($('.pat-pickadate', $el).val()).to.be.equal("");
       });
 
+      it('hide today and clear buttons', function() {
+        var $el = $('<div><input class="pat-pickadate" data-pat-pickadate=\'today:false;clear:false\'/>');
+        registry.scan($el);
+        // today and clear buttons are missing
+        expect($('.pattern-pickadate-now', $el).length).to.be.equal(0);
+        expect($('.pattern-pickadate-clear', $el).length).to.be.equal(0);
+      });
+
     });
 
   });

--- a/mockup/tests/utils-test.js
+++ b/mockup/tests/utils-test.js
@@ -74,33 +74,31 @@ define([
 
     describe('bool', function() {
 
-      it('returns true for "true"', function() {
+      it('returns true for truthy values', function() {
+        expect(utils.bool(true)).to.be.equal(true);
+        expect(utils.bool(1)).to.be.equal(true);
+        expect(utils.bool('1')).to.be.equal(true);
         expect(utils.bool('true')).to.be.equal(true);
         expect(utils.bool(' true ')).to.be.equal(true);
         expect(utils.bool('TRUE')).to.be.equal(true);
         expect(utils.bool('True')).to.be.equal(true);
+        expect(utils.bool(13)).to.be.equal(true);
+        expect(utils.bool('foo')).to.be.equal(true);
       });
-
-      it('returns true for true', function() {
-        var val = utils.bool(true);
-        expect(val).to.be.equal(true);
-      });
-
-      it('returns true for true', function() {
-        var val = utils.bool(1);
-        expect(val).to.be.equal(true);
-      });
-
-      it('returns false for strings != "true"', function() {
-        expect(utils.bool('1')).to.be.equal(false);
-        expect(utils.bool('')).to.be.equal(false);
+        
+      it('returns false for falsy values', function() {
         expect(utils.bool('false')).to.be.equal(false);
-      });
-
-      it('returns false for undefined/null', function() {
+        expect(utils.bool(' false ')).to.be.equal(false);
+        expect(utils.bool('FALSE')).to.be.equal(false);
+        expect(utils.bool('False')).to.be.equal(false);
+        expect(utils.bool(false)).to.be.equal(false);
+        expect(utils.bool('0')).to.be.equal(false);
+        expect(utils.bool(0)).to.be.equal(false);
+        expect(utils.bool('')).to.be.equal(false);
         expect(utils.bool(undefined)).to.be.equal(false);
         expect(utils.bool(null)).to.be.equal(false);
       });
+
     });
 
 


### PR DESCRIPTION
- Remove the now obsolete footer buttons as a whole from the date picker.
- Add options ``today`` and  ``clear`` to hide those buttons when set to ``false``.
- Use display: inline-block instead of problematic float:left.
- Also, via a change in plone.app.widget, the "Clear" button is not shown for ``required`` date/time fields.

Also adresses: #732 

Related:
https://github.com/plone/Products.CMFPlone/pull/1947
https://github.com/plone/plone.app.widgets/pull/154
https://github.com/plone/mockup/pull/740
https://github.com/plone/plone.app.z3cform/pull/60
https://github.com/plone/Products.Archetypes/pull/78
https://github.com/plone/plonetheme.barceloneta/pull/123

Jenkins:
http://jenkins.plone.org/job/pull-request-5.1/1294/