### PR TITLE
relateditems: type timeout, allow selecting current context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,12 +14,13 @@ New features:
 
 Bug fixes:
 
+- Relateditems: Raise the timeout when typing searchterms from 100 milliseconds to 500 milliseconds to prevent a too high server load.
+  [thet]
+
 - Improved default relateditems pattern sort.
   It now defaults to search term ranking when searching
   and folder position (getObjPositionInParent) when browsing.
   [davisagli]
-
-- *add item here*
 
 
 2.7.2 (2018-04-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Relateditems: Do not filter out current context.
+  Filtering out the current context makes sense for the related items field but it can be problematic for other use cases.
+  [thet]
+
 - Relateditems: Raise the timeout when typing searchterms from 100 milliseconds to 500 milliseconds to prevent a too high server load.
   [thet]
 

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -223,7 +223,7 @@ define([
 
         url: this.options.vocabularyUrl,
         dataType: 'JSON',
-        quietMillis: 100,
+        quietMillis: 500,
 
         data: function (term, page) {
 

--- a/mockup/patterns/relateditems/pattern.js
+++ b/mockup/patterns/relateditems/pattern.js
@@ -540,10 +540,6 @@ define([
       if (item.selectable === false) {
         return false;
       }
-      if (self.options.contextPath === this.options.rootPath + item.path) {
-        // filter out current item
-        return false;
-      }
       if (self.options.selectableTypes === null) {
         return true;
       } else {


### PR DESCRIPTION
Relateditems: Raise the timeout when typing searchterms from 100 milliseconds to 500 milliseconds to prevent a too high server load.

Relateditems: Do not filter out current context.
Filtering out the current context makes sense for the related items field but it can be problematic for other use cases.