### PR TITLE
Mark special links: Do not mark anchors as special links. fixes gh-707

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,9 +18,13 @@ New features:
   - Add contextual menu to theme files in the file tree.
   [b4oshany]
 
+- Mark special links pattern: Do not mark anchors as special links
+  [frapell]
+
 Bug fixes:
 
 - * Add item here *
+
 
 2.1.8 (2017-08-05)
 ------------------

--- a/mockup/patterns/markspeciallinks/pattern.js
+++ b/mockup/patterns/markspeciallinks/pattern.js
@@ -135,11 +135,11 @@ define([
         // All links without an http href (without the link-plain class), not within this site,
         // and no img children should be wrapped in a link-[protocol] span
         contentarea.find(
-            'a[href]:not([href^="http:"]):not(.link-plain):not([href^="' + url + '"]):not(:has(img))')
+            'a[href]:not([href^="http:"]):not(.link-plain):not([href^="' + url + '"]):not(:has(img)):not([href^="#"])')
             .each(function() {
                 // those without a http link may have another interesting protocol
                 // wrap these in a link-[protocol] span
-                res = protocols.exec(this.href);
+                res = protocols.exec($(this).attr('href'));
                 if (res) {
                     var iconclass = 'glyphicon link-' + res[0];
                     $(this).before('<i class="' + iconclass + '"></i>');

--- a/mockup/tests/pattern-markspeciallinks-test.js
+++ b/mockup/tests/pattern-markspeciallinks-test.js
@@ -45,6 +45,11 @@ define([
         '      <li><a href="feed://www.plone.org">feed</a></li>' +
         '      <li><a href="webcal://www.plone.org">webcal</a></li>' +
         '    </ul>' +
+        '</div>' +
+        '<div class="anchors pat-markspeciallinks">' +
+        '  <p>Find out What&#39s new in <a href="#anchor">Plone</a>.<br>' +
+        '     Plone is written in <a class="link-plain" href="http://www.python.org">Python</a>.' +
+        '  </p>' +
         '</div>');
 
 
@@ -75,6 +80,11 @@ define([
       expect(listel.eq(8).find('i').hasClass('link-callto')).to.be.equal(true);
       expect(listel.eq(9).find('i').hasClass('link-feed')).to.be.equal(true);
       expect(listel.eq(10).find('i').hasClass('link-webcal')).to.be.equal(true);
+    });
+    it('do not show the lock icon for anchor links', function() {
+      registry.scan(this.$el);
+      var link = this.$el.next('.anchors').find('p').find('a');
+      expect(link.eq(0).prev().length).to.be.equal(0);
     });
   });
 });


### PR DESCRIPTION
Backport from https://github.com/plone/mockup/pull/821 so it can be included with 5.0