### PR TITLE
Fix callback for sortable pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Incompatibile changes:
 
 Bug fixes:
 
+- Fix callback of sortable pattern
+  [tomgross]
+
 - Related Items: Fix filtering of non-selectable and non-browsable items, so that no empty list elements are contained.
   Filtering behavior is: When browsing, show only folderish or non-selected, selectable items (but non-selectable, folderish items are greyed out).
   When searching, show only selectable items, which were not already selected.

--- a/mockup/patterns/sortable/pattern.js
+++ b/mockup/patterns/sortable/pattern.js
@@ -4,7 +4,7 @@
  *    selector(string): Selector to use to draggable items in pattern ('li')
  *    dragClass(string): Class to apply to original item that is being dragged. ('item-dragging')
  *    cloneClass(string): Class to apply to cloned item that is dragged. ('dragging')
- *    drop(function): callback function for when item is dropped (null)
+ *    drop(string): Name of callback function in global namespace to be called when item is dropped ('')
  *
  * Documentation:
  *    # Default
@@ -65,7 +65,7 @@ define([
           addClass(pattern.options.cloneClass).
           css({opacity: 0.75, position: 'absolute'}).appendTo(document.body);
       },
-      drop: null // function to handle drop event
+      drop: ''  // name of global function to handle drop event.
     },
     init: function() {
       var self = this;
@@ -110,7 +110,7 @@ define([
         $el.removeClass(self.options.dragClass);
         $(dd.proxy).remove();
         if (self.options.drop) {
-          self.options.drop($el, $el.index() - start);
+          window[self.options.drop]($el, $el.index() - start);
         }
       })
       .drop('init', function(e, dd ) {


### PR DESCRIPTION
This PR fixes the drop-callback of the sortable pattern

https://community.plone.org/t/mockup-pattern-sortable-associating-a-callback-function-with-drag-and-drop-not-working-as-expected/3608

Since the pattern arguments always seem to be converted to strings, this patch looks up the method name in the global window space.

https://stackoverflow.com/questions/359788/how-to-execute-a-javascript-function-when-i-have-its-name-as-a-string

 