### PR TITLE
Related Items filter/css

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ New features:
     - Filter out non-selectable and non-folderish items in the result set when in browse mode.
     - Add option to scan the selected list of items for other patterns.
     - Add option for contextPath - objects with this path will not be selectable. This prevents the object where the relation is set on to from being selected and self-referenced.
+    - Make favorites container positon relative, so that the absolute positioned dropdown appears correctly.
   [thet]
 
 - Include TinyMCE 4.5.6

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -134,7 +134,7 @@ define([
       favorites: [],
       maximumSelectionSize: -1,
       minimumInputLength: 0,
-      mode: 'auto', // possible values are search and browse
+      mode: 'auto', // possible values are 'auto', 'search' and 'browse'.
       orderable: true,  // mockup-patterns-select2
       pathOperator: 'plone.app.querystring.operation.string.path',
       rootPath: '/',
@@ -238,18 +238,6 @@ define([
 
           var more = (page * this.options.pageSize) < data.total;
           var results = data.results;
-
-          // Filter out non-selectable and non-folderish while browsing.
-          if (this.browsing) {
-            results = results.filter(
-              function (item) {
-                if (!item.is_folderish && !this.isSelectable(item)) {
-                  return false;
-                }
-                return true;
-              }.bind(this)
-            );
-          }
 
           // Extend ``data`` with a ``oneLevelUp`` item when browsing
           var path = this.currentPath.split('/');
@@ -455,6 +443,7 @@ define([
         return false;
       }
       if (self.options.contextPath === this.options.rootPath + item.path) {
+        // filter out current item
         return false;
       }
       if (self.options.selectableTypes === null) {
@@ -500,9 +489,20 @@ define([
 
         for (var i = 0; i < data.length; i = i + 1) {
           if (data[i].UID === item.UID) {
-            // Exclude already selected items in result list.
-            return;
+            // do not allow already selected items to be selected again.
+            item.selectable = false;
           }
+        }
+        if (
+          !item.selectable && (
+            !self.browsing ||
+            self.browsing && !item.is_folderish
+          )
+        ) {
+          // Filter out non-selectable and non-folderish while browsing.
+          // or
+          // Exclude already selected items while searching.
+          return;
         }
         var result = $(self.applyTemplate('result', item));
 

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -81,6 +81,10 @@
             vertical-align: middle;
         }
     }
+
+    .favorites {
+        position: relative;  // make dropdown appear on right, as the dropdown is positioned absolute / left-0.
+    }
 }
 
 .pattern-relateditems-dropdown {

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -199,8 +199,17 @@ define([
       // Only Images and Folders should be shown.
       expect($('.pattern-relateditems-result-select')).to.have.length(5);
 
+      // Select first folder
+      $('a.pattern-relateditems-result-select[data-path="/folder1"]').click();
+      expect($('input.pat-relateditems').val()).to.be.equal('UID6');
+
+      // Still, this folder should be shown in the result list - only not selectable.
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      expect($('.pattern-relateditems-result-select')).to.have.length(5);
+
       // Browse into second folder which contains images
-      $('.pattern-relateditems-result-browse')[1].click();
+      $('.pattern-relateditems-result-browse[data-path="/folder2"]').click();
       clock.tick(1000);
 
       // 1 "One level up" and 2 images
@@ -208,8 +217,8 @@ define([
       expect($('.pattern-relateditems-result-select')[0].text).to.contain('One level up');
 
       // Select first image
-      $('a.pattern-relateditems-result-select')[1].click();
-      expect($('input.pat-relateditems').val()).to.be.equal('UID17');
+      $('a.pattern-relateditems-result-select[data-path="/folder2/image17"]').click();
+      expect($('input.pat-relateditems').val()).to.be.equal('UID6,UID17');
 
       // Browse one level up
       $('.select2-search-field input.select2-input').click();
@@ -231,7 +240,7 @@ define([
       expect($('.pattern-relateditems-result-select')).to.have.length(2);
 
       // We can even browse into folders in search mode
-      $('.pattern-relateditems-result-browse')[0].click();
+      $('.pattern-relateditems-result-browse[data-path="/folder2"]').click();
       clock.tick(1000);
 
       // Being in folder 2, we see again two items...
@@ -239,8 +248,8 @@ define([
       expect($('.pattern-relateditems-result-select')[0].text).to.contain('One level up');
 
       // Selecting the image will add it to the selected items.
-      $('a.pattern-relateditems-result-select')[1].click();
-      expect($('input.pat-relateditems').val()).to.be.equal('UID17,UID18');
+      $('a.pattern-relateditems-result-select[data-path="/folder2/image18"]').click();
+      expect($('input.pat-relateditems').val()).to.be.equal('UID6,UID17,UID18');
 
     });
 


### PR DESCRIPTION
- Make favorites container positon relative, so that the absolute positioned dropdown appears correctly.
- do not filter out already selected but folderish items in browse mode

There is one weired thing with the "do not filter out already selected but folderish items in browse mode" commit: When a folderish item is selected, it's hard to browse into this folder again. The result list always resets to another position when hovering over it. Have to investigate that.