### PR TITLE
Fix for loading country specific languages codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,8 @@ Bug fixes:
   make sure that 'Original' is prefilled in the scale drop down
   [frapell]
 
-- Fix for loading country specific language codes [lyralemos]
+- Fix for loading country specific language codes
+  [lyralemos]
 
 
 2.7.2 (2018-04-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Bug fixes:
   make sure that 'Original' is prefilled in the scale drop down
   [frapell]
 
+- Fix for loading country specific language codes [lyralemos]
+
 
 2.7.2 (2018-04-08)
 ------------------

--- a/mockup/js/i18n.js
+++ b/mockup/js/i18n.js
@@ -20,7 +20,7 @@ define([
     }
     self.currentLanguage = $('html').attr('lang') || 'en-us';
 
-    //Fix for country specific languages
+    // Fix for country specific languages
     if (self.currentLanguage.split('-').length > 1) {
       self.currentLanguage = self.currentLanguage.split('-')[0] + '_' + self.currentLanguage.split('-')[1].toUpperCase();
     }

--- a/mockup/js/i18n.js
+++ b/mockup/js/i18n.js
@@ -19,6 +19,12 @@ define([
       self.baseUrl = '/plonejsi18n';
     }
     self.currentLanguage = $('html').attr('lang') || 'en-us';
+
+    //Fix for country specific languages
+    if (self.currentLanguage.split('-').length > 1) {
+      self.currentLanguage = self.currentLanguage.split('-')[0] + '_' + self.currentLanguage.split('-')[1].toUpperCase();
+    }
+
     self.storage = null;
     self.catalogs = {};
     self.ttl = 24 * 3600 * 1000;


### PR DESCRIPTION
With this fix, country specific language codes are correctly loaded. Fixes plone/Products.CMFPlone#949

As language codes are obtained via lang property in the html tag, there is an inconsistency with Plone locales code base. For instance, Brazilian Portuguese lang attribute is pt-br, but in plone locales is referred to as pt_BR.

This code does a simple transformation on the language code so that correct translations are loaded.