### PR TITLE
Fixing problem with parseBodyTag when txt contains non ASCII chars.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- add items here
+- Fixing problem with parseBodyTag when txt contains
+  non ASCII chars.
+  [mamico]
 
 
 2.7.0 (2018-01-27)

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -303,7 +303,7 @@ define([
   };
 
   var parseBodyTag = function(txt) {
-    return $((/<body[^>]*>((.|[\n\r])*)<\/body>/im).exec(txt)[0]
+    return $((/<body[^>]*>[^]*<\/body>/im).exec(txt)[0]
       .replace('<body', '<div').replace('</body>', '</div>')).eq(0).html();
   };
 

--- a/mockup/tests/utils-test.js
+++ b/mockup/tests/utils-test.js
@@ -70,6 +70,18 @@ define([
         expect(fn).to.throwException(TypeError);
       });
 
+      it('parses the body tag\'s content from a response with multiple lines', function() {
+        var response = '<body><h1>foo</h1>\n\t<p>bar\n</p></body>',
+            html = utils.parseBodyTag(response);
+        expect(html).to.equal('<h1>foo</h1>\n\t<p>bar\n</p>');
+      });
+
+      it('parses the body tag\'s content from a response with not ASCII chars (e.g. line separator)', function() {
+        var response = '<body><p>foo ' + String.fromCharCode(8232) + ' bar</p></body>',
+            html = utils.parseBodyTag(response);
+        expect(html).to.equal('<p>foo ' + String.fromCharCode(8232) + ' bar</p>');
+      });
+
     });
 
     describe('bool', function() {


### PR DESCRIPTION
Current regex `((.|[\n\r])*)` doesn't match non ASCII characters. 

I've found that `[^]` (see also https://stackoverflow.com/a/36006948) could be simpler and better.

I experienced the problem in the wild with pat-modal and AJAX and a remote page with not ASCII characters.

This PR try to add tests that stress this problem and a fix to solve them.