### PR TITLE
Allow more flexible anchors in TinyMCE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ New features:
   - Added options to change sorting.
   [Gagaro]
 
+- TinyMCE pattern:
+
+  - Make anchor handling more flexible
+  [tomgross]
+
 Bug fixes:
 
 - Structure pattern:

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -224,7 +224,7 @@ define([
       self.anchorData = [];
       var node, i, j, name, title;
 
-      var nodes = self.tiny.dom.select('a.mceItemAnchor,img.mceItemAnchor,a.mce-item-anchor,img.mce-item-anchor');
+      var nodes = self.tiny.dom.select('.mceItemAnchor,.mce-item-anchor');
       for (i = 0; i < nodes.length; i = i + 1) {
         node = nodes[i];
         name = self.tiny.dom.getAttrib(node, 'name');


### PR DESCRIPTION
With the current implementation 2 kinds of elements are parsed for the anchor selction in TinyMCE

1. `a`  and `img` with either the `mceItemAnchor`  or the `mce-item-anchor` class present
2. elements set by the `anchorSelector` parameter (`h1,h2,h3` by default)

This PR changes the behavior of 1. It adds **ALL** elements with one of the classes  `mceItemAnchor`  or `mce-item-anchor` set to the list of available anchors.

The risk of breaking something should be very low. The advantage is that you can allow anchors for custom elements (with the `name` or `id` attribute) by setting the marker class.