### PR TITLE
Querystring pattern: Fix #716, where the path-depth was added to stri…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ New features:
 
 Bug fixes:
 
+- Querystring pattern: Fix #716, where the path-depth was added to string values like the title when a path criteria was present.
+  [thet]
+
 - Structure pattern:
 
   - Set default page icon on item row. Fixes: https://github.com/plone/Products.CMFPlone/issues/2131

--- a/mockup/patterns/querystring/pattern.js
+++ b/mockup/patterns/querystring/pattern.js
@@ -608,7 +608,7 @@ define([
       }
       else if (typeof self.$value !== 'undefined') {
         var value = self.$value.val();
-        if(typeof(value) === 'string'){
+        if(ival === 'path' && value) {
           var depth = self.getDepthString();
           if(depth){
             value += depth;


### PR DESCRIPTION
…ng values like the title when a path criteria was present.

No tests as there is no test suite for mockup-patterns-querystring and I don't feel like going to create one for this fix.

Merge together:
https://github.com/plone/mockup/pull/818
https://github.com/plone/Products.CMFPlone/pull/2208
https://github.com/plone/Products.CMFPlone/pull/2209
