### PR TITLE
Mark external link with rel="noopener"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Mark special links: Mark external link with rel="noopener"
+  https://developers.google.com/web/tools/lighthouse/audits/noopener
+  [mamico]
 
 Bug fixes:
 

--- a/mockup/patterns/markspeciallinks/pattern.js
+++ b/mockup/patterns/markspeciallinks/pattern.js
@@ -123,7 +123,8 @@ define([
       if (elonw) {
           // all http links (without the link-plain class), not within this site
           contentarea.find('a[href^="http"]:not(.link-plain):not([href^="' + url + '"])')
-                     .attr('target', '_blank');
+                     .attr('target', '_blank')
+                     .attr('rel', 'noopener');
       }
 
       if (msl) {


### PR DESCRIPTION
For performance and security external link marked as target=_blank must be opened as rel="nopener".

More info here:
https://developers.google.com/web/tools/lighthouse/audits/noopener
https://mathiasbynens.github.io/rel-noopener/
