### PR TITLE
Restore ability from < 2.5.1 to let the ``drop`` callback be a function.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,11 @@ New features:
 
 Bug fixes:
 
-- * Add items here *
+- Restore ability from < 2.5.1 to let the ``drop`` callback be a function.
+  It can still be the name of the function in the global namespace.
+  Fixes #808.
+  [thet]
+
 
 2.6.0 (2017-09-06)
 ------------------
@@ -52,7 +56,7 @@ New features:
 
 Bug fixes:
 
-- Fix callback of sortable pattern
+- Fix callback of sortable pattern.
   [tomgross]
 
 - Related Items: Fix filtering of non-selectable and non-browsable items, so that no empty list elements are contained.

--- a/mockup/patterns/sortable/pattern.js
+++ b/mockup/patterns/sortable/pattern.js
@@ -4,7 +4,7 @@
  *    selector(string): Selector to use to draggable items in pattern ('li')
  *    dragClass(string): Class to apply to original item that is being dragged. ('item-dragging')
  *    cloneClass(string): Class to apply to cloned item that is dragged. ('dragging')
- *    drop(string): Name of callback function in global namespace to be called when item is dropped ('')
+ *    drop(function, string): Callback function or name of callback function in global namespace to be called when item is dropped ('')
  *
  * Documentation:
  *    # Default
@@ -65,7 +65,7 @@ define([
           addClass(pattern.options.cloneClass).
           css({opacity: 0.75, position: 'absolute'}).appendTo(document.body);
       },
-      drop: ''  // name of global function to handle drop event.
+      drop: undefined  // callback function or name of global function
     },
     init: function() {
       var self = this;
@@ -109,8 +109,12 @@ define([
         var $el = $(this);
         $el.removeClass(self.options.dragClass);
         $(dd.proxy).remove();
-        if (self.options.drop) {
-          window[self.options.drop]($el, $el.index() - start);
+          if (self.options.drop) {
+            if (typeof self.options.drop === 'string') {
+              window[self.options.drop]($el, $el.index() - start);
+            } else {
+              self.options.drop($el, $el.index() - start);
+            }
         }
       })
       .drop('init', function(e, dd ) {


### PR DESCRIPTION
It can still be the name of the function in the global namespace.
Fixes #808.