### PR TITLE
Theme filemanager searching feature fixes

### DIFF
--- a/mockup/patterns/filemanager/pattern.js
+++ b/mockup/patterns/filemanager/pattern.js
@@ -189,7 +189,8 @@ define([
           findinFilesView.triggerView
         ],
         id: 'find',
-        app: self
+        app: self,
+        disable: function() {}
       })
 
       self.views = [

--- a/mockup/patterns/thememapper/pattern.thememapper.less
+++ b/mockup/patterns/thememapper/pattern.thememapper.less
@@ -1,6 +1,6 @@
 @import "@{mockuplessPath}/ui.less";
 /* just be lazy here and include all of bootstrap... */
-@import "@{mockupPath}/filemanager/pattern.filemanager.less";
+@import "@{mockup-patterns-filemanager}";
 
 body.plone-toolbar-left-default {
 	padding-left: 0px;


### PR DESCRIPTION
@b4oshany Small issue. If the "edited" theme is readonly, find menu actions get disabled. (Code in thememapper patterns calls disable for all button groups.) Iterating through all buttons to only enable find-menu looked complex in themepattern, so I propose simply disabling "disable" from find menu component.