### PR TITLE
Make "One level up"-item customizable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ Bug fixes:
 - fix structure pattern: if title is empty then show items ID.
   [jensens]
 
+- fix localization of "Open folder" link title in related items pattern
+  [datakurre]
+
 
 2.4.0 (2017-02-20)
 ------------------

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -257,7 +257,7 @@ define([
           ) {
             results = [{
               'oneLevelUp': true,
-              'Title': _('One level up'),
+              'Title': _t('One level up'),
               'path': path.slice(0, path.length - 1).join('/') || '/',
               'portal_type': 'Folder',
               'is_folderish': true,

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -176,7 +176,10 @@ define([
         template = self.options[tpl + 'Template'];
       }
       // let's give all the options possible to the template generation
-      var options = $.extend(true, {}, self.options, item, {'browsing': self.browsing});
+      var options = $.extend(true, {}, self.options, item, {
+        'browsing': self.browsing,
+        'open_folder': _t('Open folder')
+      });
       options._item = item;
       return _.template(template)(options);
     },

--- a/mockup/patterns/relateditems/templates/result.xml
+++ b/mockup/patterns/relateditems/templates/result.xml
@@ -1,7 +1,7 @@
 <div class="pattern-relateditems-result">
   <span class="pattern-relateditems-buttons">
   <% if (is_folderish) { %>
-    <a class="pattern-relateditems-result-browse" data-path="<%- path %>" title="Open folder"></a>
+    <a class="pattern-relateditems-result-browse" data-path="<%- path %>" title="<%- open_folder %>"></a>
   <% } %>
   </span>
   <a class="pattern-relateditems-result-select<% if (selectable) { %> selectable<% } else if (browsing && is_folderish) { %> pattern-relateditems-result-browse<% } %><% if (typeof oneLevelUp !== 'undefined' && oneLevelUp) { %> one-level-up<% } %>" data-path="<%- path %>">

--- a/mockup/patterns/relateditems/templates/result.xml
+++ b/mockup/patterns/relateditems/templates/result.xml
@@ -1,4 +1,4 @@
-<div class="pattern-relateditems-result">
+<div class="pattern-relateditems-result<% if (typeof oneLevelUp !== 'undefined' && oneLevelUp) { %> one-level-up<% } %>">
   <span class="pattern-relateditems-buttons">
   <% if (is_folderish) { %>
     <a class="pattern-relateditems-result-browse" data-path="<%- path %>" title="<%- open_folder %>"></a>


### PR DESCRIPTION
I wanted to customize "One level up", so I added the class name also for the top result node.

Includes also two localization fixes.