### PR TITLE
bower update 2.1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Align bower.json versions fixes to Products.CMFPlone 5.0.x.
+  [thet]
 
 Bug Fixes:
 

--- a/bower.json
+++ b/bower.json
@@ -10,29 +10,32 @@
     "dropzone": "4.0.1",
     "es5-shim": "4.0.3",
     "marked": "0.3.3",
-    "jqtree": "0.22.0",
+    "jqtree": "1.4.1",
     "jquery": "1.11.3",
     "jquery-form": "3.46.0",
     "jquery.cookie": "1.4.1",
     "jquery.recurrenceinput.js": "v1.5.2",
     "logging": "",
-    "moment": "2.10.3",
+    "moment": "2.10.6",
     "patternslib": "2.0.11",
     "pickadate": "3.5.6",
     "react": "0.10.0",
     "requirejs-text": "2.0.12",
     "selectivizr": "1.0.2",
     "select2": "3.5.1",
-    "tinymce-builded": "4.3.4"
+    "tinymce-builded": "4.3.12",
+    "requirejs": "",
+    "less": "2.1.2",
+    "r.js": "2.1.15"
+  },
+  "resolutions": {
+    "jquery": "1.11.3",
+    "select2": "3.5.1",
+    "patternslib": "2.0.11",
+    "moment": "2.10.6"
   },
   "devDependencies": {
     "expect": "0.3.1",
     "sinonjs": "1.14.1"
-  },
-  "resolutions": {
-    "bootstrap": "3.3.4",
-    "jquery": "1.11.3",
-    "select2": "3.5.1",
-    "moment": "2.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockup",
-  "version": "2.1.8.dev0",
+  "version": "2.1.8",
   "description": "A collection of client side patterns for faster and easier web development",
   "homepage": "http://plone.github.io/mockup",
   "devDependencies": {


### PR DESCRIPTION
Align bower.json versions fixes to Products.CMFPlone 5.0.x.

/cc @datakurre @b4oshany 
CMFPlone 5.0 depends on mockup 2.1.x - so updated the jqtree version in this branch - among others.