### PR TITLE
Related Items: Add dropdown with recently added items.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-* add items here
+- Related Items: Add dropdown with recently added items.
+  [thet]
 
 Bug fixes:
 
@@ -42,7 +43,7 @@ New features:
 
   - Make anchor handling more flexible
   [tomgross]
-  
+
   - Mark special links
   - Do not mark anchors as special links
   [frapell]

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -335,7 +335,23 @@ define([
   };
 
   var removeHTML = function(val) {
-    return val.replace(/<[^>]+>/ig, "");
+    return val.replace(/<[^>]+>/ig, '');
+  };
+
+  var storage = {
+    // Simple local storage wrapper, which doesn't break down if it's not available.
+    get: function (name) {
+        if (window.localStorage) {
+          var val = window.localStorage[name];
+          return typeof(val) === 'string' ? JSON.parse(val) : undefined;
+      }
+    },
+
+    set: function (name, val) {
+      if (window.localStorage) {
+        window.localStorage[name] = JSON.stringify(val);
+      }
+    }
   };
 
   return {
@@ -350,6 +366,7 @@ define([
     loading: new Loading(),  // provide default loader
     parseBodyTag: parseBodyTag,
     QueryHelper: QueryHelper,
-    setId: setId
+    setId: setId,
+    storage: storage
   };
 });

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -13,6 +13,8 @@
  *    mode(string): Initial widget mode. Possible values: 'search', 'browse'. If set to 'search', the catalog is searched for a searchterm. If set to 'browse', browsing starts at basePath. Default: 'search'.
  *    orderable(boolean): Whether or not items should be drag-and-drop sortable. (true)
  *    pageSize(int): Batch size to break down big result sets into multiple pages. (10).
+ *    recentlyUsed(boolen): Show the recently used items dropdown (false).
+ *    recentlyUsedMaxItems(integer): Maximum items to keep in recently used list. 0: no restriction. (20).
  *    rootPath(string): Only display breadcrumb path elements deeper than this path. Default: "/"
  *    rootUrl(string): Visible URL up to the rootPath. This is prepended to the currentPath to generate submission URLs.
  *    scanSelection(boolean): Scan the list of selected elements for other patterns.
@@ -102,6 +104,7 @@ define([
   'translate',
   'text!mockup-patterns-relateditems-url/templates/breadcrumb.xml',
   'text!mockup-patterns-relateditems-url/templates/favorite.xml',
+  'text!mockup-patterns-relateditems-url/templates/recentlyused.xml',
   'text!mockup-patterns-relateditems-url/templates/result.xml',
   'text!mockup-patterns-relateditems-url/templates/selection.xml',
   'text!mockup-patterns-relateditems-url/templates/toolbar.xml',
@@ -109,6 +112,7 @@ define([
 ], function($, _, Base, Select2, ButtonView, utils, registry, _t,
             BreadcrumbTemplate,
             FavoriteTemplate,
+            RecentlyUsedTemplate,
             ResultTemplate,
             SelectionTemplate,
             ToolbarTemplate
@@ -135,6 +139,9 @@ define([
       contextPath: undefined,
       dropdownCssClass: 'pattern-relateditems-dropdown',
       favorites: [],
+      recentlyUsed: false,
+      recentlyUsedMaxItems: 20,
+      recentlyUsedKey: 'relateditems_recentlyused',
       maximumSelectionSize: -1,
       minimumInputLength: 0,
       mode: 'auto', // possible values are 'auto', 'search' and 'browse'.
@@ -157,6 +164,8 @@ define([
       breadcrumbTemplateSelector: null,
       favoriteTemplate: FavoriteTemplate,
       favoriteTemplateSelector: null,
+      recentlyusedTemplate: RecentlyUsedTemplate,
+      recentlyusedTemplateSelector: null,
       resultTemplate: ResultTemplate,
       resultTemplateSelector: null,
       selectionTemplate: SelectionTemplate,
@@ -167,6 +176,26 @@ define([
       // needed
       multiple: true,
 
+    },
+
+    recentlyUsed: function (filterSelectable) {
+      var ret = utils.storage.get(this.options.recentlyUsedKey) || [];
+      // hard-limit to 1000 entries
+      ret = ret.slice(ret.length-1000, ret.length);
+      if (filterSelectable) {
+        // Filter out only selectable items.
+        // This is used only to create the list of items to be displayed.
+        // the list to be stored is unfiltered and can be reused among
+        // different instances of this widget with different settings.
+        ret.filter(this.isSelectable.bind(this));
+      }
+      // max is applied AFTER filtering selectable items.
+      var max = parseInt(this.options.recentlyUsedMaxItems, 10);
+      if (max) {
+        // return the slice from the end, as we want to display newest items first.
+        ret = ret.slice(ret.length-max, ret.length);
+      }
+      return ret;
     },
 
     applyTemplate: function(tpl, item) {
@@ -190,7 +219,6 @@ define([
     },
 
     setAjax: function () {
-
       var ajax = {
 
         url: this.options.vocabularyUrl,
@@ -289,7 +317,7 @@ define([
       this.options.ajax = ajax;
     },
 
-    setBreadCrumbs: function () {
+    renderToolbar: function () {
       var self = this;
       var path = self.currentPath;
       var html;
@@ -314,6 +342,14 @@ define([
         favoritesHtml = favoritesHtml + self.applyTemplate('favorite', item_copy);
       });
 
+      var recentlyUsedHtml = '';
+      if (self.options.recentlyUsed) {
+        var recentlyUsed = self.recentlyUsed(true);  // filter out only those items which can actually be selected
+        _.each(recentlyUsed.reverse(), function (item) {  // reverse to get newest first.
+          recentlyUsedHtml = recentlyUsedHtml + self.applyTemplate('recentlyused', item);
+        });
+      }
+
       html = self.applyTemplate('toolbar', {
         items: itemsHtml,
         favItems: favoritesHtml,
@@ -321,6 +357,8 @@ define([
         searchText: _t('Current path:'),
         searchModeText: _t('Search'),
         browseModeText: _t('Browse'),
+        recentlyUsedItems: recentlyUsedHtml,
+        recentlyUsedText: _t('Recently Used'),
       });
 
       self.$toolbar.html(html);
@@ -379,6 +417,26 @@ define([
         self.browseTo($(this).attr('href'));
       });
 
+      if (self.options.recentlyUsed) {
+        $('.pattern-relateditems-recentlyused-select', self.$toolbar).on('click', function(event) {
+          event.preventDefault();
+          var uid = $(this).data('uid');
+          var item = self.recentlyUsed().filter(function (it) { return it.UID === uid; });
+          if (item.length > 0) {
+            item = item[0];
+          } else {
+            return;
+          }
+          self.selectItem(item);
+          if (self.options.maximumSelectionSize > 0) {
+            var items = self.$el.select2('data');
+            if (items.length >= self.options.maximumSelectionSize) {
+              return;
+            }
+          }
+        });
+      }
+
       function initUploadView(UploadView, disabled) {
         var uploadButtonId = 'upload-' + utils.generateId();
         var uploadButton = new ButtonView({
@@ -431,7 +489,7 @@ define([
       self.emit('before-browse');
       self.currentPath = path;
       self.$el.select2('close');
-      self.setBreadCrumbs();
+      self.renderToolbar();
       self.$el.select2('open');
       self.emit('after-browse');
     },
@@ -442,6 +500,18 @@ define([
       var data = self.$el.select2('data');
       data.push(item);
       self.$el.select2('data', data, true);
+
+      if (self.options.recentlyUsed) {
+        // add to recently added items
+        var recentlyUsed = self.recentlyUsed();  // do not filter for selectable but get all. append to that list the new item.
+        var alreadyPresent = recentlyUsed.filter(function (it) { return it.UID === item.UID; });
+        if (alreadyPresent.length > 0) {
+          recentlyUsed.splice(recentlyUsed.indexOf(alreadyPresent[0]), 1);
+        }
+        recentlyUsed.push(item);
+        utils.storage.set(self.options.recentlyUsedKey, recentlyUsed);
+      }
+
       self.emit('selected');
     },
 
@@ -544,14 +614,14 @@ define([
               $parent.removeClass('pattern-relateditems-active');
               self.deselectItem(item);
             } else {
-              self.selectItem(item);
-              $parent.addClass('pattern-relateditems-active');
               if (self.options.maximumSelectionSize > 0) {
                 var items = self.$el.select2('data');
                 if (items.length >= self.options.maximumSelectionSize) {
                   self.$el.select2('close');
                 }
               }
+              self.selectItem(item);
+              $parent.addClass('pattern-relateditems-active');
               if (self.options.closeOnSelect) {
                 self.$el.select2('close');
               }
@@ -639,7 +709,7 @@ define([
         event.preventDefault();
       });
 
-      self.setBreadCrumbs();
+      self.renderToolbar();
 
     }
   });

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -82,9 +82,30 @@
         }
     }
 
-    .favorites {
+    .favorites
+    .recentlyUsed {
         position: relative;  // make dropdown appear on right, as the dropdown is positioned absolute / left-0.
     }
+
+    .dropdown-menu {
+        padding: 1em 0;
+        a {
+            cursor: pointer;
+            display: block;
+            padding: 0.5em 1em;
+            &, &:hover {
+                text-decoration: none;
+                border-bottom: none !important;
+            }
+            &:hover {
+                background: rgba(0, 0, 0, 0.1);
+            }
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+
 }
 
 .pattern-relateditems-dropdown {
@@ -146,6 +167,7 @@
 
 }
 
+.pattern-relateditems-recentlyused-path,
 .pattern-relateditems-item-path,
 .pattern-relateditems-result-path {
     font-size: 0.8em;

--- a/mockup/patterns/relateditems/templates/recentlyused.xml
+++ b/mockup/patterns/relateditems/templates/recentlyused.xml
@@ -1,0 +1,7 @@
+<div class="pattern-relateditems-recentlyused">
+  <a class="pattern-relateditems-recentlyused-select" data-uid="<%- UID %>">
+    <% if (getURL && (getIcon || portal_type === "Image")) { %><img src="<%- getURL %>/@@images/image/icon "><br><% } %>
+    <span class="pattern-relateditems-recentlyused-title<%- portal_type ? ' contenttype-' + portal_type.toLowerCase() : '' %><%- review_state ? ' state-' + review_state : '' %>" title="<%- portal_type %>"><%- Title %></span>
+    <span class="pattern-relateditems-recentlyused-path"><%- path %></span>
+  </a>
+</div>

--- a/mockup/patterns/relateditems/templates/toolbar.xml
+++ b/mockup/patterns/relateditems/templates/toolbar.xml
@@ -10,6 +10,20 @@
   <%= items %>
 </div>
 <div class="controls pull-right">
+
+  <% if (recentlyUsedItems) { %>
+  <div class="recentlyUsed dropdown pull-right">
+    <button type="button" class="recentlyUsed dropdown-toggle btn btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <span class="glyphicon glyphicon-time"/>
+      <%- recentlyUsedText %>
+      <span class="caret"/>
+    </button>
+    <ul class="dropdown-menu">
+      <%= recentlyUsedItems %>
+    </ul>
+  </div>
+  <% } %>
+
   <% if (favorites.length > 0) { %>
   <div class="favorites dropdown pull-right">
     <button type="button" class="favorites dropdown-toggle btn btn-primary" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -101,7 +101,7 @@ define(['underscore'], function(_) {
     var app = menu.app;
 
     var result = _.clone(menuOptions);
-    if ( !(app.pasteAllowed && model.is_folderish)) {
+    if ( !(app.pasteAllowed() && model.is_folderish)) {
       delete result.pasteItem;
     }
     if (app.inQueryMode() || menu.options.canMove === false) {

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -36,17 +36,20 @@ define([
       text: '',
       label: ''
     },
-    pasteAllowed: !!$.cookie('__cp'),
     sort_on: 'getObjPositionInParent',
     sort_order: 'ascending',
     additionalCriterias: [],
     cookieSettingPrefix: '_fc_',
+
+    pasteAllowed: function () {
+        return !!$.cookie('__cp');
+    },
+
     initialize: function(options) {
       var self = this;
       BaseView.prototype.initialize.apply(self, [options]);
       self.loading = new utils.Loading();
       self.loading.show();
-      self.pasteAllowed = !!$.cookie('__cp');
 
       /* close popovers when clicking away */
       $(document).click(function(e) {
@@ -231,8 +234,7 @@ define([
     togglePasteBtn: function(){
       var self = this;
       if (_.find(self.buttons.items, function(btn){ return btn.id === 'paste'; })) {
-        self.pasteAllowed = !!$.cookie('__cp');
-        if (self.pasteAllowed) {
+        if (self.pasteAllowed()) {
           self.buttons.get('paste').enable();
         } else {
           self.buttons.get('paste').disable();

--- a/mockup/tests/pattern-relateditems-test.js
+++ b/mockup/tests/pattern-relateditems-test.js
@@ -154,6 +154,7 @@ define([
           })
         );
       });
+
     });
 
     afterEach(function() {
@@ -379,6 +380,163 @@ define([
       expect($('.path-wrapper .pattern-relateditems-path-label', $container).text()).to.be.equal('Current path:');
       expect($($('.path-wrapper .crumb')[1], $container).text()).to.be.equal('folder1');
 
+    });
+
+    it('use recently used', function () {
+      // Test if adding items add to the recently used list.
+
+      // Clear local storage at first.
+      delete localStorage.relateditems_recentlyused;
+
+      initializePattern({'selectableTypes': ['Folder'], 'recentlyUsed': true});
+      var clock = sinon.useFakeTimers();
+      var $input;
+
+      // initially - without having previously select something - the recently used button is not shown.
+      expect($('button.recentlyUsed', $container).length).to.be.equal(0);
+
+      // Select some items
+      // folder 1
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder1"]').click();
+      // folder 2
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder2"]').click();
+
+      // check, if items are selected
+      expect($('input.pat-relateditems').val()).to.be.equal('UID6,UID7');
+
+      // destroy relateditems widget and reload it
+      $('.pattern-relateditems-container').remove();
+
+      initializePattern({'selectableTypes': ['Folder'], 'recentlyUsed': true});
+
+      // after re-initialization (or page reload. no dynamic re-rendering based
+      // on the data model yet, sorry), the recently used button should be there.
+      expect($('button.recentlyUsed', $container).length).to.be.equal(1);
+
+      // last selected should be first in list.
+      expect($($('.pattern-relateditems-recentlyused-select')[0]).data('uid')).to.be.equal('UID7');
+      expect($($('.pattern-relateditems-recentlyused-select')[1]).data('uid')).to.be.equal('UID6');
+
+      // Klicking on last used item should add it to the selection.
+      $($('.pattern-relateditems-recentlyused-select')[0]).click();
+      expect($('input.pat-relateditems').val()).to.be.equal('UID7');
+
+      // done.
+    });
+
+    it('recently used deactivated', function () {
+      // Test if deactivating recently used really deactivates it.
+
+      // Clear local storage at first.
+      delete localStorage.relateditems_recentlyused;
+
+      initializePattern({'selectableTypes': ['Folder']});  // per default recently used isn't activated.
+      var clock = sinon.useFakeTimers();
+      var $input;
+
+      // initially - without having previously select something - the recently used button is not shown.
+      expect($('button.recentlyUsed', $container).length).to.be.equal(0);
+
+      // Select some items
+      // folder 1
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder1"]').click();
+      // folder 2
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder2"]').click();
+
+      // check, if items are selected
+      expect($('input.pat-relateditems').val()).to.be.equal('UID6,UID7');
+
+      // destroy relateditems widget and reload it
+      $('.pattern-relateditems-container').remove();
+
+      initializePattern({'selectableTypes': ['Folder']});
+
+      // recently used button should still not be visible
+      expect($('button.recentlyUsed', $container).length).to.be.equal(0);
+
+      // done.
+    });
+
+    it('limit recently used', function () {
+      // Test if limiting recently used items really limits the list.
+
+      // Clear local storage at first.
+      delete localStorage.relateditems_recentlyused;
+
+      // initialize without a max items setting - recently items isn't shown yet anyways.
+      initializePattern({'selectableTypes': ['Folder', 'Image'], 'recentlyUsed': true});
+      var clock = sinon.useFakeTimers();
+      var $input;
+
+      // Select some items
+      // folder 1
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder1"]').click();
+      // folder 2
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder2"]').click();
+      // image 1
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/image1"]').click();
+      // image 2
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/image2"]').click();
+
+      // check, if items are selected
+      expect($('input.pat-relateditems').val()).to.be.equal('UID6,UID7,UID8,UID9');
+
+      // destroy relateditems widget and reload it
+      $('.pattern-relateditems-container').remove();
+
+      initializePattern({'selectableTypes': ['Folder', 'Image'], 'recentlyUsed': true, 'recentlyUsedMaxItems': '2'});
+
+      // only two should be visible, last selected should be first in list.
+      expect($('.pattern-relateditems-recentlyused-select').length).to.be.equal(2);
+      expect($($('.pattern-relateditems-recentlyused-select')[0]).data('uid')).to.be.equal('UID9');
+      expect($($('.pattern-relateditems-recentlyused-select')[1]).data('uid')).to.be.equal('UID8');
+
+      // done.
+    });
+
+    it('recently used custom key', function () {
+      // Test if configuring a custom storage key for recently used has any effect.
+
+      var key = 'recently_used_cusom_key@ümläüte';
+
+      // Clear local storage at first.
+      delete localStorage[key];
+
+      // initialize without a max items setting - recently items isn't shown yet anyways.
+      initializePattern({'selectableTypes': ['Folder', 'Image'], 'recentlyUsed': true, 'recentlyUsedKey': key});
+      var clock = sinon.useFakeTimers();
+      var $input;
+
+      // Select some items
+      // folder 1
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder1"]').click();
+      // folder 2
+      $('.select2-search-field input.select2-input').click();
+      clock.tick(1000);
+      $('a.pattern-relateditems-result-select[data-path="/folder2"]').click();
+
+      var items = JSON.parse(localStorage[key]);
+      expect(items.length).to.be.equal(2);
+
+      // done.
     });
 
   });


### PR DESCRIPTION
recently used items are stored in ``localStorage``. 

note: the related PR https://github.com/plone/plone.app.relationfield/pull/21 was superseded by 
https://github.com/plone/plone.app.widgets/pull/177

merge together:
https://github.com/plone/mockup/pull/826
https://github.com/plone/Products.CMFPlone/pull/2257
https://github.com/plone/plone.app.widgets/pull/177
https://github.com/plone/plone.app.relationfield/pull/22
https://github.com/plone/plone.app.z3cform/pull/84
https://github.com/plone/Products.Archetypes/pull/102

