### PR TITLE
New pattern mockup-patterns-structureupdater

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New features:
     Show effective and ineffective label styled as bootstrap badges.
   - Show "Description" below title, if it's set in ``availableColumns`` and ``activeColumns`` to save some screen space.
   - Do not break whitespace within actionmenu links and don't underline them when hovering.
+  - Trigger ``context-info-loaded`` on body to be able to listen to the event outside the pattern.
   [thet]
 
 - Related Items widget:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Breaking changes:
 
 New features:
 
+- New pattern ``mockup-patterns-structureupdater`` to update title and description depending on the current context on Plone's folder contents page.
+  [thet]
+
 - Add default plone color less variables for a more consistent design.
   They will be overwritten by values set by Plone or integration projects.
   [thet]

--- a/mockup/js/config.js
+++ b/mockup/js/config.js
@@ -87,6 +87,7 @@
       'mockup-patterns-select2': 'patterns/select2/pattern',
       'mockup-patterns-sortable': 'patterns/sortable/pattern',
       'mockup-patterns-structure': 'patterns/structure/pattern',
+      'mockup-patterns-structureupdater': 'patterns/structure/pattern-structureupdater',
       'mockup-patterns-structure-url': 'patterns/structure',
       'mockup-patterns-textareamimetypeselector': 'patterns/textareamimetypeselector/pattern',
       'mockup-patterns-texteditor': 'patterns/texteditor/pattern',

--- a/mockup/patterns/structure/js/views/addmenu.js
+++ b/mockup/patterns/structure/js/views/addmenu.js
@@ -14,7 +14,7 @@ define([
     initialize: function(options) {
       var self = this;
       ButtonGroup.prototype.initialize.apply(self, [options]);
-      self.app.on('context-info-loaded', function(data) {
+      $('body').on('context-info-loaded', function(data) {
         self.$items.empty();
         _.each(data.addButtons, function(item) {
           var view = new ButtonView({

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -110,7 +110,7 @@ define([
             url: self.getAjaxUrl(self.contextInfoUrl),
             dataType: 'json',
             success: function(data) {
-              self.trigger('context-info-loaded', data);
+              $('body').trigger('context-info-loaded', data);
             },
             error: function(response) {
               // XXX handle error?

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -29,7 +29,7 @@ define([
       self.subsetIds = [];
       self.contextInfo = null;
 
-      self.app.on('context-info-loaded', function(data) {
+      $('body').on('context-info-loaded', function(data) {
         self.contextInfo = data;
         /* set default page info */
         self.setContextInfo();

--- a/mockup/patterns/structure/js/views/upload.js
+++ b/mockup/patterns/structure/js/views/upload.js
@@ -17,7 +17,7 @@ define([
       self.app = options.app;
       PopoverView.prototype.initialize.apply(self, [options]);
       self.currentPathData = null;
-      self.app.on('context-info-loaded', function(data) {
+      $('body').on('context-info-loaded', function(data) {
         self.currentPathData = data;
       });
     },

--- a/mockup/patterns/structure/pattern-structureupdater.js
+++ b/mockup/patterns/structure/pattern-structureupdater.js
@@ -1,0 +1,40 @@
+/* Structure Updater pattern.
+ *
+ * Options:
+ *    titleSelector(string): CSS selector to match title elements for the current context ('').
+ *    descriptionSelector(string): CSS selector to match description elements of the current context to be updated ('').
+ *
+ * Documentation:
+ *    The Structure Updater pattern updates the information of the current context after a user navigated to a new folder.
+ *
+ */
+
+define([
+  'jquery',
+  'pat-base'
+], function($, Base) {
+  'use strict';
+
+  var StructureUpdater = Base.extend({
+    name: 'structureupdater',
+    trigger: '.template-folder_contents',
+    parser: 'mockup',
+    defaults: {
+      titleSelector: '',
+      descriptionSelector: ''
+    },
+
+    init: function() {
+
+      $('body').on('context-info-loaded', function (e, data) {
+        $(this.options.titleSelector, this.$el).html(data.object && data.object.Title || '&nbsp;');
+        $(this.options.descriptionSelector, this.$el).html(data.object && data.object.Description || '&nbsp;');
+      }.bind(this));
+
+    }
+
+  });
+
+  return StructureUpdater;
+
+});


### PR DESCRIPTION
- New pattern ``mockup-patterns-structureupdater`` to update title and description depending on the current context on Plone's folder contents page.
- Structure widget: Trigger ``context-info-loaded`` on body to be able to listen to the event outside the pattern.