### PR TITLE
Do not use relative paths for imports in less files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New features:
 
 Bug fixes:
 
+- Do not use relative paths for imports in less files.
+  Use the less variables for paths instead.
+  Fixes a case, where less files couldn't be found in Plone development mode.
+  [thet]
+
 - fix datepicker markup, see plone/Products.CMFPlone#1953 - removes also ugly separator and uses CSS to add space.
   [jensens]
 

--- a/mockup/less/docs.less
+++ b/mockup/less/docs.less
@@ -1,29 +1,28 @@
 @import "mixins.less";
 
 @import "@{bowerPath}/bootstrap/less/variables.less";
-@icon-font-path: "../dev/bower_components/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 @import "@{bowerPath}/bootstrap/less/bootstrap.less";
-@icon-font-path: "../dev/bower_components/bootstrap/dist/fonts/";
-@mockuplessPath: '../less/';
+@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 
 
-@import "../patterns/autotoc/pattern.autotoc.less";
-@import "../patterns/markspeciallinks/pattern.markspeciallinks.less";
-@import "../patterns/modal/pattern.modal.less";
-@import "../patterns/pickadate/pattern.pickadate.less";
-@import "../patterns/querystring/pattern.querystring.less";
-@import "../patterns/relateditems/pattern.relateditems.less";
-@import "../patterns/select2/pattern.select2.less";
-@import "../patterns/structure/less/pattern.structure.less";
-@import "../patterns/tinymce/less/pattern.tinymce.less";
-@import "../patterns/tooltip/pattern.tooltip.less";
-@import "../patterns/tree/pattern.tree.less";
-@import "../patterns/upload/less/pattern.upload.less";
-@import "../patterns/filemanager/pattern.filemanager.less";
-@import "../patterns/thememapper/pattern.thememapper.less";
-@import "../patterns/resourceregistry/pattern.resourceregistry.less";
-@import "../patterns/livesearch/pattern.livesearch.less";
-@import "../patterns/recurrence/pattern.recurrence.less";
+@import "@{mockupPath}/autotoc/pattern.autotoc.less";
+@import "@{mockupPath}/markspeciallinks/pattern.markspeciallinks.less";
+@import "@{mockupPath}/modal/pattern.modal.less";
+@import "@{mockupPath}/pickadate/pattern.pickadate.less";
+@import "@{mockupPath}/querystring/pattern.querystring.less";
+@import "@{mockupPath}/relateditems/pattern.relateditems.less";
+@import "@{mockupPath}/select2/pattern.select2.less";
+@import "@{mockupPath}/structure/less/pattern.structure.less";
+@import "@{mockupPath}/tinymce/less/pattern.tinymce.less";
+@import "@{mockupPath}/tooltip/pattern.tooltip.less";
+@import "@{mockupPath}/tree/pattern.tree.less";
+@import "@{mockupPath}/upload/less/pattern.upload.less";
+@import "@{mockupPath}/filemanager/pattern.filemanager.less";
+@import "@{mockupPath}/thememapper/pattern.thememapper.less";
+@import "@{mockupPath}/resourceregistry/pattern.resourceregistry.less";
+@import "@{mockupPath}/livesearch/pattern.livesearch.less";
+@import "@{mockupPath}/recurrence/pattern.recurrence.less";
 
 @import "@{bowerPath}/bootstrap/less/variables.less";
 @import "@{bowerPath}/bootstrap/less/bootstrap.less";

--- a/mockup/less/filemanager.less
+++ b/mockup/less/filemanager.less
@@ -1,4 +1,4 @@
 @import "mixins.less";
-@import "../patterns/filemanager/pattern.filemanager.less";
+@import "@{mockupPath}/filemanager/pattern.filemanager.less";
 @import "@{bowerPath}/bootstrap/less/bootstrap.less";
-@icon-font-path: "@{pathPrefix}../bower_components/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";

--- a/mockup/less/resourceregistry.less
+++ b/mockup/less/resourceregistry.less
@@ -1,4 +1,4 @@
 @import "mixins.less";
-@import "../patterns/resourceregistry/pattern.resourceregistry.less";
+@import "@{mockupPath}/resourceregistry/pattern.resourceregistry.less";
 
-@icon-font-path: "@{pathPrefix}../bower_components/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";

--- a/mockup/less/structure.less
+++ b/mockup/less/structure.less
@@ -1,15 +1,15 @@
 @import "mixins.less";
 @import "plonetoolbar.less";
-@import "../patterns/autotoc/pattern.autotoc.less";
-@import "../patterns/pickadate/pattern.pickadate.less";
-@import "../patterns/modal/pattern.modal.less";
-@import "../patterns/select2/pattern.select2.less";
-@import "../patterns/relateditems/pattern.relateditems.less";
-@import "../patterns/tinymce/less/pattern.tinymce.less";
-@import "../patterns/querystring/pattern.querystring.less";
-@import "../patterns/structure/less/pattern.structure.less";
+@import "@{mockupPath}/autotoc/pattern.autotoc.less";
+@import "@{mockupPath}/pickadate/pattern.pickadate.less";
+@import "@{mockupPath}/modal/pattern.modal.less";
+@import "@{mockupPath}/select2/pattern.select2.less";
+@import "@{mockupPath}/relateditems/pattern.relateditems.less";
+@import "@{mockupPath}/tinymce/less/pattern.tinymce.less";
+@import "@{mockupPath}/querystring/pattern.querystring.less";
+@import "@{mockupPath}/structure/less/pattern.structure.less";
 
-@icon-font-path: "@{pathPrefix}../bower_components/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 
 .modal.fade.in>.modal-dialog {
   z-index: 1010;

--- a/mockup/less/ui.less
+++ b/mockup/less/ui.less
@@ -1,6 +1,6 @@
 /* ui helper less rules */
 @import "@{mockuplessPath}/base.less";
-@import "../patterns/tooltip/pattern.tooltip.less";
+@import "@{mockupPath}/tooltip/pattern.tooltip.less";
 
 /* loading icon animation */
 .plone-loader{

--- a/mockup/less/widgets.less
+++ b/mockup/less/widgets.less
@@ -1,12 +1,12 @@
 @import "mixins.less";
-@import "../patterns/select2/pattern.select2.less";
-@import "../patterns/pickadate/pattern.pickadate.less";
-@import "../patterns/relateditems/pattern.relateditems.less";
-@import "../patterns/querystring/pattern.querystring.less";
-@import "../patterns/tinymce/less/pattern.tinymce.less";
-@import "../patterns/passwordstrength/pattern.passwordstrength.less";
-@import "../patterns/recurrence/pattern.recurrence.less";
-@icon-font-path: "@{pathPrefix}../bower_components/bootstrap/dist/fonts/";
+@import "@{mockupPath}/select2/pattern.select2.less";
+@import "@{mockupPath}/pickadate/pattern.pickadate.less";
+@import "@{mockupPath}/relateditems/pattern.relateditems.less";
+@import "@{mockupPath}/querystring/pattern.querystring.less";
+@import "@{mockupPath}/tinymce/less/pattern.tinymce.less";
+@import "@{mockupPath}/passwordstrength/pattern.passwordstrength.less";
+@import "@{mockupPath}/recurrence/pattern.recurrence.less";
+@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 
 #content {
     


### PR DESCRIPTION
Use the less variables for paths instead.
Fixes a case, where less files couldn't be found in Plone development mode.