### PR TITLE
Bugfix: Prefill the scale drop down when "Original" was the used scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ Bug fixes:
   and folder position (getObjPositionInParent) when browsing.
   [davisagli]
 
+- Tinymce: When editing an image, and it had the 'Original' scale selected,
+  make sure that 'Original' is prefilled in the scale drop down
+  [frapell]
+
 
 2.7.2 (2018-04-08)
 ------------------

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -743,9 +743,7 @@ define([
             self.linkType = linkType;
             self.linkTypes[self.linkType].load(self.imgElm);
             var scale = self.dom.getAttrib(self.imgElm, 'data-scale');
-            if(scale){
-              self.$scale.val(scale);
-            }
+            self.$scale.val(scale);
             $('#tinylink-' + self.linkType, self.modal.$modal).trigger('click');
           }else if (src) {
             self.guessImageLink(src);


### PR DESCRIPTION
The chosen size for an image scale was being prefilled fine for all scales, except when the chosen scale was "Original", in which case the scale was an empty string.

Because of the removed "if", the chosen scale when "Original" was used, was "Large"

Steps to reproduce:

1) Open the "Insert/edit image" in TinyMCE
2) Choose an image, and choose the "Original" scale
3) Click "Insert"
4) Click the "Insert/edit image" again for the inserted image
5) Notice the "Size" drop down will now have "Large" selected

Expected result:

"Original" should be the selected option for the "Size" drop down