### PR TITLE
Resolve ajaxUrl later

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Breaking changes:
 
 New features:
 
+- For ``pat-modal``, let the ajax modal variant acquire it's ajax url when the modal is shown instead when the pattern is initialized.
+  This makes the modal respect a dynamically changed href attribute on a anchor tag, after it was initialized.
+  [thet]
+
 - New pattern ``mockup-patterns-structureupdater`` to update title and description depending on the current context on Plone's folder contents page.
   [thet]
 

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -545,7 +545,10 @@ define([
             self.options.content = '';
           }
           if (!self.options.ajaxUrl && self.$el.attr('href').substr(0, 1) !== '#') {
-            self.options.ajaxUrl = self.$el.attr('href');
+            self.options.ajaxUrl = function () {
+              // Resolve ``href`` attribute later, when modal is shown.
+              return self.$el.attr('href');
+            };
           }
         }
         self.$el.on('click', function(e) {
@@ -561,8 +564,14 @@ define([
       var self = this;
       self.emit('before-ajax');
       self.loading.show();
+
+      var ajaxUrl = self.options.ajaxUrl;
+      if (typeof ajaxUrl === 'function') {
+        ajaxUrl = ajaxUrl.apply(self, [self.options]);
+      }
+
       self.ajaxXHR = $.ajax({
-        url: self.options.ajaxUrl,
+        url: ajaxUrl,
         type: self.options.ajaxType
       }).done(function(response, textStatus, xhr) {
         self.ajaxXHR = undefined;


### PR DESCRIPTION
For ``pat-modal``, let the ajax modal variant acquire it's ajax url when the modal is shown instead when the pattern is initialized.
This makes the modal respect a dynamically changed href attribute on a anchor tag, after it was initialized.