### PR TITLE
Modal performance: don't reposition after loading each img

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- add items here
+- Modal performance: don't reposition after loading each img
+  [cillianderoiste]
 
 
 2.7.0 (2018-01-27)

--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -845,9 +845,6 @@ define([
       self.$modal.addClass(self.options.templateOptions.classActiveName);
       registry.scan(self.$modal);
       self.positionModal();
-      $('img', self.$modal).load(function() {
-        self.positionModal();
-      });
       $(window.parent).on('resize.plone-modal.patterns', function() {
         self.positionModal();
       });


### PR DESCRIPTION
This reverts d06669e994f5a3:

   resize/position modal again once all images are loaded,
   plone/plone.app.toolbar#98

plone.app.toolbar is obsolete, and repositioning after loading each
image can get expensive. For example, if a modal contains a
DataGridField widget with reordering enabled and 20 rows, each row
contains 4 images, so the modal is repositioned 80 times.

The issue, plone/plone.app.toolbar#98, is no longer visible, so I'm
not sure if we run into other issues by removing this code.