### PR TITLE
pat-contentloader: do not remove target

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ New features:
 
 Bug fixes:
 
+- pat-contentloader: When the content which replaces the target is empty, empty the target instead of removing it.
+  This fixes a problem, where an empty result didn't did remove the ability to successfully replace the target for subsequent content loads.
+  [thet]
+
 - Relateditems: Do not filter out current context.
   Filtering out the current context makes sense for the related items field but it can be problematic for other use cases.
   [thet]

--- a/mockup/patterns/contentloader/pattern.js
+++ b/mockup/patterns/contentloader/pattern.js
@@ -126,9 +126,16 @@ define([
       if(!$content){
         $content = $(that.options.content).clone();
       }
-      $content.show();
-      $target.replaceWith($content);
-      Registry.scan($content);
+      if ($content.length) {
+        $content.show();
+        $target.replaceWith($content);
+        Registry.scan($content);
+      } else {
+        // empty target node instead of removing it.
+        // allows for subsequent content loader calls to work sucessfully.
+        $target.empty();
+      }
+
       that.$el.removeClass('loading-content');
     }
   });


### PR DESCRIPTION
pat-contentloader: When the content which replaces the target is empty, empty the target instead of removing it.
This fixes a problem, where an empty result didn't did remove the ability to successfully replace the target for subsequent content loads.