### PR TITLE
Fixed path to tooltip less files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ New features:
 
 Bug fixes:
 
+- Fixed path to tooltip less files.
+  This gave an ugly site in develoment mode when editing the loggedin bundle css.
+  Fixes `issue 1843 <https://github.com/plone/Products.CMFPlone/issues/1843>`_.
+  [maurits]
+
 - Style filemanager toolbar to better fix small screens.
   [thet]
 

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -2,7 +2,7 @@
 @icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 @import "@{bowerPath}/bootstrap/less/glyphicons.less";
 @import "@{mockuplessPath}/ui.less";
-@import "@{mockuplessPath}/../patterns/tooltip/pattern.tooltip.less";
+@import "@{mockupPath}/tooltip/pattern.tooltip.less";
 
 @import "@{bowerPath}/bootstrap/less/mixins.less";
 @import "@{bowerPath}/bootstrap/less/utilities.less";


### PR DESCRIPTION
This gave an ugly site in develoment mode when editing the loggedin bundle css.
Fixes https://github.com/plone/Products.CMFPlone/issues/1843.