### PR TITLE
feat: add an option for the path operator in QueryHelper and tinymce pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,9 @@ New:
 - Add ``defaultSortOn`` option in ``livesearch`` pattern.
   [Gagaro]
 
+- Add an option to set the path operator in QueryHelp and tinymce pattern.
+  [Gagaro]
+
 Fixes:
 
 - Change ``bool`` function in mockup-utils to allow for truthy values and match on falsy values.

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -19,6 +19,7 @@ define([
       pattern: null, // must be passed in
       vocabularyUrl: null,
       searchParam: 'SearchableText', // query string param to pass to search url
+      pathOperator: 'plone.app.querystring.operation.string.path',
       attributes: ['UID', 'Title', 'Description', 'getURL', 'portal_type'],
       batchSize: 10, // number of results to retrive
       baseCriteria: [],
@@ -102,13 +103,13 @@ define([
       if (searchOptions.searchPath) {
         criterias.push({
           i: 'path',
-          o: 'plone.app.querystring.operation.string.path',
+          o: self.options.pathOperator,
           v: searchOptions.searchPath + '::' + self.options.pathDepth
         });
       } else if (self.pattern.browsing) {
         criterias.push({
           i: 'path',
-          o: 'plone.app.querystring.operation.string.path',
+          o: self.options.pathOperator,
           v: self.getCurrentPath() + '::' + self.options.pathDepth
         });
       }

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -134,6 +134,7 @@ define([
       orderable: true,  // mockup-patterns-select2
       rootPath: '/',
       rootUrl: '',  // default to be relative.
+      pathOperator: 'plone.app.querystring.operation.string.path',
       selectableTypes: null, // null means everything is selectable, otherwise a list of strings to match types that are selectable
       separator: ',',
       tokenSeparators: [',', ' '],
@@ -191,7 +192,7 @@ define([
 
         baseCriteria.push({
           i: 'path',
-          o: 'plone.app.querystring.operation.string.path',
+          o: this.options.pathOperator,
           v: this.options.rootPath + this.currentPath
         });
 


### PR DESCRIPTION
Related to #734 and #736.

It allows to change the query to be done on the portal root for example.