### PR TITLE
Make it possible to customize the available image classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- add items here
+- Add `imageClasses` option to the tinymce pattern
+  to allow overriding the list of alignment classes.
+  [davisagli]
 
 Bug fixes:
 

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -568,7 +568,7 @@ define([
         src: src,
         title: title ? title : null,
         alt: self.$alt.val(),
-        'class': 'image-' + self.$align.val(),
+        'class': self.$align.val(),
         'data-linkType': self.linkType,
         'data-scale': self.$scale.val()
       }, self.linkTypes[self.linkType].attributes());
@@ -754,8 +754,8 @@ define([
           var klasses = className.split(' ');
           for (var i = 0; i < klasses.length; i = i + 1) {
             var klass = klasses[i];
-            if (klass.indexOf('image-') !== -1) {
-              self.$align.val(klass.replace('image-', ''));
+            if (self.options.imageClasses.indexOf(klass) !== -1) {
+              self.$align.val(klass);
             }
           }
         }

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -164,6 +164,11 @@ define([
         {title: 'Icon', value: 'icon'},
         {title: 'Large', value: 'large'}
       ],
+      imageClasses: {
+        'image-inline': 'Inline',
+        'image-right': 'Right',
+        'image-left': 'Left'
+      },
       targetList: [
         {text: _t('Open in this window / frame'), value: ''},
         {text: _t('Open in new window'), value: '_blank'},

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -63,9 +63,9 @@
       <div class="form-group align">
         <label><%- imageAlignText %></label>
         <select name="align">
-          <% _.each(['inline', 'right', 'left'], function(align){ %>
+          <% _.each(Object.keys(options.imageClasses), function(align){ %>
               <option value="<%- align %>">
-              <%- align.charAt(0).toUpperCase() + align.slice(1) %>
+              <%- options.imageClasses[align] %>
               </option>
           <% }); %>
         <select>


### PR DESCRIPTION
This adds an option to the tinymce pattern to make it possible to configure the available image classes / alignment options. I want to use this on one site to provide a "full width image" option.