### PR TITLE
Fix issue where formunloadalert pattern raised initialization error for modals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,6 +88,9 @@ Bug fixes:
 - fix localization of "Open folder" link title in related items pattern
   [datakurre]
 
+- Fix issue where formunloadalert pattern raised initialization error for modals.
+  [datakurre]
+
 
 2.4.0 (2017-02-20)
 ------------------

--- a/mockup/patterns/formunloadalert/pattern.js
+++ b/mockup/patterns/formunloadalert/pattern.js
@@ -62,8 +62,8 @@ define([
 
       var $modal = self.$el.parents('.plone-modal');
       if ($modal.size() !== 0) {
-        $modal.data('pattern-modal').on('hide', function(e) {
-          var modal = $modal.data('pattern-modal');
+        $modal.data('patternPloneModal').on('hide', function(e) {
+          var modal = $modal.data('patternPloneModal');
           if (modal) {
             modal._suppressHide = self._handleUnload.apply(self, e);
           }


### PR DESCRIPTION
I was annoyed by formunloadalert pattern raising errors into JS console when modals were opened.

The broken code in question was years old. I have no idea, what it is supposed to do and if it still really works: https://github.com/plone/mockup/commit/22ead2779a0897442db2977076714b92fff9ea16

Yet, I found that what was previously data('pattern-modal') is nowadays data('patternPloneModal'). I assume this change is related to making mockup Patternslib compatible. @thet might know