### PR TITLE
Pickadate optimizations - backport from master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ New features:
 
 - PickADate pattern: Add a button to set the date or time to now and another to clear all inputs.
   Remove the clear buttons from the date and time picker itself, as they allowed incomplete input submission (e.g. date only when date and time were required).
+  Also remove the now obsolete footer buttons as a whole from the date picker.
+  Add options ``today`` and  ``clear`` to hide those buttons when set to ``false``.
+  Use ``display: inline-block`` instead of problematic ``float:left``.
   [thet]
 
 - PickADate pattern: Add option to automatically set the time when changing the date.

--- a/mockup/patterns/pickadate/pattern.js
+++ b/mockup/patterns/pickadate/pattern.js
@@ -3,6 +3,8 @@
  * Options:
  *    date(object): Date widget options described here. If false is selected date picker wont be shown. ({{selectYears: true, selectMonths: true })
  *    time(object): Time widget options described here. If false is selected time picker wont be shown. ({})
+ *    today(Boolean): Show the today button. (true)
+ *    clear(Boolean): Show the clear button. (true)
  *    autoSetTimeOnDateChange(string): Automatically set the time when a date is set. You can specify an offset with a special syntax - a stringified JSON Array in the form of "[H,M]" will set it to hour:minute. If you prepend an "+" or "-", this will added or subscracted to the current time. It does not go beyond 12:00am. ("+[0,0]").
  *    separator(string): Separator between date and time if both are enabled.
  *    (' ')
@@ -50,7 +52,7 @@
  *
  *    {{ example-8 }}
  *
- *    # Date and time with one timezone
+ *    # Date and time with one timezone and no today and clear buttons
  *
  *    {{ example-9 }}
  *
@@ -79,7 +81,7 @@
  *    <input class="pat-pickadate" data-pat-pickadate='{"timezone": {"default": "Europe/Vienna", "data": [{"id":"Europe/Berlin","text":"Europe/Berlin"},{"id":"Europe/Vienna","text":"Europe/Vienna"}]}}'/>
  *
  * Example: example-9
- *    <input class="pat-pickadate" data-pat-pickadate='{"timezone": {"data": [{"id":"Europe/Berlin","text":"Europe/Berlin"}]}}'/>
+ *    <input class="pat-pickadate" data-pat-pickadate='{"timezone": {"data": [{"id":"Europe/Berlin","text":"Europe/Berlin"}]}, "today": false, "clear": false}'/>
  *
  */
 
@@ -87,12 +89,13 @@
 define([
   'jquery',
   'pat-base',
+  'mockup-utils',
+  'translate',
   'picker',
   'picker.date',
   'picker.time',
-  'mockup-patterns-select2',
-  'translate'
-], function($, Base, Picker, PickerDate, PickerTime, Select2, _t) {
+  'mockup-patterns-select2'
+], function($, Base, utils, _t) {
   'use strict';
 
   var PickADate = Base.extend({
@@ -106,17 +109,20 @@ define([
         selectMonths: true,
         formatSubmit: 'yyyy-mm-dd',
         format: 'yyyy-mm-dd',
-        clear: false,
-        close: _t('Close'),
-        today: _t('Today'),
         labelMonthNext: _t('Next month'),
         labelMonthPrev: _t('Previous month'),
         labelMonthSelect: _t('Select a month'),
-        labelYearSelect: _t('Select a year')
+        labelYearSelect: _t('Select a year'),
+        // hide buttons
+        clear: false,
+        close: false,
+        today: false
       },
       time: {
-        clear: false
+        clear: false  // hide button
       },
+      today: true,  // show today button
+      clear: true,  // show clear button
       timezone: null,
       titleClear: _t('Clear'),
       titleNow: _t('Today'),
@@ -336,25 +342,28 @@ define([
         }
       }
 
-      self.$now = $('<button class="btn btn-xs btn-info" title="' + self.options.titleNow + '"><span class="glyphicon glyphicon-time"></span></button>')
-        .addClass(self.options.classNowName)
-        .on('click', function (e) {
-            e.preventDefault();
-            var now = new Date();
-            if (self.$date) { self.$date.data('pickadate').set('select', now); }
-            if (self.$time) { self.$time.data('pickatime').set('select', now); }
-        })
-        .appendTo(self.$wrapper);
+      if (utils.bool(self.options.today)) {
+        self.$now = $('<button class="btn btn-xs btn-info" title="' + self.options.titleNow + '"><span class="glyphicon glyphicon-time"></span></button>')
+          .addClass(self.options.classNowName)
+          .on('click', function (e) {
+              e.preventDefault();
+              var now = new Date();
+              if (self.$date) { self.$date.data('pickadate').set('select', now); }
+              if (self.$time) { self.$time.data('pickatime').set('select', now); }
+          })
+          .appendTo(self.$wrapper);
+      }
 
-      self.$clear = $('<button class="btn btn-xs btn-danger" title="' + self.options.titleClear + '"><span class="glyphicon glyphicon-trash"></span></button>')
-        .addClass(self.options.classClearName)
-        .on('click', function (e) {
-            e.preventDefault();
-            if (self.$date) { self.$date.data('pickadate').clear(); }
-            if (self.$time) { self.$time.data('pickatime').clear(); }
-        })
-        .appendTo(self.$wrapper);
-
+      if (utils.bool(self.options.clear)) {
+        self.$clear = $('<button class="btn btn-xs btn-danger" title="' + self.options.titleClear + '"><span class="glyphicon glyphicon-trash"></span></button>')
+          .addClass(self.options.classClearName)
+          .on('click', function (e) {
+              e.preventDefault();
+              if (self.$date) { self.$date.data('pickadate').clear(); }
+              if (self.$time) { self.$time.data('pickatime').clear(); }
+          })
+          .appendTo(self.$wrapper);
+      }
     },
     updateValue: function() {
       var self = this,

--- a/mockup/patterns/pickadate/pattern.pickadate.less
+++ b/mockup/patterns/pickadate/pattern.pickadate.less
@@ -13,10 +13,6 @@
   position: relative;
   margin-bottom: 0.5em;
 
-  &:after {
-    clear: both;
-  }
-
   .picker{
     display: none;
     &.picker--opened{
@@ -25,7 +21,7 @@
   }
 
   .pattern-pickadate-date-wrapper {
-    float: left;
+    display: inline-block;
     .picker__input {
       width: 300px;
       margin-bottom: 0.2em;
@@ -41,13 +37,12 @@
   }
 
   .pattern-pickadate-separator {
-    float: left;
-    display: block;
+    display: inline-block;
     margin: 0 0.2em;
   }
 
   .pattern-pickadate-time-wrapper {
-    float: left;
+    display: inline-block;
     .picker__input {
       width: 180px;
       margin-bottom: 0.2em;
@@ -66,7 +61,7 @@
   }
 
   .pattern-pickadate-timezone-wrapper {
-      float: left;
+    display: inline-block;
   }
 
   .pattern-pickadate-now {
@@ -74,10 +69,14 @@
   }
 
   .pattern-pickadate-clear {
-      margin-left: 0.5em;
+    margin-left: 0.5em;
   }
 
   .picker__select--month, .picker__select--year {
     height: 3em;
+  }
+  
+  .picker__footer {
+    display: none;
   }
 }

--- a/mockup/tests/pattern-pickadate-test.js
+++ b/mockup/tests/pattern-pickadate-test.js
@@ -351,7 +351,7 @@ define([
         var $results = $('li.select2-result-selectable');
         expect($results.size()).to.equal(0);
 
-        var $pattern = $('input.pattern-pickadate-timezone.select2-offscreen');
+        var $pattern = $('input.pattern-pickadate-timezone');
         $pattern.on('select2-open', function() {
           // timezone elements should be available
           $results = $('li.select2-result-selectable');
@@ -395,7 +395,7 @@ define([
 
         // check if data values are set to default
         expect($('.pattern-pickadate-timezone .select2-chosen').text()).to.equal('Europe/Vienna');
-        expect($('input.pattern-pickadate-timezone.select2-offscreen').attr('data-value')).to.equal('Europe/Vienna');
+        expect($('input.pattern-pickadate-timezone').attr('data-value')).to.equal('Europe/Vienna');
 
       });
 
@@ -412,7 +412,7 @@ define([
 
         // check if visible and data value are set to default
         expect($('.pattern-pickadate-timezone .select2-chosen').text()).to.equal('Enter timezone...');
-        expect($('input.pattern-pickadate-timezone.select2-offscreen').attr('data-value')).to.equal(undefined);
+        expect($('input.pattern-pickadate-timezone').attr('data-value')).to.equal(undefined);
 
       });
 
@@ -430,7 +430,7 @@ define([
 
         // check if data values are set to default
         expect($('.select2-chosen', $time).text()).to.equal('Europe/Berlin');
-        expect($('input.pattern-pickadate-timezone.select2-offscreen').attr('data-value')).to.equal('Europe/Berlin');
+        expect($('input.pattern-pickadate-timezone').attr('data-value')).to.equal('Europe/Berlin');
 
         expect($('.pattern-pickadate-timezone').data('select2')._enabled).to.equal(false);
         expect($('.select2-container-disabled').size()).to.equal(1);
@@ -601,6 +601,14 @@ define([
         // now clear it.
         $('.pattern-pickadate-clear', $el).click();
         expect($('.pat-pickadate', $el).val()).to.be.equal("");
+      });
+
+      it('hide today and clear buttons', function() {
+        var $el = $('<div><input class="pat-pickadate" data-pat-pickadate=\'today:false;clear:false\'/>');
+        registry.scan($el);
+        // today and clear buttons are missing
+        expect($('.pattern-pickadate-now', $el).length).to.be.equal(0);
+        expect($('.pattern-pickadate-clear', $el).length).to.be.equal(0);
       });
 
     });


### PR DESCRIPTION
- Remove the now obsolete footer buttons as a whole from the date picker.
- Add options today and clear to hide those buttons when set to false.
- Use display: inline-block instead of problematic float:left.