### PR TITLE
thememapper, filemanager upds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Autoformat + eslint fixes for thememapper and filemanager patterns.
+  [thet]
+
 - Update ``ace-builds`` to 1.2.6, which fixes IME handling in new Chrome.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Style filemanager toolbar to better fix small screens.
+  [thet]
+
 - Fix pattern options initialization according to change in plone.app.theming.
   See: https://github.com/plone/plone.app.theming/pull/124
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Fix setting empty ace editor instance by passing an empty text.
+  [thet]
+
 - Unify disabling of buttons by using setting the ``disabled`` DOM property instead using classes.
   Fixes thememapper button staying disabled all the time.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Fix pattern options initialization according to change in plone.app.theming.
+  See: https://github.com/plone/plone.app.theming/pull/124
+  [thet]
+
 - Fix setting empty ace editor instance by passing an empty text.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Unify disabling of buttons by using setting the ``disabled`` DOM property instead using classes.
+  Fixes thememapper button staying disabled all the time.
+  [thet]
+
 - Autoformat + eslint fixes for thememapper and filemanager patterns.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Update ``ace-builds`` to 1.2.6, which fixes IME handling in new Chrome.
+  [thet]
+
 - Fix i18n in upload pattern.
   [cedricmessiant]
 

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "mockup",
   "description": "A collection of client side patterns for faster and easier web development",
   "dependencies": {
-    "ace-builds": "1.2.3",
+    "ace-builds": "1.2.6",
     "backbone": "1.1.2",
     "backbone.paginator": "0.8.1",
     "bootstrap": "3.3.6",

--- a/mockup/js/ui/views/button.js
+++ b/mockup/js/ui/views/button.js
@@ -27,14 +27,6 @@ define([
       }
       BaseView.prototype.initialize.apply(this, [options]);
 
-      this.on('disable', function() {
-        this.disable();
-      }, this);
-
-      this.on('enable', function() {
-        this.enable();
-      }, this);
-
       this.on('render', function() {
         this.$el.attr('title', this.options.title || '');
         this.$el.attr('aria-label', this.options.title || this.options.tooltip || '');
@@ -61,7 +53,7 @@ define([
     },
     handleClick: function(e) {
       e.preventDefault();
-      if (!this.$el.is('.disabled')) {
+      if (!this.$el.prop('disabled')) {
         this.uiEventTrigger('click', this, e);
       }
     },
@@ -69,12 +61,10 @@ define([
       return _.extend({'icon': '', 'title': ''}, this.options);
     },
     disable: function() {
-      this.options.disabled = true;
-      this.$el.addClass('disabled');
+      this.$el.prop('disabled', true);
     },
     enable: function() {
-      this.options.disabled = false;
-      this.$el.removeClass('disabled');
+      this.$el.prop('disabled', false);
     }
   });
 

--- a/mockup/js/ui/views/buttongroup.js
+++ b/mockup/js/ui/views/buttongroup.js
@@ -10,12 +10,12 @@ define([
     idPrefix: 'btngroup-',
     disable: function() {
       _.each(this.items, function(button) {
-        button.trigger('disable');
+        button.disable();
       });
     },
     enable: function() {
       _.each(this.items, function(button) {
-        button.trigger('enable');
+        button.enable();
       });
     }
   });

--- a/mockup/patterns/filemanager/js/basepopover.js
+++ b/mockup/patterns/filemanager/js/basepopover.js
@@ -24,7 +24,7 @@ define([
         return;
       }
       var $path = self.$('.current-path');
-      if ($path.length !== 0){
+      if ($path.length !== 0) {
         $path.html(self.getPath());
       }
     },

--- a/mockup/patterns/filemanager/js/customize.js
+++ b/mockup/patterns/filemanager/js/customize.js
@@ -27,20 +27,20 @@ define([
       PopoverView.prototype.render.call(this);
       self.$form = self.$('form');
       self.$results = self.$('.results');
-      self.$form.submit(function(e){
+      self.$form.submit(function(e) {
         e.preventDefault();
         $.ajax({
           url: self.app.options.resourceSearchUrl,
           dataType: 'json',
-          success: function(data){
+          success: function(data) {
             self.$results.empty();
-            _.each(data, function(item){
+            _.each(data, function(item) {
               var $item = $(
                 '<li class="list-group-item" data-id="' + item.id + '">' +
                   '<span class="badge"><a href=#">' + _t('Customize') + '</a></span>' +
                   item.id +
                 '</li>');
-              $('a', $item).click(function(e){
+              $('a', $item).click(function(e) {
                 e.preventDefault();
                 self.customize($(this).parents('li').eq(0).attr('data-id'));
               });

--- a/mockup/patterns/filemanager/js/delete.js
+++ b/mockup/patterns/filemanager/js/delete.js
@@ -21,8 +21,8 @@ define([
     deleteButtonClicked: function(e) {
       var self = this;
       var path = self.app.getNodePath();
-      if( path === undefined ) {
-        alert("No file selected.");
+      if (path === undefined) {
+        alert('No file selected.');
         return;
       }
       self.app.doAction('delete', {
@@ -39,8 +39,8 @@ define([
             parent = parent.substr(0, parent.lastIndexOf('/'));
 
             var node = self.app.getNodeByPath(parent);
-            if( node !== null ) {
-                self.app.$tree.tree('openNode', node);
+            if (node !== null) {
+              self.app.$tree.tree('openNode', node);
             }
 
             self.app.closeActiveTab();

--- a/mockup/patterns/filemanager/js/newfolder.js
+++ b/mockup/patterns/filemanager/js/newfolder.js
@@ -23,7 +23,7 @@ define([
       var self = this;
       var $input = self.$('input');
       var name = $input.val();
-      if (name){
+      if (name) {
         self.app.doAction('addFolder', {
           type: 'POST',
           data: {

--- a/mockup/patterns/filemanager/js/rename.js
+++ b/mockup/patterns/filemanager/js/rename.js
@@ -33,7 +33,7 @@ define([
       var self = this;
       var $input = self.$('input');
       var filename = $input.val();
-      if (filename){
+      if (filename) {
         self.app.doAction('renameFile', {
           type: 'POST',
           data: {
@@ -44,20 +44,19 @@ define([
             self.hide();
             self.data = data;
             self.app.refreshTree(function() {
-              if( self.data.newParent != "/" ) {
-                var path = [self.data.newParent, self.data.newName].join('/');
-                var oldPath = [self.data.oldParent, self.data.oldName].join('/');
-              }
-              else {
-                var path = '/' + self.data.newName;
-                var oldPath = '/' + self.data.oldName
+              var path;
+              var oldPath;
+              if (self.data.newParent != '/') {
+                path = [self.data.newParent, self.data.newName].join('/');
+                oldPath = [self.data.oldParent, self.data.oldName].join('/');
+              } else {
+                path = '/' + self.data.newName;
+                oldPath = '/' + self.data.oldName;
               }
 
-              if( self.app.fileData[path] !== undefined ) {
-                self.app.refreshFile(path)
-              }
-              else {
-                var node = self.app.getNodeByPath(path);
+              if (self.app.fileData[path] !== undefined) {
+                self.app.refreshFile(path);
+              } else {
                 self.app.selectItem(path);
               }
 

--- a/mockup/patterns/filemanager/js/upload.js
+++ b/mockup/patterns/filemanager/js/upload.js
@@ -18,13 +18,11 @@ define([
       self.upload = new Upload(self.$('.uploadify-me').addClass('pat-upload'), {
         url: self.app.options.uploadUrl,
         success: function(response) {
-          if( self.callback ) {
-            if( response.status == "success" ) {  
+          if (self.callback) {
+            if (response.status == 'success') {
               self.callback.apply(self.app, [response]);
-            }
-            else
-            {
-                alert("There was a problem during the upload process");
+            } else {
+              alert('There was a problem during the upload process');
             }
           }
         }
@@ -34,7 +32,6 @@ define([
     toggle: function(button, e) {
       /* we need to be able to change the current default upload directory */
       PopoverView.prototype.toggle.apply(this, [button, e]);
-      var self = this;
       if (!this.opened) {
         return;
       }

--- a/mockup/patterns/filemanager/pattern.filemanager.less
+++ b/mockup/patterns/filemanager/pattern.filemanager.less
@@ -106,7 +106,10 @@
         }
     }
     .navbar {
-        a.btn {
+        .btn-group > a.btn {
+            float: none;
+            display: inline-block;
+            margin-bottom: 0.5em;
             text-decoration: none;
         }
     }
@@ -116,6 +119,11 @@
     .nav-and-editor {
         float: left;
         width: 75%;
+
+        .navbar .navbar-collapse.collapse {
+            // force editor tabs to be displayed
+            height: 37px !important;
+        }
     }
     .navbar-nav > li {
         padding-left: 15px;
@@ -141,7 +149,7 @@
             }
         }
         > a {
-            float: left;
+            display: inline-block;
             padding: 8px 0px;
             text-decoration: none;
             color: @gray-dark;
@@ -156,6 +164,5 @@
             color: @brand-warning;
         }
     }
-
 
 }

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -550,7 +550,7 @@ define([
       self.ace = new TextEditor(self.$editor);
 
       if (self.currentPath === undefined) {
-        self.ace.setText();
+        self.ace.setText('');
         self.ace.setSyntax('text');
         self.ace.editor.clearSelection();
         self.$tree.tree('selectNode', null);

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -30,7 +30,6 @@
  *
  */
 
-
 define([
   'jquery',
   'pat-base',
@@ -51,8 +50,8 @@ define([
   'mockup-utils',
   'text!mockup-ui-url/templates/popover.xml'
 ], function($, Base, _, Tree, TextEditor, AppTemplate, Toolbar,
-            ButtonView, ButtonGroup, AddNewView, NewFolderView, DeleteView,
-            CustomizeView, RenameView, UploadView, _t, utils) {
+  ButtonView, ButtonGroup, AddNewView, NewFolderView, DeleteView,
+  CustomizeView, RenameView, UploadView, _t, utils) {
   'use strict';
 
   var FileManager = Base.extend({
@@ -69,7 +68,8 @@ define([
       '</li>'),
     saveBtn: null,
     uploadFolder: '',
-    fileData: {},  /* mapping of files to data that it describes */
+    fileData: {},
+    /* mapping of files to data that it describes */
     defaults: {
       aceConfig: {},
       actionUrl: null,
@@ -94,17 +94,14 @@ define([
           var themeTypes = ['css', 'html', 'htm', 'txt', 'xml', 'js', 'cfg', 'less'];
 
           $('span', li).addClass('glyphicon');
-          if( node.folder ) {
-            $('span', li).addClass('glyphicon-folder-close')
-          }
-          else if( $.inArray(node.fileType, imageTypes) >= 0) {
+          if (node.folder) {
+            $('span', li).addClass('glyphicon-folder-close');
+          } else if ($.inArray(node.fileType, imageTypes) >= 0) {
             $('span', li).addClass('glyphicon-picture');
-          }
-          else if( $.inArray(node.fileType, themeTypes) >= 0) {
+          } else if ($.inArray(node.fileType, themeTypes) >= 0) {
             $('span', li).addClass('glyphicon-file');
-          }
-          else {
-            $('span', li).addClass('glyphicon-cog')
+          } else {
+            $('span', li).addClass('glyphicon-cog');
           }
         }
       });
@@ -173,7 +170,7 @@ define([
         deleteView.triggerView
       ];
 
-      if (self.options.uploadUrl && utils.featureSupport.dragAndDrop() && utils.featureSupport.fileApi()){
+      if (self.options.uploadUrl && utils.featureSupport.dragAndDrop() && utils.featureSupport.fileApi()) {
         var uploadView = new UploadView({
           triggerView: new ButtonView({
             id: 'upload',
@@ -195,7 +192,7 @@ define([
         self.views.push(uploadView);
         mainButtons.push(uploadView.triggerView);
       }
-      if (self.options.resourceSearchUrl){
+      if (self.options.resourceSearchUrl) {
         var customizeView = new CustomizeView({
           triggerView: new ButtonView({
             id: 'customize',
@@ -222,8 +219,8 @@ define([
       self._save = function() {
 
         var path = $('.active', self.$tabs).data('path');
-        if( path === undefined || path === false ) {
-          alert("No file selected.");
+        if (path === undefined || path === false) {
+          alert('No file selected.');
           return;
         }
         self.doAction('saveFile', {
@@ -234,10 +231,10 @@ define([
             _authenticator: utils.getAuthenticator()
           },
           success: function(data) {
-            if( data['error'] !== undefined ) {
-              alert("There was a problem saving the file.");
+            if (data['error'] !== undefined) {
+              alert('There was a problem saving the file.');
             }
-            $('[data-path="' + path + '"]').removeClass("modified");
+            $('[data-path="' + path + '"]').removeClass('modified');
           }
         });
       };
@@ -247,12 +244,12 @@ define([
       });
       self.render();
     },
-    $: function(selector){
+    $: function(selector) {
       return this.$el.find(selector);
     },
     refreshTree: function(callback) {
       var self = this;
-      if( callback === undefined ) {
+      if (callback === undefined) {
         callback = function() {};
       }
       self.$tree.tree('loadDataFromUrl',
@@ -261,7 +258,7 @@ define([
         callback
       );
     },
-    render: function(){
+    render: function() {
       var self = this;
       self.$el.html(self.template(self.options));
       self.$('#toolbar').append(self.toolbar.render().el);
@@ -275,29 +272,28 @@ define([
       self.$editor = self.$('.editor');
 
       /* close popovers when clicking away */
-      $(document).click(function(e){
-          var $el = $(e.target);
-          if(!$el.is(':visible')){
-              // ignore this, fake event trigger to element that is not visible
-              return;
+      $(document).click(function(e) {
+        var $el = $(e.target);
+        if (!$el.is(':visible')) {
+          // ignore this, fake event trigger to element that is not visible
+          return;
+        }
+        if ($el.is('a') || $el.parent().is('a')) {
+          return;
+        }
+        var $popover = $('.popover:visible');
+        if ($popover.length > 0 && !$.contains($popover[0], $el[0])) {
+          var popover = $popover.data('component');
+          if (popover) {
+            popover.hide();
           }
-          if($el.is('a') || $el.parent().is('a')){
-              return;
-          }
-          var $popover = $('.popover:visible');
-          if($popover.length > 0 && !$.contains($popover[0], $el[0])){
-              var popover = $popover.data('component');
-              if(popover){
-                  popover.hide();
-              }
-          }
+        }
       });
 
       self.$tree.bind('tree.select', function(e) {
-        if( e.node === null ) {
+        if (e.node === null) {
           self.toggleButtons(false);
-        }
-        else{
+        } else {
           self.toggleButtons(true);
           self.handleClick(e);
         }
@@ -317,16 +313,16 @@ define([
 
       self.$tree.bind('tree.init', function(e) {
         var node = self.$tree.tree('getTree').children[0];
-        if( node ) {
+        if (node) {
           self.$tree.tree('selectNode', node);
         }
       });
 
       $(self.$tabs).on('click', function(e) {
         var path = $(e.target).data('path');
-        if( path === undefined ) {
+        if (path === undefined) {
           path = $(e.target.parentElement).data('path');
-          if( path === undefined ) {
+          if (path === undefined) {
             return false;
           }
         }
@@ -337,16 +333,15 @@ define([
       });
     },
     toggleButtons: function(on) {
-      if( on === undefined ) {
+      if (on === undefined) {
         return;
       }
 
-      if( on ) {
+      if (on) {
         $('#btn-delete', this.$el).attr('disabled', false);
         $('#btn-save', this.$el).attr('disabled', false);
         $('#btn-rename', this.$el).attr('disabled', false);
-      }
-      else{
+      } else {
         $('#btn-delete', this.$el).attr('disabled', 'disabled');
         $('#btn-save', this.$el).attr('disabled', 'disabled');
         $('#btn-rename', this.$el).attr('disabled', 'disabled');
@@ -361,9 +356,9 @@ define([
       var self = this;
       var active = self.$tabs.find('.active .remove');
       var $siblings = $(active).parent().siblings();
-      if ($siblings.length > 0){
+      if ($siblings.length > 0) {
         var $item;
-        if ($(active).parent().prev().length > 0){
+        if ($(active).parent().prev().length > 0) {
           $item = $(active).parent().prev();
         } else {
           $item = $(active).parent().next();
@@ -378,21 +373,19 @@ define([
     },
     closeTab: function(path) {
       var self = this;
-      if( path === undefined ) {
+      if (path === undefined) {
         return;
       }
 
       var tabs = self.$tabs.children();
 
       $(tabs).each(function() {
-        if( $(this).data('path') == path )
-        {
+        if ($(this).data('path') == path) {
           $(this).find('a.remove').trigger('click');
         }
       });
     },
     closeActivePopovers: function() {
-      var self = this;
       var active = $('.navbar a.active');
       $(active).each(function() {
         $(this).click();
@@ -400,22 +393,22 @@ define([
     },
     createTab: function(path) {
       var self = this;
-      var $item = $(self.tabItemTemplate({path: path}));
+      var $item = $(self.tabItemTemplate({
+        path: path
+      }));
       self.shrinkTab($item);
       self.$tabs.append($item);
-      $('.remove', $item).click(function(e){
+      $('.remove', $item).click(function(e) {
         e.preventDefault();
         e.stopPropagation();
         self.closeActivePopovers();
-        if ($(this).parent().hasClass('active'))
-        {
+        if ($(this).parent().hasClass('active')) {
           self.closeActiveTab();
-        }
-        else {
+        } else {
           $(this).parent().remove();
         }
       });
-      $('.select', $item).click(function(e){
+      $('.select', $item).click(function(e) {
         e.preventDefault();
         $('li', self.$tabs).removeClass('active');
         var $li = $(this).parent();
@@ -425,60 +418,61 @@ define([
     },
     updateTabs: function(path) {
       var self = this;
-      if( path === undefined ) {
+      if (path === undefined) {
         return;
       }
       $('li', self.$tabs).removeClass('active');
       var $existing = $('[data-path="' + path + '"]', self.$tabs);
-      if ($existing.length === 0){
+      if ($existing.length === 0) {
         self.createTab(path);
-      }else{
+      } else {
         $existing.addClass('active');
       }
     },
     shrinkTab: function(tab) {
-        var self = this;
-        if( self.$tabs.hasClass('smallTabs') ) {
-            tab = $(tab);
-            var text = tab.text();
-            if( text.lastIndexOf('/') > 0 )
-            {
-                text = text.substr(text.lastIndexOf('/') + 1);
-                tab.find('.select').text(text);
-            }
+      var self = this;
+      if (self.$tabs.hasClass('smallTabs')) {
+        tab = $(tab);
+        var text = tab.text();
+        if (text.lastIndexOf('/') > 0) {
+          text = text.substr(text.lastIndexOf('/') + 1);
+          tab.find('.select').text(text);
         }
+      }
     },
     openFile: function(event) {
       var self = this;
-      if( event.node === null ) {
+      if (event.node === null) {
         return true;
       }
-      if (event.node.folder){
-        if( self.options.theme ) {
+      if (event.node.folder) {
+        if (self.options.theme) {
           self.setUploadUrl(event.node.path);
         }
         return true;
       }
       var doc = event.node.path;
-      if(self.fileData[doc]) {
+      if (self.fileData[doc]) {
         self.openEditor(doc);
 
         var resetLine = function() {
-          if( self.fileData[doc].line === undefined ) {
+          if (self.fileData[doc].line === undefined) {
             return;
           }
           self.ace.editor.scrollToLine(self.fileData[doc].line);
-          self.ace.editor.moveCursorToPosition(self.fileData[doc].cursorPosition)
+          self.ace.editor.moveCursorToPosition(self.fileData[doc].cursorPosition);
           //We only want this to fire after the intial render,
           //Not after rendering a "scroll" or "focus" event,
           //So we remove it immediately after.
-          self.ace.editor.renderer.off("afterRender", resetLine);
+          self.ace.editor.renderer.off('afterRender', resetLine);
         };
         //This sets the listener before rendering finishes
-        self.ace.editor.renderer.on("afterRender", resetLine);
+        self.ace.editor.renderer.on('afterRender', resetLine);
       } else {
         self.doAction('getFile', {
-          data: { path: doc },
+          data: {
+            path: doc
+          },
           dataType: 'json',
           success: function(data) {
             self.fileData[doc] = data;
@@ -489,29 +483,24 @@ define([
     },
     getNodeByPath: function(path) {
       var self = this;
-      if( path === undefined || path === "" )
-      {
-       return null;
+      if (path === undefined || path === '') {
+        return null;
       }
 
-      if( path.indexOf('/') === 0 )
-      {
-        path = path.substr(1,path.length);
+      if (path.indexOf('/') === 0) {
+        path = path.substr(1, path.length);
       }
 
       var folders = path.split('/');
       var children = self.$tree.tree('getTree').children;
 
-      for( var i = 0; i < folders.length; i++ )
-      {
-        for( var z = 0; z < children.length; z++ )
-        {
-          if( children[z].name == folders[i] ) {
-            if( children[z].folder == true && i != (folders.length - 1) ) {
+      for (var i = 0; i < folders.length; i++) {
+        for (var z = 0; z < children.length; z++) {
+          if (children[z].name == folders[i]) {
+            if (children[z].folder == true && i != (folders.length - 1)) {
               children = children[z].children;
               break;
-            }
-            else {
+            } else {
               return children[z];
             }
           }
@@ -522,7 +511,7 @@ define([
     },
     doAction: function(action, options) {
       var self = this;
-      if (!options){
+      if (!options) {
         options = {};
       }
       $.ajax({
@@ -539,19 +528,19 @@ define([
     openEditor: function(path) {
       var self = this;
 
-      if( path !== undefined ) {
-          self.updateTabs(path);
+      if (path !== undefined) {
+        self.updateTabs(path);
       }
 
       // first we need to save the current editor content
-      if(self.currentPath) {
+      if (self.currentPath) {
         self.fileData[self.currentPath].contents = self.ace.editor.getValue();
         var lineNum = self.ace.editor.getFirstVisibleRow();
         self.fileData[self.currentPath].line = lineNum;
         self.fileData[self.currentPath].cursorPosition = self.ace.editor.getCursorPosition();
       }
       self.currentPath = path;
-      if (self.ace !== undefined){
+      if (self.ace !== undefined) {
         self.ace.editor.destroy();
         self.ace.editor.container.parentNode.replaceChild(
           self.ace.editor.container.cloneNode(true),
@@ -560,44 +549,41 @@ define([
       }
       self.ace = new TextEditor(self.$editor);
 
-      if( self.currentPath === undefined ) {
-          self.ace.setText();
-          self.ace.setSyntax('text');
-          self.ace.editor.clearSelection();
-          self.$tree.tree('selectNode', null);
-      }
-      else if( typeof self.fileData[path].info !== 'undefined' )
-      {
-          var preview = self.fileData[path].info;
-          if( self.ace.editor !== undefined ) {
-              self.ace.editor.off();
-          }
-          $('.ace_editor').empty().append(preview);
-      }
-      else
-      {
-          self.ace.setText(self.fileData[path].contents);
-          self.ace.setSyntax(path);
-          self.ace.editor.clearSelection();
+      if (self.currentPath === undefined) {
+        self.ace.setText();
+        self.ace.setSyntax('text');
+        self.ace.editor.clearSelection();
+        self.$tree.tree('selectNode', null);
+      } else if (typeof self.fileData[path].info !== 'undefined') {
+        var preview = self.fileData[path].info;
+        if (self.ace.editor !== undefined) {
+          self.ace.editor.off();
+        }
+        $('.ace_editor').empty().append(preview);
+      } else {
+        self.ace.setText(self.fileData[path].contents);
+        self.ace.setSyntax(path);
+        self.ace.editor.clearSelection();
       }
 
       self.resizeEditor();
-      self.$el.trigger("fileChange");
+      self.$el.trigger('fileChange');
       self.ace.editor.on('change', function() {
         if (self.ace.editor.curOp && self.ace.editor.curOp.command.name) {
-          $('[data-path="' + path + '"]').addClass("modified");
+          $('[data-path="' + path + '"]').addClass('modified');
         }
       });
       self.ace.editor.on('paste', function() {
-        $('[data-path="' + path + '"]').addClass("modified");
+        $('[data-path="' + path + '"]').addClass('modified');
       });
       self.ace.editor.commands.addCommand({
         name: 'saveFile',
         bindKey: {
-          win: 'Ctrl-S', mac: 'Command-S',
+          win: 'Ctrl-S',
+          mac: 'Command-S',
           sender: 'editor|cli'
         },
-        exec: function (env, args, request) {
+        exec: function(env, args, request) {
           self._save();
         }
       });
@@ -607,27 +593,27 @@ define([
     },
     getNodePath: function(node) {
       var self = this;
-      if(node === undefined){
+      if (node === undefined) {
         node = self.getSelectedNode();
       }
       var path = self.getFolderPath(node.parent);
-      if (path !== '/'){
+      if (path !== '/') {
         path += '/';
       }
 
       var name = (node.name !== undefined) ? node.name : '';
       return path + name;
     },
-    getFolderPath: function(node){
+    getFolderPath: function(node) {
       var self = this;
-      if(node === undefined){
+      if (node === undefined) {
         node = self.getSelectedNode();
       }
       var parts = [];
-      if (!node.folder && node.name){
+      if (!node.folder && node.name) {
         node = node.parent;
       }
-      while (node.name){
+      while (node.name) {
         parts.push(node.name);
         node = node.parent;
       }
@@ -637,40 +623,42 @@ define([
     getUpload: function() {
       var self = this;
 
-      return _.find(self.views, function(x) { return x.upload !== undefined });
+      return _.find(self.views, function(x) {
+        return x.upload !== undefined;
+      });
     },
     resizeEditor: function() {
-        var self = this;
+      var self = this;
 
-        self.$editor = $('.editor', self.$el);
-        var tab = self.$tabs.children()[0];
-        if( $(tab).outerHeight() < (self.$tabs.height() - 1) ) {
-            self.$tabs.addClass('smallTabs');
-            $(self.$tabs.children()).each(function() {
-                self.shrinkTab(this);
-            });
-        }
-        var tabBox = self.$tabs.parent();
+      self.$editor = $('.editor', self.$el);
+      var tab = self.$tabs.children()[0];
+      if ($(tab).outerHeight() < (self.$tabs.height() - 1)) {
+        self.$tabs.addClass('smallTabs');
+        $(self.$tabs.children()).each(function() {
+          self.shrinkTab(this);
+        });
+      }
+      var tabBox = self.$tabs.parent();
 
-        //Contains both the tabs, and editor window
-        var container = tabBox.parent().parent();
-        var h = container.innerHeight();
-        h -= tabBox.outerHeight();
+      //Contains both the tabs, and editor window
+      var container = tabBox.parent().parent();
+      var h = container.innerHeight();
+      h -= tabBox.outerHeight();
 
-        //+2 for the editor borders
-        h -= 2;
-        //accounts for the borders/margin
-        self.$editor.height(h);
-        var w = container.innerWidth();
-        w -= (container.outerWidth(true) - container.innerWidth());
+      //+2 for the editor borders
+      h -= 2;
+      //accounts for the borders/margin
+      self.$editor.height(h);
+      var w = container.innerWidth();
+      w -= (container.outerWidth(true) - container.innerWidth());
 
-        self.$editor.width(w);
-        if (self.ace !== undefined){
-          //This forces ace to redraw if the container has changed size
-          self.ace.editor.resize();
-          self.ace.editor.$blockScrolling = Infinity;
-          self.ace.editor.focus();
-        }
+      self.$editor.width(w);
+      if (self.ace !== undefined) {
+        //This forces ace to redraw if the container has changed size
+        self.ace.editor.resize();
+        self.ace.editor.$blockScrolling = Infinity;
+        self.ace.editor.focus();
+      }
     },
     selectItem: function(path) {
       var self = this;
@@ -680,18 +668,18 @@ define([
     setUploadUrl: function(path) {
       var self = this;
 
-      if( path === undefined ) {
-        path = "";
+      if (path === undefined) {
+        path = '';
       }
 
       self.uploadFolder = path;
       var view = self.getUpload();
-      if( view !== undefined ) {
+      if (view !== undefined) {
         var url = self.options.uploadUrl +
-                  path +
-                  "/themeFileUpload" +
-                  "?_authenticator=" +
-                  utils.getAuthenticator();
+          path +
+          '/themeFileUpload' +
+          '?_authenticator=' +
+          utils.getAuthenticator();
 
         view.upload.dropzone.options.url = url;
       }
@@ -699,7 +687,7 @@ define([
     refreshFile: function(path) {
       var self = this;
 
-      if( path === undefined ) {
+      if (path === undefined) {
         path = self.getSelectedNode().path;
       }
       self.closeTab(path);

--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -338,13 +338,13 @@ define([
       }
 
       if (on) {
-        $('#btn-delete', this.$el).attr('disabled', false);
-        $('#btn-save', this.$el).attr('disabled', false);
-        $('#btn-rename', this.$el).attr('disabled', false);
+        $('#btn-delete', this.$el).prop('disabled', false);
+        $('#btn-save', this.$el).prop('disabled', false);
+        $('#btn-rename', this.$el).prop('disabled', false);
       } else {
-        $('#btn-delete', this.$el).attr('disabled', 'disabled');
-        $('#btn-save', this.$el).attr('disabled', 'disabled');
-        $('#btn-rename', this.$el).attr('disabled', 'disabled');
+        $('#btn-delete', this.$el).prop('disabled', true);
+        $('#btn-save', this.$el).prop('disabled', true);
+        $('#btn-rename', this.$el).prop('disabled', true);
       }
     },
     handleClick: function(event) {

--- a/mockup/patterns/resourceregistry/js/overrides.js
+++ b/mockup/patterns/resourceregistry/js/overrides.js
@@ -78,7 +78,7 @@ define([
         filepath: that.editing,
         data: that.editor.editor.getValue()
       }, function(){
-        that.$el.find('.plone-btn-primary,.plone-btn-default').addClass('disabled');
+        that.$el.find('.plone-btn-primary,.plone-btn-default').prop('disabled', true);
       });
     },
 
@@ -200,9 +200,9 @@ define([
       that.editor.setSyntax(that.editing);
       that.tabView.loading.hide();
       that.editor.editor.on('change', function(){
-        that.$el.find('.plone-btn-primary,.plone-btn-default').removeClass('disabled');
+        that.$el.find('.plone-btn-primary,.plone-btn-default').prop('disabled', false);
       });
-    }    
+    }
   });
 
   return OverridesView;

--- a/mockup/patterns/thememapper/js/cacheview.js
+++ b/mockup/patterns/thememapper/js/cacheview.js
@@ -3,7 +3,7 @@ define([
   'underscore',
   'mockup-patterns-filemanager-url/js/basepopover',
   'mockup-utils'
-], function($, _, PopoverView, utils ) {
+], function($, _, PopoverView, utils) {
   'use strict';
   var template = _.template(
     '<div>' +
@@ -28,7 +28,7 @@ define([
 
         var url = self.app.options.themeUrl;
         url = url.substr(0, url.indexOf('portal_resource'));
-        url += "/theming-controlpanel";
+        url += '/theming-controlpanel';
 
         $.ajax({
           url: url,
@@ -36,7 +36,7 @@ define([
             'form.button.InvalidateCache': true,
             '_authenticator': utils.getAuthenticator()
           },
-          success: function(response) {
+          success: function() {
             self.$message.hide();
             self.$success.show();
             self.$clear.hide();
@@ -54,7 +54,6 @@ define([
     },
     toggle: function(button, e) {
       PopoverView.prototype.toggle.apply(this, [button, e]);
-      var self = this;
     }
 
   });

--- a/mockup/patterns/thememapper/js/lessbuilderview.js
+++ b/mockup/patterns/thememapper/js/lessbuilderview.js
@@ -50,41 +50,41 @@ define([
       this.setFilename();
     },
     setFilename: function() {
-        var self = this;
+      var self = this;
 
-        if( self.app.lessPaths['save'] === undefined ) {
-            return;
-        }
+      if (self.app.lessPaths['save'] === undefined) {
+        return;
+      }
 
-        var filePath = self.app.lessPaths['less'];
-        var devPath = self.app.devPath[0];
-        var prodPath = self.app.prodPath[0];
+      var filePath = self.app.lessPaths['less'];
+      var devPath = self.app.devPath[0];
+      var prodPath = self.app.prodPath[0];
+      var f;
 
-        if( filePath == devPath ) {
-            var f = prodPath;
-        }
-        else {
-            var f = self.app.lessPaths['save'];
-        }
+      if (filePath == devPath) {
+        f = prodPath;
+      } else {
+        f = self.app.lessPaths['save'];
+      }
 
-        f = f.substr(f.lastIndexOf('/') + 1, f.length);
-        self.$filename.attr('placeholder', f);
+      f = f.substr(f.lastIndexOf('/') + 1, f.length);
+      self.$filename.attr('placeholder', f);
     },
     start: function() {
       var self = this;
       self.$button.show();
       self.$errorButton.hide();
-      self.$message.text("Click to compile the current file");
+      self.$message.text('Click to compile the current file');
       self.$error.hide();
     },
     working: function() {
       var self = this;
       self.$button.hide();
-      self.$message.text("Working....");
+      self.$message.text('Working....');
     },
     end: function() {
       var self = this;
-      self.$message.text("Compiled successfully");
+      self.$message.text('Compiled successfully');
       setTimeout(self.reset.bind(self), 3000);
     },
     reset: function() {
@@ -93,47 +93,49 @@ define([
       self.toggle();
     },
     showError: function(error) {
-      this.$message.text("");
+      this.$message.text('');
       this.$error.text(error).show();
       this.$errorButton.show();
     },
     showLessBuilder: function() {
       var self = this;
 
-      if( self.app.lessPaths['save'] === undefined ) {
-        self.showError("Error: invalid filetype");
+      if (self.app.lessPaths['save'] === undefined) {
+        self.showError('Error: invalid filetype');
         return false;
       }
 
       self.working();
 
       var config = {
-        less: [ self.app.lessVariableUrl,
-                self.app.lessPaths['less'],
-                self.app.lessUrl]
-      }
+        less: [self.app.lessVariableUrl,
+          self.app.lessPaths['less'],
+          self.app.lessUrl
+        ]
+      };
 
       var iframe = new IFrame({
         name: 'lessc',
         resources: config.less,
         callback: self.app.saveThemeCSS,
         env: self.app,
-        configure: function(iframe){
-          iframe.window.lessErrorReporting = function(what, error, href){
-            if( error.href !== undefined )
-            {
+        configure: function(iframe) {
+          iframe.window.lessErrorReporting = function(what, error, href) {
+            if (error.href !== undefined) {
               self.app.fileManager.ace.editor.scrollToLine(error.line, true);
-              if( error.type == "Name" ) {
-                var reg = new RegExp(".*(@\\S+)\\s.*");
+              if (error.type == 'Name') {
+                var reg = new RegExp('.*(@\\S+)\\s.*');
                 var matches = reg.exec(error.message);
-                if( matches !== null ) {
+                if (matches !== null) {
                   var varName = matches[1];
                   var result = self.app.fileManager.ace.editor.findAll(varName);
                 }
-              }
-              else {
+              } else {
                 //The line number is always off by 1? (and LESS indexes from 0) so -2
-                self.app.fileManager.ace.editor.moveCursorToPosition({row: error.line - 2, column: error.column});
+                self.app.fileManager.ace.editor.moveCursorToPosition({
+                  row: error.line - 2,
+                  column: error.column
+                });
                 self.app.fileManager.ace.editor.focus();
               }
               self.showError(error);
@@ -148,10 +150,10 @@ define([
               var iframe = window.iframe['lessc'];
               var styles = $('style', iframe.document);
 
-              var css = "";
+              var css = '';
 
               $(styles).each(function() {
-                 css += this.innerHTML;
+                css += this.innerHTML;
               });
 
               iframe.options.callback(css);

--- a/mockup/patterns/thememapper/js/rulebuilder.js
+++ b/mockup/patterns/thememapper/js/rulebuilder.js
@@ -4,14 +4,14 @@ define([
 ], function($, _) {
   'use strict';
 
-  var RuleBuilder = function(thememapper){
+  var RuleBuilder = function(thememapper) {
     /**
-      * Rule builder
-      *
-      * Contains functions to build CSS and XPath selectors as well as a Diazo rule
-      * from a given node, and acts as a state machine for the rules wizard.
-      *
-      */
+     * Rule builder
+     *
+     * Contains functions to build CSS and XPath selectors as well as a Diazo rule
+     * from a given node, and acts as a state machine for the rules wizard.
+     *
+     */
 
     var self = this;
     self.thememapper = thememapper;
@@ -35,22 +35,19 @@ define([
       el: self.thememapper.rulebuilderView.el,
       button: self.thememapper.rulebuilderView.triggerView.el,
       isOpened: function() {
-        return $(this.el).is(":visible");
+        return $(this.el).is(':visible');
       },
       close: function() {
-        if( this.isOpened() ) {
-          if( self.active && $els.step2.is(":visible") )
-          {
+        if (this.isOpened()) {
+          if (self.active && $els.step2.is(':visible')) {
             self.end();
-          }
-          else
-          {
+          } else {
             $(this.button).click();
           }
         }
       },
       load: function() {
-        if( !this.isOpened() ) {
+        if (!this.isOpened()) {
           $(this.button).click();
         }
       }
@@ -58,17 +55,17 @@ define([
 
     var $els = {
       reusePanel: $('#new-rule-reuse-panel'),
-      reuseSelectors: $("#new-rule-reuse-selectors"),
-      selectTheme: $("#new-rule-select-theme"),
-      selectThemeNext: $("#new-rule-select-theme .next"),
-      selectContentNext: $("#new-rule-select-content .next"),
-      wizardSteps: $(".rule-wizard-step"),
-      selectContent: $("#new-rule-select-content"),
-      step1: $("#new-rule-step-1"),
-      step1Next: $("#new-rule-step-1 .next"),
-      step2: $("#new-rule-step-2"),
-      step2Insert: $("#new-rule-step-2 .insert"),
-      step2Copy: $("#new-rule-step-2 .copy"),
+      reuseSelectors: $('#new-rule-reuse-selectors'),
+      selectTheme: $('#new-rule-select-theme'),
+      selectThemeNext: $('#new-rule-select-theme .next'),
+      selectContentNext: $('#new-rule-select-content .next'),
+      wizardSteps: $('.rule-wizard-step'),
+      selectContent: $('#new-rule-select-content'),
+      step1: $('#new-rule-step-1'),
+      step1Next: $('#new-rule-step-1 .next'),
+      step2: $('#new-rule-step-2'),
+      step2Insert: $('#new-rule-step-2 .insert'),
+      step2Copy: $('#new-rule-step-2 .copy'),
       inspectors: self.thememapper.$inspectorContainer,
       ruleOutput: $('#new-rule-output'),
       themePanel: $('#inspectors .mockup-inspector'),
@@ -95,7 +92,7 @@ define([
     $els.selectThemeNext.click(function() {
       self.themeInspector.on();
 
-      if(!$els.inspectors.is(":visible")) {
+      if (!$els.inspectors.is(':visible')) {
         self.thememapper.showInspectors();
       }
 
@@ -103,7 +100,7 @@ define([
       self.ruleBuilderPopover.close();
 
       $els.themePanel.expose({
-        color: "#fff",
+        color: '#fff',
         closeOnClick: false,
         closeOnEsc: false,
         closeSpeed: 0,
@@ -132,21 +129,20 @@ define([
 
       function indent(string, amount) {
         var padding = '';
-        for(var i = 0; i < amount; ++i) {
+        for (var i = 0; i < amount; ++i) {
           padding += ' ';
         }
         return '\n' + padding + string.replace(/\n/g, '\n' + padding) + '\n';
       }
 
       //If we're already starting at the very end, go back to the beginning
-      if( session.getDocument().$lines.length == aceEditor.getSelectionRange().end.row + 1)
-      {
+      if (session.getDocument().$lines.length == aceEditor.getSelectionRange().end.row + 1) {
         aceEditor.navigateFileStart();
       }
 
       // Go to the next opening tag - we want to insert before this
       findStartTag(false);
-      if(aceEditor.getCursorPosition().row <= 1) {
+      if (aceEditor.getCursorPosition().row <= 1) {
         // Probably the opening rules tag
         findStartTag(false);
       }
@@ -154,16 +150,16 @@ define([
       var selectionText = aceEditor.getSelectedText();
 
       // If we didn't find anything, look for the end of the current tag
-      if(selectionText == "") {
-        aceEditor.find("(/>|</)", {
+      if (selectionText === '') {
+        aceEditor.find('(/>|</)', {
           backwards: false,
           wrap: false,
           wholeWord: false,
           regExp: true
         });
 
-        var selectionText = aceEditor.getSelectedText();
-        if(selectionText == "") {
+        selectionText = aceEditor.getSelectedText();
+        if (selectionText === '') {
           // Still nothing? Go to the end
           aceEditor.navigateFileEnd();
         } else {
@@ -176,7 +172,7 @@ define([
       var cursorPosition = aceEditor.getCursorPosition();
       var newlines = rule.match(/\n/g);
       var rows = 0;
-      if(newlines != null) {
+      if (newlines != null) {
         rows = newlines.length;
       }
 
@@ -197,7 +193,7 @@ define([
 
     $els.selectContentNext.click(function() {
       self.unthemedInspector.on();
-      if(!$els.inspectors.is(":visible")) {
+      if (!$els.inspectors.is(':visible')) {
         self.thememapper.showInspectors();
       }
 
@@ -205,7 +201,7 @@ define([
       self.ruleBuilderPopover.close();
 
       $els.unthemedPanel.expose({
-        color: "#fff",
+        color: '#fff',
         closeOnClick: false,
         closeOnEsc: false,
         closeSpeed: 0,
@@ -232,8 +228,7 @@ define([
     self.start = function(ruleType) {
       var self = this;
 
-      if( ruleType === undefined )
-      {
+      if (ruleType === undefined) {
         ruleType = self.getSelectedType();
       }
 
@@ -242,18 +237,18 @@ define([
 
       self._contentElement = null;
       self._themeElement = null;
-      self.currentScope = "theme";
+      self.currentScope = 'theme';
 
       // Drop rules get e.g. drop:content or drop:theme,
       // which predetermines the scope
       var ruleSplit = ruleType.split(':');
-      if(ruleSplit.length >= 2) {
-          self.ruleType = ruleSplit[0];
-          self.subtype = ruleSplit[1];
-          self.currentScope = self.subtype;
-      } else{
-          self.ruleType = ruleType;
-          self.subtype = null;
+      if (ruleSplit.length >= 2) {
+        self.ruleType = ruleSplit[0];
+        self.subtype = ruleSplit[1];
+        self.currentScope = self.subtype;
+      } else {
+        self.ruleType = ruleType;
+        self.subtype = null;
       }
 
       self.active = true;
@@ -262,9 +257,9 @@ define([
     };
 
     /**
-    * Build a diazo rule. 'themeChildren' and 'contentChildren' should be true or
-    * false to indicate whether a -children selector is to be used.
-    */
+     * Build a diazo rule. 'themeChildren' and 'contentChildren' should be true or
+     * false to indicate whether a -children selector is to be used.
+     */
     self.buildRule = function(themeChildren, contentChildren) {
       if (self.ruleType === null) {
         return '';
@@ -293,9 +288,9 @@ define([
     };
 
     /**
-    * Return a valid (but not necessarily unique) CSS selector for the given
-    * element.
-    */
+     * Return a valid (but not necessarily unique) CSS selector for the given
+     * element.
+     */
     self.calculateCSSSelector = function(element) {
       var selector = element.tagName.toLowerCase();
 
@@ -303,10 +298,10 @@ define([
         selector += '#' + element.id;
       } else {
         var classes = $(element).attr('class');
-        if(classes !== undefined) {
+        if (classes !== undefined) {
           var splitClasses = classes.split(/\s+/);
-          for(var i = 0; i < splitClasses.length; i=i+1) {
-            if(splitClasses[i] !== '' && splitClasses[i].indexOf('_theming') === -1) {
+          for (var i = 0; i < splitClasses.length; i = i + 1) {
+            if (splitClasses[i] !== '' && splitClasses[i].indexOf('_theming') === -1) {
               selector += '.' + splitClasses[i];
               break;
             }
@@ -318,9 +313,9 @@ define([
     };
 
     /**
-    * Return a valid, unqiue CSS selector for the given element. Returns null if
-    * no reasoanble unique selector can be built.
-    */
+     * Return a valid, unqiue CSS selector for the given element. Returns null if
+     * no reasoanble unique selector can be built.
+     */
     self.calculateUniqueCSSSelector = function(element) {
       var paths = [];
       var path = null;
@@ -330,12 +325,12 @@ define([
 
       while (element && element.nodeType === 1) {
         var selector = this.calculateCSSSelector(element);
-            paths.splice(0, 0, selector);
-            path = paths.join(' ');
+        paths.splice(0, 0, selector);
+        path = paths.join(' ');
 
         // The ultimateParent constraint is necessary since
         // this may be inside an iframe
-        if($(path, ultimateParent).length === 1) {
+        if ($(path, ultimateParent).length === 1) {
           return path;
         }
 
@@ -346,14 +341,14 @@ define([
     };
 
     /**
-    * Return a valid, unique XPath selector for the given element.
-    */
+     * Return a valid, unique XPath selector for the given element.
+     */
     self.calculateUniqueXPathExpression = function(element) {
       var parents = $(element).parents();
 
       function elementIndex(e) {
         var siblings = $(e).siblings(e.tagName.toLowerCase());
-        if(siblings.length > 0) {
+        if (siblings.length > 0) {
           return '[' + ($(e).index() + 1) + ']';
         } else {
           return '';
@@ -361,17 +356,17 @@ define([
       }
 
       var xpathString = '/' + element.tagName.toLowerCase();
-      if(element.id) {
+      if (element.id) {
         return '/' + xpathString + '[@id=\'' + element.id + '\']';
       } else {
         xpathString += elementIndex(element);
       }
 
-      for(var i = 0; i < parents.length; i=i+1) {
+      for (var i = 0; i < parents.length; i = i + 1) {
         var p = parents[i];
         var pString = '/' + p.tagName.toLowerCase();
 
-        if(p.id) {
+        if (p.id) {
           return '/' + pString + '[@id=\'' + p.id + '\']' + xpathString;
         } else {
           xpathString = pString + elementIndex(p) + xpathString;
@@ -382,27 +377,28 @@ define([
     };
 
     /**
-    * Return a unique CSS or XPath selector, preferring a CSS one.
-    */
+     * Return a unique CSS or XPath selector, preferring a CSS one.
+     */
     self.bestSelector = function(element) {
       return self.calculateUniqueCSSSelector(element) ||
-             self.calculateUniqueXPathExpression(element);
+        self.calculateUniqueXPathExpression(element);
     };
 
     self.openRuleFile = function() {
 
       var fileManager = self.thememapper.fileManager;
 
-      var treeNodes = fileManager.$tree.tree('getTree')
-      var opened = false
+      var treeNodes = fileManager.$tree.tree('getTree');
+      var opened = false;
 
       _.each(treeNodes.children, function(node) {
-        if( node.name == self.rulesFilename )
-        {
+        if (node.name == self.rulesFilename) {
           //if it's open already, don't reopen it.
           //That will move the cursors location
-          if( fileManager.$tabs.find('.active').data('path') != '/' + self.rulesFilename ) {
-            self.thememapper.fileManager.openFile({node: node});
+          if (fileManager.$tabs.find('.active').data('path') != '/' + self.rulesFilename) {
+            self.thememapper.fileManager.openFile({
+              node: node
+            });
           }
           opened = true;
         }
@@ -411,16 +407,16 @@ define([
     };
 
     /**
-    * Build a Diazo selector element with the appropriate namespace.
-    */
+     * Build a Diazo selector element with the appropriate namespace.
+     */
     self.calculateDiazoSelector = function(element, scope, children) {
       var selectorType = scope;
-      if(children) {
+      if (children) {
         selectorType += '-children';
       }
 
       var cssSelector = self.calculateUniqueCSSSelector(element);
-      if(cssSelector) {
+      if (cssSelector) {
         return 'css:' + selectorType + '="' + cssSelector + '"';
       } else {
         var xpathSelector = self.calculateUniqueXPathExpression(element);
@@ -430,66 +426,68 @@ define([
     };
 
     self.select = function(element) {
-      if(this.currentScope == "theme") {
+      if (this.currentScope == 'theme') {
         this._themeElement = element;
-      } else if(this.currentScope == "content") {
+      } else if (this.currentScope == 'content') {
         this._contentElement = element;
       }
     };
 
     self.getSelectedType = function() {
-      var type = $("input[name='new-rule-type']:checked").val();
+      var type = $('input[name=\'new-rule-type\']:checked').val();
       return type;
     };
 
     self.next = function() {
-        var self = this;
-        if(self.subtype !== null) {
-            // Drop rules have only one scope
-            self.currentScope = null;
-        } else {
-            // Other rules have content and theme
-            if(self.currentScope == "theme") {
-                self.currentScope = "content";
-            } else if (self.currentScope == "content") {
-                self.currentScope = null;
-            }
+      var self = this;
+      if (self.subtype !== null) {
+        // Drop rules have only one scope
+        self.currentScope = null;
+      } else {
+        // Other rules have content and theme
+        if (self.currentScope == 'theme') {
+          self.currentScope = 'content';
+        } else if (self.currentScope == 'content') {
+          self.currentScope = null;
         }
-        this.callback(this);
+      }
+      this.callback(this);
     };
 
     self.updateRule = function() {
-        $els.ruleOutput.val(
-            self.buildRule(
-                $els.newRuleThemeChildren.is(':checked'),
-                $els.newRuleUnthemedChildren.is(':checked')
-            )
-        );
+      $els.ruleOutput.val(
+        self.buildRule(
+          $els.newRuleThemeChildren.is(':checked'),
+          $els.newRuleUnthemedChildren.is(':checked')
+        )
+      );
     };
 
     self.scrollTo = function(selector) {
-      if( $(selector).length == 0 ) {
+      if ($(selector).length == 0) {
         return;
       }
 
-      $('html,body').animate({scrollTop: $(selector).offset().top}, 600);
+      $('html,body').animate({
+        scrollTop: $(selector).offset().top
+      }, 600);
     };
 
     /**
-    *   Called by the rulebuilderView. If there are selected
-    *   elements in the inspectors, we want to give the user the
-    *   option to use those.
-    */
+     *   Called by the rulebuilderView. If there are selected
+     *   elements in the inspectors, we want to give the user the
+     *   option to use those.
+     */
     self.checkSelectors = function() {
       var selected = false;
       $('.selector-info').each(function() {
-        if( $(this).text() != "" ) {
+        if ($(this).text() != '') {
           //Theres an item selected, so show the option to use it
           $els.reusePanel.show();
           selected = true;
         }
       });
-      if( !selected ) {
+      if (!selected) {
         //if we opened the panel previously, close it now
         $els.reusePanel.hide();
       }
@@ -501,13 +499,13 @@ define([
       var themeFrameHighlighter = this.thememapper.mockupInspector;
       var unthemedFrameHighlighter = this.thememapper.unthemedInspector;
 
-      if($.mask.isLoaded(true) && !self.ruleBuilderPopover.isOpened()) {
+      if ($.mask.isLoaded(true) && !self.ruleBuilderPopover.isOpened()) {
         self.scrollTo(self.thememapper.fileManager.$el);
         $.mask.close();
       }
 
-      if(ruleBuilder.currentScope == 'theme') {
-        if(themeFrameHighlighter.saved != null && $els.reuseSelectors.is(":checked")) {
+      if (ruleBuilder.currentScope == 'theme') {
+        if (themeFrameHighlighter.saved != null && $els.reuseSelectors.is(':checked')) {
           self.ruleBuilderPopover.close();
 
           // Use saved rule
@@ -516,13 +514,13 @@ define([
         } else {
           // Let the frame highlighter perform a selection
           $els.selectTheme.show();
-          if(!self.ruleBuilderPopover.isOpened()) {
+          if (!self.ruleBuilderPopover.isOpened()) {
             self.ruleBuilderPopover.load();
           }
         }
 
-      } else if(ruleBuilder.currentScope == 'content') {
-        if(unthemedFrameHighlighter.saved != null && $els.reuseSelectors.is(":checked")) {
+      } else if (ruleBuilder.currentScope == 'content') {
+        if (unthemedFrameHighlighter.saved != null && $els.reuseSelectors.is(':checked')) {
           self.ruleBuilderPopover.close();
 
           // Use saved rule
@@ -531,37 +529,37 @@ define([
         } else {
           // Let the frame highlighter perform a selection
           $els.selectContent.show();
-          if(!self.ruleBuilderPopover.isOpened()) {
+          if (!self.ruleBuilderPopover.isOpened()) {
             self.ruleBuilderPopover.load();
           }
         }
 
-      } else if(ruleBuilder.ruleType != null && ruleBuilder.currentScope == null) {
+      } else if (ruleBuilder.ruleType != null && ruleBuilder.currentScope == null) {
 
         $els.wizardSteps.hide();
         $els.step2.show();
         self.updateRule(ruleBuilder);
 
-        if( self.openRuleFile() ) {
+        if (self.openRuleFile()) {
           $els.step2Insert.show();
         } else {
           $els.step2Insert.hide();
         }
 
-        if(!self.ruleBuilderPopover.isOpened()) {
+        if (!self.ruleBuilderPopover.isOpened()) {
           self.ruleBuilderPopover.load();
         }
 
       } else { // end
 
-        if(self.ruleBuilderPopover.isOpened()) {
+        if (self.ruleBuilderPopover.isOpened()) {
           self.ruleBuilderPopover.close();
         }
 
         $els.wizardSteps.hide();
         $els.step1.show();
       }
-    }
+    };
   };
 
   return RuleBuilder;

--- a/mockup/patterns/thememapper/js/rulebuilderview.js
+++ b/mockup/patterns/thememapper/js/rulebuilderview.js
@@ -2,7 +2,7 @@ define([
   'underscore',
   'mockup-patterns-filemanager-url/js/basepopover',
   'text!mockup-patterns-thememapper-url/templates/rulebuilder.xml',
-], function(_, PopoverView, RulebuilderTemplate ) {
+], function(_, PopoverView, RulebuilderTemplate) {
   'use strict';
   var rulebuilderTemplate = _.template(RulebuilderTemplate);
 
@@ -11,16 +11,14 @@ define([
     title: _.template('<%= _t("Rule Builder") %>'),
     content: rulebuilderTemplate,
     render: function() {
-      var self = this;
       PopoverView.prototype.render.call(this);
       return this;
     },
     toggle: function(button, e) {
       PopoverView.prototype.toggle.apply(this, [button, e]);
-      var self = this;
       if (!this.opened) {
         return;
-      }else {
+      } else {
         this.app.ruleBuilder.checkSelectors();
       }
     }

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -306,7 +306,6 @@ define([
       self.$unthemedInspector = $('<div class="unthemed-inspector"/>').appendTo(self.$inspectorContainer);
 
       // initialize patterns now
-      self.editable = (self.options.editable == 'True') ? true : false;
       self.lessUrl = (self.options.lessUrl !== undefined ) ? self.options.lessUrl : false;
       self.lessVariableUrl = (self.options.lessVariables !== undefined ) ? self.options.lessVariables : false;
 
@@ -340,8 +339,8 @@ define([
       });
       self.buildLessButton.disable();
 
-      if( !self.editable ) {
-        if( self.fileManager.toolbar ) {
+      if(!self.options.editable) {
+        if(self.fileManager.toolbar) {
           var items = self.fileManager.toolbar.items;
           $(items).each(function() {
             this.disable();

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -26,7 +26,6 @@
  *
  */
 
-
 define([
   'jquery',
   'pat-base',
@@ -227,7 +226,7 @@ define([
       var originalBg = self.$frameInfo.css('background-color');
 
       if (!originalBg || originalBg === highlightBg){
-          originalBg = '#FFFFFF'; // default to white
+        originalBg = '#FFFFFF'; // default to white
       }
 
       self.$frameInfo
@@ -245,7 +244,7 @@ define([
       }
 
       self.animateSelector(self.$el.find('.frame-info'));
-      self.$el.find('.selector-info').text(node == null? "" : self.ruleBuilder.bestSelector(node));
+      self.$el.find('.selector-info').text(node == null? '': self.ruleBuilder.bestSelector(node));
 
       if(self.ruleBuilder.active) {
         self.ruleBuilder.select(node);
@@ -255,7 +254,7 @@ define([
     },
     onselect: function(highlighter, node) {
       var self = this;
-      self.$currentSelector.text(node == null? "" : self.ruleBuilder.bestSelector(node));
+      self.$currentSelector.text(node == null? '': self.ruleBuilder.bestSelector(node));
     }
   });
 
@@ -307,7 +306,7 @@ define([
       self.$unthemedInspector = $('<div class="unthemed-inspector"/>').appendTo(self.$inspectorContainer);
 
       // initialize patterns now
-      self.editable = (self.options.editable == "True") ? true : false;
+      self.editable = (self.options.editable == 'True') ? true : false;
       self.lessUrl = (self.options.lessUrl !== undefined ) ? self.options.lessUrl : false;
       self.lessVariableUrl = (self.options.lessVariables !== undefined ) ? self.options.lessVariables : false;
 
@@ -323,7 +322,7 @@ define([
 
       self.ruleBuilder = new RuleBuilder(self, self.ruleBuilderCallback);
 
-      self.fileManager.on("fileChange", function() {
+      self.fileManager.on('fileChange', function() {
         var node = self.fileManager.getSelectedNode();
         self.setLessPaths(node);
       });
@@ -339,8 +338,6 @@ define([
         ruleBuilder: self.ruleBuilder,
         url: self.options.unthemedUrl,
       });
-      self.fileManager.$tree.bind('tree.click', function(e){
-      });
       self.buildLessButton.disable();
 
       if( !self.editable ) {
@@ -351,7 +348,7 @@ define([
           });
           self.lessbuilderView.triggerView.disable();
         }
-      };
+      }
 
       // initially, let's hide the panels
       self.hideInspectors();
@@ -366,42 +363,42 @@ define([
           path: 'manifest.cfg'
         },
         success: function(data) { this.setDefaultPaths(data); }.bind(self)
-      })
+      });
     },
     setSavePath: function() {
-        var self = this;
-        var filename = self.lessbuilderView.$filename.val()
+      var self = this;
+      var filename = self.lessbuilderView.$filename.val();
 
-        if( filename == "" ) {
-            filename = self.lessbuilderView.$filename.attr('placeholder');
-        }
+      if(filename === '') {
+        filename = self.lessbuilderView.$filename.attr('placeholder');
+      }
 
-        var s = self.lessPaths['save'];
-        var folder = s.substr(0, s.lastIndexOf('/'));
+      var s = self.lessPaths['save'];
+      var folder = s.substr(0, s.lastIndexOf('/'));
 
-        var savePath = folder + '/' + filename;
-        self.lessPaths['save'] = savePath;
+      var savePath = folder + '/' + filename;
+      self.lessPaths['save'] = savePath;
     },
     setLessPaths: function(node) {
       var self = this;
 
-      if( node.fileType == "less" ){
+      if(node.fileType === 'less'){
         self.buildLessButton.enable();
       }
-      else{
+      else {
         self.buildLessButton.disable();
       }
 
-      if( node.path != "" ) {
-        var reg = new RegExp("/(.*\\.)less$", "m");
+      if (node.path !== '') {
+        var reg = new RegExp('/(.*\\.)less$', 'm');
         var path = reg.exec(node.path);
 
         if( path === null ) {
           self.lessPaths = {};
           return false;
         }
-        var lessPath = path[1] + "less";
-        var cssPath = path[1] + "css";
+        var lessPath = path[1] + 'less';
+        var cssPath = path[1] + 'css';
 
         //file paths should be in the form of:
         // "[directory/]filename.less"
@@ -419,8 +416,8 @@ define([
     },
     setDefaultPaths: function(manifest) {
       var self = this;
-      var dev = new RegExp("development-css\\s*=\\s*\\/\\+\\+theme\\+\\+.*?\\/(.*)");
-      var prod = new RegExp("production-css\\s*=\\s*\\/\\+\\+theme\\+\\+.*?\\/(.*)");
+      var dev = new RegExp('development-css\\s*=\\s*\\/\\+\\+theme\\+\\+.*?\\/(.*)');
+      var prod = new RegExp('production-css\\s*=\\s*\\/\\+\\+theme\\+\\+.*?\\/(.*)');
 
       var devUrl = dev.exec(manifest.contents)[1];
       var prodUrl = prod.exec(manifest.contents)[1];
@@ -432,7 +429,7 @@ define([
     saveThemeCSS: function(styles) {
       var self = this.env;
 
-      if( styles === "" || styles === undefined ) {
+      if(styles === '' || styles === undefined) {
         //There was probably a problem during compilation
         return false;
       }
@@ -448,17 +445,17 @@ define([
           _authenticator: utils.getAuthenticator()
         },
         success: function(data) {
-          if(data.success == 'tmp') {
+          if (data.success === 'tmp') {
             self.fileManager.fileData['_generated_.css'] = {
               contents: data.value,
               ext: 'css'
-            }
+            };
             self.fileManager.openEditor('_generated_.css');
           } else {
             self.fileManager.refreshTree(function() {
               //We need to make sure we open the newest version
-              delete self.fileManager.fileData['/' + self.lessPaths['save']]
-              self.fileManager.selectItem(self.lessPaths['save'])
+              delete self.fileManager.fileData['/' + self.lessPaths['save']];
+              self.fileManager.selectItem(self.lessPaths['save']);
             });
           }
           self.lessbuilderView.end();
@@ -520,7 +517,7 @@ define([
       });
       self.fullscreenButton.on('button:click', function() {
         var btn = $('<a href="#">'+
-            '<span class="btn btn-danger closeeditor">' + _t("Close Fullscreen") + '</span>'+
+            '<span class="btn btn-danger closeeditor">' + _t('Close Fullscreen') + '</span>'+
             '</a>').prependTo($('.tree'));
 
         $(btn).click(function() {
@@ -554,7 +551,7 @@ define([
         tooltip: _t('Reload the current file'),
         context: 'default'
       });
-      self.refreshButton.on("button:click", function() {
+      self.refreshButton.on('button:click', function() {
         self.fileManager.refreshFile();
       });
       self.cacheButton = new ButtonView({
@@ -581,7 +578,7 @@ define([
       self.cacheView = new CacheView({
         triggerView: self.cacheButton,
         app: self
-      })
+      });
       self.lessbuilderView = new LessBuilderView({
         triggerView: self.buildLessButton,
         app: self

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -326,11 +326,13 @@ body.plone-toolbar-left-default {
     }
 
     .pat-filemanager .navbar .btn-group > a.btn {
+        float: none;
+        display: inline-block;
         line-height: 10px;
         padding: 5px;
         font-size: small;
         padding-bottom: 8px;
-        margin-bottom: -15px;
+        margin-bottom: 0.5em;
     }
 
     .btn-group {

--- a/mockup/patterns/thememapper/templates/inspector.xml
+++ b/mockup/patterns/thememapper/templates/inspector.xml
@@ -25,7 +25,7 @@
 
   <div class="panel-footer">
     <div class="btn-group">
-      <button class="btn btn-default turnon" disabled="disabled" i18n:translate="">Inspector on</button>
+      <button class="btn btn-default turnon" disabled i18n:translate="">Inspector on</button>
       <button class="btn btn-default turnoff" i18n:translate="">Inspector off</button>
     </div>
   </div>

--- a/mockup/patterns/upload/templates/upload.xml
+++ b/mockup/patterns/upload/templates/upload.xml
@@ -13,7 +13,7 @@
                 <input
                     id="fakeUploadFile"
                     placeholder="<%- _t("Choose File") %>"
-                    disabled="disabled"
+                    disabled
                     />
             </div>
             <div class="col-md-3">


### PR DESCRIPTION
- Fix setting empty ace editor instance by passing an empty text.

- Unify disabling of buttons by using setting the ``disabled`` DOM property instead using classes.
  Fixes thememapper button staying disabled all the time.

- Autoformat + eslint fixes for thememapper and filemanager patterns.

- Update ``ace-builds`` to 1.2.6, which fixes IME handling in new Chrome.

Related & merge together:
https://github.com/plone/mockup/pull/754
https://github.com/plone/Products.CMFPlone/pull/1992
https://github.com/plone/plone.app.theming/pull/124