### PR TITLE
Fixed resource registry controlpanel overrides tab save button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes: 
 
-- * Add items here *
+- Fixed resource registry override tab's Save button being disabled
+  [obct537]
 
 
 2.6.1 (2017-10-03)

--- a/mockup/patterns/resourceregistry/js/overrides.js
+++ b/mockup/patterns/resourceregistry/js/overrides.js
@@ -33,8 +33,8 @@ define([
           '<% if(view.editing){ %>' +
             '<p class="resource-name text-primary"><%- view.editing %></p> ' +
             '<div class="plone-btn-group">' +
-              '<button class="plone-btn plone-btn-primary plone-btn-xs disabled"><%- _t("Save") %></button> ' +
-              '<button class="plone-btn plone-btn-default plone-btn-xs disabled"><%- _t("Cancel") %></button>' +
+              '<button class="plone-btn plone-btn-primary plone-btn-xs" disabled><%- _t("Save") %></button> ' +
+              '<button class="plone-btn plone-btn-default plone-btn-xs" disabled><%- _t("Cancel") %></button>' +
               '<button class="plone-btn plone-btn-danger plone-btn-xs"><%- _t("Delete customizations") %></button>' +
             '</div>' +
           '<% } %>' +


### PR DESCRIPTION
The override pattern was removing the "disabled" property, but the button was being disabled by the disabled CSS class, making the buttons unusable.