### PR TITLE
In the insert link/image modal, pass use the correct related items wi…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,12 +10,12 @@ Breaking changes:
 
 New features:
 
- - make thumb size in folder contents listing adjustable/supressable 
+ - make thumb size in folder contents listing adjustable/supressable
    replace meaningless paper clip icon (fontello) with mime type icons
    from mimetype registry
    https://github.com/plone/Products.CMFPlone/issues/1734
    [fgrcon]
- 
+
 - For ``pat-modal``, let the ajax modal variant acquire it's ajax url when the modal is shown instead when the pattern is initialized.
   This makes the modal respect a dynamically changed href attribute on a anchor tag, after it was initialized.
   [thet]
@@ -50,6 +50,9 @@ New features:
   [frapell]
 
 Bug fixes:
+
+- In the insert link/image modal, pass use the correct related items widget options from the ``linkModal`` attribute.
+  [thet]
 
 - Fixed path to tooltip less files.
   This gave an ugly site in develoment mode when editing the loggedin bundle css.

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -84,7 +84,7 @@ define([
     },
 
     createRelatedItems: function() {
-      var options = this.tinypattern.options.relatedItems;
+      var options = this.linkModal.options.relatedItems;
       options.upload = false;  // ensure that related items upload is off.
       this.relatedItems = new RelatedItems(this.getEl(), options);
     },

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -223,11 +223,6 @@ define([
             insertHeading: _t('Insert Image')
           },
           relatedItems: {
-            baseCriteria: [{
-              i: 'portal_type',
-              o: 'plone.app.querystring.operation.list.contains',
-              v: self.options.imageTypes.concat(self.options.folderTypes)
-            }],
             selectableTypes: self.options.imageTypes
           }
         });


### PR DESCRIPTION
…dget options from the linkModal attribute.

Fixes ``selectableTypes`` not respected in TinyMCE's image and link upload modals.