### PR TITLE
Pin jqtree = 1.4.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,9 @@ Bug fixes:
 - Fix issue where formunloadalert pattern raised initialization error for modals.
   [datakurre]
 
+- Update jqtree to version 1.4.1
+  [datakurre]
+
 
 2.4.0 (2017-02-20)
 ------------------

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "console-polyfill": "0.2.2",
     "dropzone": "4.3.0",
     "es5-shim": "4.5.9",
-    "jqtree": "1.3.3",
+    "jqtree": "1.4.1",
     "jquery": "1.11.3",
     "jquery-form": "3.51",
     "jquery.cookie": "1.4.1",


### PR DESCRIPTION
@b4oshany requires up-to-date jqtree version to be able to add drag and drop move support for filemanager pattern. @thet, should be upgrade this with the filemanager pattern feature pull or could be update this separately? Also, is there anything else to consider that tests on mockup pass with this pull and then we also update the resources in CMFPlone with https://github.com/plone/Products.CMFPlone/pull/2082