### PR TITLE
Queue inline validation calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,15 @@
 Changelog
 =========
 
-2.5.2 (Unreleased)
+2.6.0 (Unreleased)
 ------------------
 
 New features:
 
-- * Add items here *
+- Queue validation calls in inlinevalidation pattern using jQuery default queue
+  to ensure validations are called in order and allow custom custom code to be
+  queued after validation has completed
+  [datakurre]
 
 Bug fixes: 
 


### PR DESCRIPTION
I've currently tested this only with dexterity objects. Probably can test with archetypes. Has Plone 5 anywhere formlib forms with this inline validation?