### PR TITLE
Fix filtering of non-selectable items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,11 @@ Incompatibile changes:
 
 Bug fixes:
 
-- * Add item here *
+- Related Items: Fix filtering of non-selectable and non-browsable items, so that no empty list elements are contained.
+  Filtering behavior is: When browsing, show only folderish or non-selected, selectable items (but non-selectable, folderish items are greyed out).
+  When searching, show only selectable items, which were not already selected.
+  This fixes an issue where it was impossible to select items when many items were filtered out.
+  [thet]
 
 
 2.5.0 (2017-07-03)

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -118,6 +118,7 @@ define([
     trigger: '.pat-relateditems',
     parser: 'mockup',
     currentPath: undefined,
+    selectedUIDs: [],
     openAfterInit: undefined,
     defaults: {
       // main option
@@ -238,6 +239,26 @@ define([
 
           var more = (page * this.options.pageSize) < data.total;
           var results = data.results;
+
+          this.selectedUIDs = (this.$el.select2('data') || []).map(function (el) {
+            // populate current selection. Reuse in formatResult
+            return el.UID;
+          });
+
+          // Filter out items:
+          // While browsing: always include folderish items
+          // Browsing and searching: Only include selectable items, which are not already selected.
+          results = results.filter(
+            function (item) {
+              if (
+                (this.browsing && item.is_folderish) ||
+                (this.isSelectable(item) && this.selectedUIDs.indexOf(item.UID) == -1)
+              ) {
+                return true;
+              }
+              return false;
+            }.bind(this)
+          );
 
           // Extend ``data`` with a ``oneLevelUp`` item when browsing
           var path = this.currentPath.split('/');
@@ -485,25 +506,12 @@ define([
 
       self.options.formatResult = function(item) {
         item.selectable = self.isSelectable(item);
-        var data = self.$el.select2('data');
 
-        for (var i = 0; i < data.length; i = i + 1) {
-          if (data[i].UID === item.UID) {
+        if (self.selectedUIDs.indexOf(item.UID) != -1) {
             // do not allow already selected items to be selected again.
             item.selectable = false;
-          }
         }
-        if (
-          !item.selectable && (
-            !self.browsing ||
-            self.browsing && !item.is_folderish
-          )
-        ) {
-          // Filter out non-selectable and non-folderish while browsing.
-          // or
-          // Exclude already selected items while searching.
-          return;
-        }
+
         var result = $(self.applyTemplate('result', item));
 
         $('.pattern-relateditems-result-select', result).on('click', function(event) {

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -272,7 +272,7 @@ define([
       // PT 2
 
       // select one element
-      $('a.pattern-relateditems-result-select')[2].click();
+      $('a.pattern-relateditems-result-select[data-path="/image1"]').click();
       expect($('input.pat-relateditems').val()).to.be.equal('UID8');
 
 
@@ -283,10 +283,10 @@ define([
       clock.tick(1000);
 
       // result list must have expected length
-      expect($('.pattern-relateditems-result-select')).to.have.length(4);
+      expect($('.pattern-relateditems-result-select.selectable')).to.have.length(2);
 
       // add another one
-      $('a.pattern-relateditems-result-select')[2].click();
+      $('a.pattern-relateditems-result-select[data-path="/image2"]').click();
       expect($('input.pat-relateditems').val()).to.be.equal('UID8,UID9');
 
       // remove first one
@@ -299,10 +299,10 @@ define([
       var keyup = $.Event('keyup-change');
       $input.trigger(keyup);
       clock.tick(1000);
-      expect($('.pattern-relateditems-result-select')).to.have.length(2);
+      expect($('.pattern-relateditems-result-select.selectable')).to.have.length(2);
 
       // add first from result
-      $('a.pattern-relateditems-result-select')[1].click();
+      $('a.pattern-relateditems-result-select[data-path="/image3"]').click();
       expect($('input.pat-relateditems').val()).to.be.equal('UID9,UID10');
 
     });
@@ -324,7 +324,7 @@ define([
       //  // PT 2
 
       //  // select one element
-      $('a.pattern-relateditems-result-select')[0].click();
+      $('a.pattern-relateditems-result-select[data-path="/document1"]').click();
       expect($('input.pat-relateditems').val()).to.be.equal('UID1');
 
 
@@ -335,10 +335,10 @@ define([
       clock.tick(1000);
 
       //  // result list must have expected length
-      expect($('.pattern-relateditems-result-select')).to.have.length(10);
+      expect($('.pattern-relateditems-result-select.selectable')).to.have.length(10);
 
       //  // add another one
-      $('a.pattern-relateditems-result-select')[0].click();
+      $('a.pattern-relateditems-result-select[data-path="/document2"]').click();
       expect($('input.pat-relateditems').val()).to.be.equal('UID1,UID2');
 
       //  // remove first one
@@ -351,10 +351,10 @@ define([
       var keyup = $.Event('keyup-change');
       $input.trigger(keyup);
       clock.tick(1000);
-      expect($('.pattern-relateditems-result-select')).to.have.length(1);
+      expect($('.pattern-relateditems-result-select.selectable')).to.have.length(1);
 
       //  // add first from result
-      $('a.pattern-relateditems-result-select')[0].click();
+      $('a.pattern-relateditems-result-select[data-path="/folder2/document15"]').click();
       expect($('input.pat-relateditems').val()).to.be.equal('UID2,UID15');
 
     });


### PR DESCRIPTION
Related Items: Fix filtering of non-selectable and non-browsable items, so that no empty list elements are contained.
Filtering behavior is: When browsing, show only folderish or non-selected, selectable items (but non-selectable, folderish items are greyed out).
When searching, show only selectable items, which were not already selected.
This fixes an issue where it was impossible to select items when many items were filtered out.
