### PR TITLE
Structure pattern - pass event data for trigger events correctly.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,14 +7,20 @@ Changelog
 New features:
 
 - Structure pattern:
+
   - Make action menu bar sticky.
   - Make action menu more compact, so that it doesn't break into a newline early.
   - Use more tooltips in the action menu.
   [thet]
 
-Bug fixes: 
+Bug fixes:
 
-- * Add items here *
+- Structure pattern:
+
+  - Set default page icon on item row. Fixes: https://github.com/plone/Products.CMFPlone/issues/2131
+  - Pass event data for the ``structure-url-changed`` event correctly.
+
+  [jensens, thet]
 
 
 2.6.1 (2017-10-03)
@@ -44,7 +50,7 @@ New features:
 - pattern-pickadate: Emit the ``updated.pickadate.patterns`` event when clicking the "clear" and "now" buttons.
   [thet]
 
-Bug fixes: 
+Bug fixes:
 
 - TinyMCE: Fix seen issue where pattern failed, because importcss_file_filter
   was already a function

--- a/mockup/patterns/structure/js/views/addmenu.js
+++ b/mockup/patterns/structure/js/views/addmenu.js
@@ -14,7 +14,7 @@ define([
     initialize: function(options) {
       var self = this;
       ButtonGroup.prototype.initialize.apply(self, [options]);
-      $('body').on('context-info-loaded', function(data) {
+      $('body').on('context-info-loaded', function(event, data) {
         self.$items.empty();
         _.each(data.addButtons, function(item) {
           var view = new ButtonView({

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -110,7 +110,7 @@ define([
             url: self.getAjaxUrl(self.contextInfoUrl),
             dataType: 'json',
             success: function(data) {
-              $('body').trigger('context-info-loaded', data);
+              $('body').trigger('context-info-loaded', [data]);
             },
             error: function(response) {
               // XXX handle error?
@@ -169,7 +169,7 @@ define([
           // TODO figure out whether the following event after this is
           // needed at all.
         }
-        $('body').trigger('structure-url-changed', path);
+        $('body').trigger('structure-url-changed', [path]);
 
       });
 
@@ -203,7 +203,7 @@ define([
             path = '/';
           }
           self.setCurrentPath(path);
-          $('body').trigger('structure-url-changed', path);
+          $('body').trigger('structure-url-changed', [path]);
           // since this next call causes state to be pushed...
           self.doNotPushState = true;
           self.collection.goTo(self.collection.information.firstPage);

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -29,7 +29,7 @@ define([
       self.subsetIds = [];
       self.contextInfo = null;
 
-      $('body').on('context-info-loaded', function(data) {
+      $('body').on('context-info-loaded', function(event, data) {
         self.contextInfo = data;
         /* set default page info */
         self.setContextInfo();

--- a/mockup/patterns/structure/js/views/upload.js
+++ b/mockup/patterns/structure/js/views/upload.js
@@ -17,7 +17,7 @@ define([
       self.app = options.app;
       PopoverView.prototype.initialize.apply(self, [options]);
       self.currentPathData = null;
-      $('body').on('context-info-loaded', function(data) {
+      $('body').on('context-info-loaded', function(event, data) {
         self.currentPathData = data;
       });
     },


### PR DESCRIPTION
Set default page icon on item row. Fixes: https://github.com/plone/Products.CMFPlone/issues/2131
Pass event data for the ``structure-url-changed`` event correctly.

Merge together:
https://github.com/plone/Products.CMFPlone/pull/2180
https://github.com/plone/mockup/pull/814