### PR TITLE
Upload pattern: authenticator token

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ New features:
 
 Bug fixes:
 
+- Upload pattern: Fix missing plone.protect authenticator token which led to broken uploads.
+  [thet]
+
 - In the insert link/image modal, pass use the correct related items widget options from the ``linkModal`` attribute.
   [thet]
 

--- a/mockup/patterns/upload/pattern.js
+++ b/mockup/patterns/upload/pattern.js
@@ -48,9 +48,9 @@ define([
   'dropzone',
   'text!mockup-patterns-upload-url/templates/upload.xml',
   'text!mockup-patterns-upload-url/templates/preview.xml',
+  'mockup-utils',
   'translate'
-], function($, _, Base, RelatedItems, Dropzone,
-            UploadTemplate, PreviewTemplate, _t) {
+], function($, _, Base, RelatedItems, Dropzone, UploadTemplate, PreviewTemplate, utils, _t) {
   'use strict';
 
   /* we do not want this plugin to auto discover */
@@ -341,6 +341,10 @@ define([
       var options = $.extend({}, self.options);
       options.url = self.getUrl();
 
+      options.headers = {
+        'X-CSRF-TOKEN': utils.getAuthenticator()
+      };
+
       // XXX force to only upload one to the server at a time,
       // right now we don't support multiple for backends
       options.uploadMultiple = false;
@@ -442,7 +446,8 @@ define([
       window.tus.upload(file, {
         endpoint: self.dropzone.options.url,
         headers: {
-          'FILENAME': file.name
+          'FILENAME': file.name,
+          'X-CSRF-TOKEN': utils.getAuthenticator()
         },
         chunkSize: chunkSize
       }).fail(function() {


### PR DESCRIPTION
Upload pattern: Fix missing plone.protect authenticator token which led to broken uploads.

Fixes: https://github.com/plone/Products.CMFPlone/issues/2076

Merge together:

https://github.com/plone/Products.CMFPlone/pull/2079
https://github.com/plone/mockup/pull/780