### PR TITLE
Fix edit link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,11 @@ New features:
 - Include TinyMCE 4.7.6
   [frapell]
 
-
 Bug fixes:
+
+- Link to /edit rather than /@@edit from structure pattern actions.
+  This fixes the link for Archetypes content items.
+  [davisagli]
 
 - add items here
 

--- a/mockup/patterns/structure/js/actionmenu.js
+++ b/mockup/patterns/structure/js/actionmenu.js
@@ -119,7 +119,7 @@ define(['underscore'], function(_) {
     var typeToViewAction = app.options.typeToViewAction;
     var viewAction = typeToViewAction && typeToViewAction[model.portal_type] || '';
     result.openItem.url = model.getURL + viewAction;
-    result.editItem.url = model.getURL + '/@@edit';
+    result.editItem.url = model.getURL + '/edit';
 
     return result;
   };

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -1292,7 +1292,7 @@ define([
       expect(item.data().id).to.equal('item9');
       expect($('.title a.manage', item).attr('href')).to.equal('http://localhost:9876/item9');
       expect($('.actionmenu a.openItem', item).attr('href')).to.equal('http://localhost:9876/item9');
-      expect($('.actionmenu a.editItem', item).attr('href')).to.equal('http://localhost:9876/item9/@@edit');
+      expect($('.actionmenu a.editItem', item).attr('href')).to.equal('http://localhost:9876/item9/edit');
     });
 
     it('test navigate to folder push states', function() {


### PR DESCRIPTION
/@@edit specifies a browser view, which is not available for Archetypes content items.  /edit should work more generally.