### PR TITLE
Concatenate value for select multiple input in generic popover in the structure pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Bug fixes:
   Fixes #808.
   [thet]
 
+- Concatenate value for select multiple input in generic popover in the structure pattern.
+  [Gagaro]
+
 
 2.6.0 (2017-09-06)
 ------------------

--- a/mockup/patterns/structure/js/views/generic-popover.js
+++ b/mockup/patterns/structure/js/views/generic-popover.js
@@ -51,7 +51,11 @@ define([
       var self = this;
       var data = {};
       _.each(self.$el.find('form').serializeArray(), function(param) {
-        data[param.name] = param.value;
+        if (param.name in data) {
+            data[param.name] += ',' + param.value;
+        } else {
+            data[param.name] = param.value;
+        }
       });
 
       self.app.buttonClickEvent(this.triggerView, data);

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -3,18 +3,20 @@ define([
   'jquery',
   'underscore',
   'pat-registry',
+  'mockup-ui-url/views/button',
   'mockup-patterns-structure',
   'mockup-patterns-structure-url/js/views/actionmenu',
   'mockup-patterns-structure-url/js/views/app',
   'mockup-patterns-structure-url/js/models/result',
   'mockup-patterns-structure-url/js/views/table',
   'mockup-patterns-structure-url/js/views/tablerow',
+  'mockup-patterns-structure-url/js/views/generic-popover',
   'mockup-patterns-structure-url/js/collections/result',
   'mockup-utils',
   'sinon',
   'moment'
-], function(expect, $, _, registry, Structure, ActionMenuView, AppView, Result,
-            TableView, TableRowView, ResultCollection, utils, sinon, moment) {
+], function(expect, $, _, registry, ButtonView, Structure, ActionMenuView, AppView, Result,
+            TableView, TableRowView, PropertiesView, ResultCollection, utils, sinon, moment) {
   'use strict';
 
   window.mocha.setup('bdd');
@@ -2669,5 +2671,43 @@ define([
     });
 
   });
+
+  /* ==========================
+   TEST: PropertiesView concatenate duplicated values
+  ========================== */
+  describe('PropertiesView concatenate duplicated values', function() {
+    beforeEach(function() {
+        this.app = {
+            "buttonClickEvent": function(triggerView, data) {
+                this.data = data;
+            },
+            "selectedCollection": $()
+        };
+        var triggerView = new ButtonView({
+            "id": "foobar"
+        });
+        triggerView.$el.appendTo('body');
+        var options = {
+            "app": this.app,
+            "triggerView": triggerView,
+            "form": {
+                "template": '<select multiple name="foo"><option selected value="1">1</option>' +
+                '<option selected value="2">2</option><option value="3">3</option></select>'
+            }
+        };
+        this.popover = new PropertiesView(options);
+    });
+
+    afterEach(function() {
+        $('body').html('');
+    });
+
+    it('test applyButtonClicked', function() {
+        this.popover.toggle();
+        this.popover.applyButtonClicked();
+        expect(this.app.data.foo).to.equal('1,2');
+    });
+  });
+
 
 });


### PR DESCRIPTION
The `remove tags` input in the tags popover of the structure pattern uses a `select multiple`.

`serializeArray()` produce one object for each value selected in this input. So only the last one is saved in the data (and posted to the view).

This PR concatenate the value to data if a value with the same name is already present (with a `,`, same as how the `pat-select2` with multiple works).