### PR TITLE
Fix issue where webpack was unable to load TinyMCE bundle styles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Bug fixes:
   make sure that 'Original' is prefilled in the scale drop down
   [frapell]
 
+- Tinymce: Fix issue where Webpack less-loader was unable to load TinyMCE bundle styles
+  [datakurre]
 
 2.7.2 (2018-04-08)
 ------------------

--- a/mockup/patterns/tinymce/less/pattern.tinymce.less
+++ b/mockup/patterns/tinymce/less/pattern.tinymce.less
@@ -1,5 +1,5 @@
-@import (inline) "@{bowerPath}tinymce-builded/js/tinymce/skins/lightgray/skin.min.css";
-@import (inline) "@{bowerPath}tinymce-builded/js/tinymce/skins/lightgray/content.min.css";
+@import (css) "@{bowerPath}tinymce-builded/js/tinymce/skins/lightgray/skin.min.css";
+@import (css) "@{bowerPath}tinymce-builded/js/tinymce/skins/lightgray/content.min.css";
 @import (inline) "@{bowerPath}tinymce-builded/js/tinymce/plugins/visualblocks/css/visualblocks.css";
 @import "@{mockupPath}/modal/pattern.modal.less";
 @import "@{mockupPath}/autotoc/pattern.autotoc.less";


### PR DESCRIPTION
because files with relative resources were imported as with (inline) instead of (css)

https://github.com/plone/mockup/pull/832#pullrequestreview-122690361