### PR TITLE
More structure widget optimizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Breaking changes:
 
 New features:
 
+- Add default plone color less variables for a more consistent design.
+  They will be overwritten by values set by Plone or integration projects.
+  [thet]
+
 - Structure widget:
   - Show ineffective label in folder contents for not yet effective and published content, likewise it's done with expires.
     Show effective and ineffective label styled as bootstrap badges.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Breaking changes:
 
 New features:
 
+- Show ineffective label in folder contents for not yet effective and published content, likewise it's done with expires.
+  Show effective and ineffective label styled as bootstrap badges.
+  [thet]
+
 - Related Items widget:
     - Add new mode "auto", which automatically sets ``search`` mode when a searchterm is present, otherwise ``browse`` mode.
     - Use searchterm as substring, which matches also within words by wrapping searchterm with the "*" wildcard.
@@ -18,6 +22,7 @@ New features:
     - Filter out non-selectable and non-folderish items in the result set when in browse mode.
     - Add option to scan the selected list of items for other patterns.
     - Add option for contextPath - objects with this path will not be selectable. This prevents the object where the relation is set on to from being selected and self-referenced.
+  [thet]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,10 @@ Breaking changes:
 
 New features:
 
-- Show ineffective label in folder contents for not yet effective and published content, likewise it's done with expires.
-  Show effective and ineffective label styled as bootstrap badges.
+- Structure widget:
+  - Show ineffective label in folder contents for not yet effective and published content, likewise it's done with expires.
+    Show effective and ineffective label styled as bootstrap badges.
+  - Show "Description" below title, if it's set in ``availableColumns`` and ``activeColumns`` to save some screen space.
   [thet]
 
 - Related Items widget:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ New features:
   - Show ineffective label in folder contents for not yet effective and published content, likewise it's done with expires.
     Show effective and ineffective label styled as bootstrap badges.
   - Show "Description" below title, if it's set in ``availableColumns`` and ``activeColumns`` to save some screen space.
+  - Don't underline actionmenu links.
   [thet]
 
 - Related Items widget:

--- a/mockup/less/mixins.less
+++ b/mockup/less/mixins.less
@@ -1,4 +1,11 @@
 @isBrowser: false;
 @pathPrefix: '';
 @isMockup: true;
-@plone-link-color: "black";
+// Plone toolbar colors. Will be overwritten.
+@plone-link-color:                          #007bb3;
+@plone-toolbar-published-color:             @plone-link-color;
+@plone-toolbar-draft-color:                 #fab82a;
+@plone-toolbar-pending-color:               #e2e721;
+@plone-toolbar-private-color:               #c4183c;
+@plone-toolbar-internal-color:              #fab82a;
+@plone-toolbar-internally-published-color:  #883dfa;

--- a/mockup/patterns/structure/js/views/tablerow.js
+++ b/mockup/patterns/structure/js/views/tablerow.js
@@ -28,12 +28,20 @@ define([
       this.now = moment();
     },
 
-    expired: function(data){
-      if(!data.attributes.ExpirationDate){
+    expired: function(data) {
+      if (!data.attributes.ExpirationDate) {
         return false;
       }
       var dt = moment(data.attributes.ExpirationDate);
       return dt.diff(this.now, 'seconds') < 0;
+    },
+
+    ineffective: function(data) {
+      if (!data.attributes.EffectiveDate) {
+        return false;
+      }
+      var dt = moment(data.attributes.EffectiveDate);
+      return dt.diff(this.now, 'seconds') > 0;
     },
 
     render: function() {
@@ -56,6 +64,7 @@ define([
 
       data._t = _t;
       data.expired = this.expired(data);
+      data.ineffective = this.ineffective(data);
       self.$el.html(self.template(data));
       var attrs = self.model.attributes;
       self.$el.addClass('state-' + attrs['review_state']).addClass('type-' + attrs.portal_type); // jshint ignore:line
@@ -68,9 +77,14 @@ define([
       self.$el.attr('data-type', data.portal_type);
       self.$el.attr('data-folderish', data['is_folderish']); // jshint ignore:line
       self.$el.removeClass('expired');
+      self.$el.removeClass('ineffective');
 
-      if(data.expired){
+      if (data.expired) {
         self.$el.addClass('expired');
+      }
+
+      if (data.ineffective) {
+        self.$el.addClass('ineffective');
       }
 
       self.el.model = this.model;

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -87,9 +87,12 @@
                 padding-top: 2px;
             }
         }
-        .plone-item-expired {
+        .plone-item-expired,
+        .plone-item-ineffective {
+          .badge();
           font-size: 12px;
-          color: #d00202;
+          background-color: #d00202;
+          color: white;
         }
     }
     .navbar {

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -79,6 +79,13 @@
                 .btn{
                     padding: 2px 4px;
                 }
+                a {
+                    white-space: nowrap;
+                    &,
+                    &:hover {
+                        text-decoration: none;
+                    }
+                }
             }
         }
         .fc-breadcrumbs-container{

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -91,8 +91,13 @@
         .plone-item-ineffective {
           .badge();
           font-size: 12px;
-          background-color: #d00202;
           color: white;
+        }
+        .plone-item-expired {
+          background-color: @plone-toolbar-private-color;
+        }
+        .plone-item-ineffective {
+          background-color: @plone-toolbar-internal-color;
         }
     }
     .navbar {

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -24,7 +24,7 @@
       <th class="selection"><input type="checkbox" class="select-all" /></th>
       <th class="title">Title</th>
       <% _.each(activeColumns, function(column){ %>
-        <% if(_.has(availableColumns, column)) { %>
+        <% if(column !== 'Description' && _.has(availableColumns, column)) { %>
           <th><%- availableColumns[column] %></th>
         <% } %>
       <% }); %>

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -17,7 +17,13 @@
     <% if(ineffective){ %>
       <span class="plone-item-ineffective"><%- _t('Before publishing date') %></span>
     <% } %>
-
+    <% if(activeColumns.indexOf('Description') !== -1 && _.has(availableColumns, 'Description') && Description) { %>
+    <p class="Description">
+      <small>
+        <%- Description %>
+      </small>
+    </p>
+    <% } %>
   </div>
   <% if(attributes["getIcon"] ){ %>
   <img class="image-<%- iconSize %> pull-right" src="<%- getURL %>/@@images/image/<%- iconSize %>">
@@ -25,7 +31,7 @@
 </td>
 
 <% _.each(activeColumns, function(column) { %>
-  <% if(_.has(availableColumns, column)) { %>
+  <% if(column !== 'Description' && _.has(availableColumns, column)) { %>
     <td class="<%- column %>"><%- attributes[column] %></td>
   <% } %>
 <% }); %>

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -14,6 +14,10 @@
     <% if(expired){ %>
       <span class="plone-item-expired"><%- _t('Expired') %></span>
     <% } %>
+    <% if(ineffective){ %>
+      <span class="plone-item-ineffective"><%- _t('Before publishing date') %></span>
+    <% } %>
+
   </div>
   <% if(attributes["getIcon"] ){ %>
   <img class="image-<%- iconSize %> pull-right" src="<%- getURL %>/@@images/image/<%- iconSize %>">

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -701,6 +701,52 @@ define([
 
     });
 
+    it('should display an expired label for expired contend', function() {
+
+      var expired = new Date();
+      expired.setDate(expired.getDate() - 10);
+
+      var model = new Result({
+        'Title': "Dummy Document",
+        'id': "dummy_document",
+        'is_folderish': false,
+        'portal_type': "Document",
+        'ExpirationDate': expired.toJSON()
+      });
+
+      var row = new TableRowView({
+        model: model,
+        app: this.app
+      });
+      var el = row.render().el;
+
+      expect($('.title .plone-item-expired', el).length).to.equal(1);
+      expect($('.title .plone-item-ineffective', el).length).to.equal(0);
+    });
+
+    it('should display an before publication date label for content which has an effective date in the future', function() {
+
+      var effective = new Date();
+      effective.setDate(effective.getDate() + 10);
+
+      var model = new Result({
+        'Title': "Dummy Document",
+        'id': "dummy_document",
+        'is_folderish': false,
+        'portal_type': "Document",
+        'EffectiveDate': effective.toJSON()
+      });
+
+      var row = new TableRowView({
+        model: model,
+        app: this.app
+      });
+      var el = row.render().el;
+
+      expect($('.title .plone-item-expired', el).length).to.equal(0);
+      expect($('.title .plone-item-ineffective', el).length).to.equal(1);
+    });
+
   });
 
   /* ==========================

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -747,6 +747,60 @@ define([
       expect($('.title .plone-item-ineffective', el).length).to.equal(1);
     });
 
+    it('should show Description below title, if available', function() {
+
+      // Ensure, Description is set.
+      this.app.activeColumns = [
+        'Description'
+      ];
+      this.app.availableColumns = {
+        'Description': 'Description'
+      };
+
+      var model = new Result({
+        'Title': "Dummy Document",
+        'Description': "Oh, this is a description of this content!",
+        'id': "dummy_document",
+        'is_folderish': false,
+        'portal_type': "Document"
+      });
+
+      var row = new TableRowView({
+        model: model,
+        app: this.app
+      });
+      var el = row.render().el;
+
+      expect($('.title .Description', el).length).to.equal(1);
+      // Description should be shown below title, but not in a column.
+      expect($('td.Description', el).length).to.equal(0);
+    });
+
+    it('should not show Description, if not set', function() {
+
+      // Ensure, Description is not set.
+      this.app.activeColumns = [];
+      this.app.availableColumns = {};
+
+      var model = new Result({
+        'Title': "Dummy Document",
+        'Description': "Oh, this is a description of this content!",
+        'id': "dummy_document",
+        'is_folderish': false,
+        'portal_type': "Document"
+      });
+
+      var row = new TableRowView({
+        model: model,
+        app: this.app
+      });
+      var el = row.render().el;
+
+      expect($('.title .Description', el).length).to.equal(0);
+      expect($('td.Description', el).length).to.equal(0);
+    });
+
+
   });
 
   /* ==========================


### PR DESCRIPTION
- Show ineffective label in folder contents for not yet effective and published content, likewise it's done with expires.
  Show effective and ineffective label styled as bootstrap badges.

- Show "Description" below title, if it's set in ``availableColumns`` and ``activeColumns`` to save some screen space.

- Add default plone color less variables for a more consistent design.
  They will be overwritten by values set by Plone or integration projects.