### PR TITLE
Structure fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Breaking changes:
 
 New features:
 
+- pat-structure: Use more tooltips in the actions menu.
+  [thet]
+
+- pat-structure: Move breadcrumbs out of folder contents table.
+  [thet]
+
 - pat-structure: Use the datatables pattern for sorting columns 
   [frapell]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,23 +16,22 @@ New features:
 - pat-structure: Move breadcrumbs out of folder contents table.
   [thet]
 
-- pat-structure: Use the datatables pattern for sorting columns 
+- pat-structure: Use the datatables pattern for sorting columns.
   [frapell]
 
-- pat-structure: Add a '250' option for the pagination
+- pat-structure: Add a '250' option for the pagination.
   [frapell]
 
-- Add a new pattern, to provide the DataTables functionality
+- Add a new pattern, to provide the DataTables functionality.
   https://datatables.net/
   [frapell]
-- *add item here*
 
 Bug fixes:
 
 - Get rid of obsolete ``X-UA-Compatible`` header.
   [hvelarde]
 
-- fix small message typos
+- Fix small message typos.
   [tkimnguyen]
 
 

--- a/mockup/patterns/datatables/pattern.datatables.less
+++ b/mockup/patterns/datatables/pattern.datatables.less
@@ -1,7 +1,7 @@
-@import (css) "@{bowerPath}/datatables.net-bs/css/dataTables.bootstrap.css";
-@import (css) "@{bowerPath}/datatables.net-buttons-bs/css/buttons.bootstrap.min.css";
-@import (css) "@{bowerPath}/datatables.net-colreorder-bs/css/colReorder.bootstrap.min.css";
-@import (css) "@{bowerPath}/datatables.net-rowreorder-bs/css/rowReorder.bootstrap.min.css";
-@import (css) "@{bowerPath}/datatables.net-select-bs/css/select.bootstrap.min.css";
-@import (css) "@{bowerPath}/datatables.net-fixedheader-bs/css/fixedHeader.bootstrap.min.css";
-@import (css) "@{bowerPath}/datatables.net-fixedcolumns-bs/css/fixedColumns.bootstrap.min.css";
+@import (inline) "@{bowerPath}/datatables.net-bs/css/dataTables.bootstrap.css";
+@import (inline) "@{bowerPath}/datatables.net-buttons-bs/css/buttons.bootstrap.min.css";
+@import (inline) "@{bowerPath}/datatables.net-colreorder-bs/css/colReorder.bootstrap.min.css";
+@import (inline) "@{bowerPath}/datatables.net-rowreorder-bs/css/rowReorder.bootstrap.min.css";
+@import (inline) "@{bowerPath}/datatables.net-select-bs/css/select.bootstrap.min.css";
+@import (inline) "@{bowerPath}/datatables.net-fixedheader-bs/css/fixedHeader.bootstrap.min.css";
+@import (inline) "@{bowerPath}/datatables.net-fixedcolumns-bs/css/fixedColumns.bootstrap.min.css";

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -147,7 +147,7 @@ define([
                     // Clear the status message
                     self.app.setStatus();
                   });
-        self.app.setStatus(_t('Cannot drag and drop items to reorder while manually sorting a column'), 'warning', btn = btn);
+        self.app.setStatus(_t('Drag and drop not possible while non-permanent column sorting active.'), 'warning', btn = btn);
         $(".pat-datatables tbody").find('tr').off("drag")
         self.$el.removeClass('order-support');
       } );

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -76,7 +76,7 @@ define([
       var datatables_options = {
         "aaSorting": [],
         "aoColumnDefs": [
-          { "bSortable": false, "aTargets": [ 0, self.app.activeColumns.length + 1 ] }
+          { "bSortable": false, "aTargets": [ 0, self.app.activeColumns.length + 2 ] }
         ],
         "paging": false,
         "searching": false,

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -71,12 +71,12 @@ define([
       var self = this;
 
       // By default do not start sorted by any column
-      // Ignore first column and the last one (activeColumns.length + 2)
+      // Ignore first column and the last one (activeColumns.length + 1)
       // Do not show paginator, search or information, we only want column sorting
       var datatables_options = {
         "aaSorting": [],
         "aoColumnDefs": [
-          { "bSortable": false, "aTargets": [ 0, self.app.activeColumns.length + 2 ] }
+          { "bSortable": false, "aTargets": [ 0, self.app.activeColumns.length + 1 ] }
         ],
         "paging": false,
         "searching": false,

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -147,7 +147,7 @@ define([
                     // Clear the status message
                     self.app.setStatus();
                   });
-        self.app.setStatus(_t('Drag and drop not possible while non-permanent column sorting active.'), 'warning', btn = btn);
+        self.app.setStatus(_t('Notice: Drag and drop reordering is disabled when viewing the contents sorted by a column.'), 'warning', btn = btn);
         $(".pat-datatables tbody").find('tr').off("drag")
         self.$el.removeClass('order-support');
       } );

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -42,8 +42,7 @@ define([
       contextInfoUrl: null, // for add new dropdown and other info
       setDefaultPageUrl: null,
       menuOptions: null, // default action menu options per item.
-      // default menu generator
-      menuGenerator: 'mockup-patterns-structure-url/js/actionmenu',
+      menuGenerator: 'mockup-patterns-structure-url/js/actionmenu',  // default menu generator
       backdropSelector: '.plone-modal', // Element upon which to apply backdrops used for popovers
 
       activeColumnsCookie: 'activeColumns',
@@ -135,30 +134,30 @@ define([
 
       buttons: null,
       _default_buttons: [{
-        title: 'Cut',
+        tooltip: 'Cut',
         url: '/cut'
       },{
-        title: 'Copy',
+        tooltip: 'Copy',
         url: '/copy'
       },{
-        title: 'Paste',
+        tooltip: 'Paste',
         url: '/paste'
       },{
-        title: 'Delete',
+        tooltip: 'Delete',
         url: '/delete',
         context: 'danger',
         icon: 'trash'
       },{
-        title: 'Workflow',
+        tooltip: 'Workflow',
         url: '/workflow'
       },{
-        title: 'Tags',
+        tooltip: 'Tags',
         url: '/tags'
       },{
-        title: 'Properties',
+        tooltip: 'Properties',
         url: '/properties'
       },{
-        title: 'Rename',
+        tooltip: 'Rename',
         url: '/rename'
       }],
 

--- a/mockup/patterns/structure/pattern.js
+++ b/mockup/patterns/structure/pattern.js
@@ -135,29 +135,37 @@ define([
       buttons: null,
       _default_buttons: [{
         tooltip: 'Cut',
+        title: 'Cut',
         url: '/cut'
       },{
         tooltip: 'Copy',
+        title: 'Copy',
         url: '/copy'
       },{
         tooltip: 'Paste',
+        title: 'Paste',
         url: '/paste'
       },{
         tooltip: 'Delete',
+        title: 'Delete',
         url: '/delete',
         context: 'danger',
         icon: 'trash'
       },{
         tooltip: 'Workflow',
+        title: 'Workflow',
         url: '/workflow'
       },{
         tooltip: 'Tags',
+        title: 'Tags',
         url: '/tags'
       },{
         tooltip: 'Properties',
+        title: 'Properties',
         url: '/properties'
       },{
         tooltip: 'Rename',
+        title: 'Rename',
         url: '/rename'
       }],
 

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -3,24 +3,25 @@
   <span><%- status.text %></span>&nbsp;<% // &nbsp; to get correct height for empty alerts %>
 </div>
 
+<div class="fc-breadcrumbs-container">
+  <div class="fc-breadcrumbs" colspan="<%- activeColumns.length + 3 %>">
+    <a href="#" data-path="/">
+      <span class="glyphicon glyphicon-home"></span> /
+    </a>
+    <% _.each(pathParts, function(part, idx, list){
+      if(part){
+        if(idx > 0){ %>
+          /
+        <% } %>
+        <a href="#" class="crumb" data-path="<%- part %>"><%- part %></a>
+      <% }
+    }); %>
+  </div>
+</div>
+
 <table class="pat-datatables table table-striped table-bordered"
        data-pat-datatables="<%- datatables_options %>">
   <thead>
-    <tr class="fc-breadcrumbs-container">
-      <td class="fc-breadcrumbs" colspan="<%- activeColumns.length + 3 %>">
-        <a href="#" data-path="/">
-          <span class="glyphicon glyphicon-home"></span> /
-        </a>
-        <% _.each(pathParts, function(part, idx, list){
-          if(part){
-            if(idx > 0){ %>
-              /
-            <% } %>
-            <a href="#" class="crumb" data-path="<%- part %>"><%- part %></a>
-          <% }
-        }); %>
-      </td>
-    </tr>
     <tr>
       <th class="selection"><input type="checkbox" class="select-all" /></th>
       <th class="title"><%- _t('Title') %></th>

--- a/mockup/patterns/tooltip/pattern.js
+++ b/mockup/patterns/tooltip/pattern.js
@@ -58,7 +58,7 @@ define([
 
   bootstrapTooltip.DEFAULTS = {
     animation: true,
-    placement: 'top',
+    placement: 'auto',
     selector: false,
     template: '<div class="tooltip mockup-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',
     trigger: 'hover focus',

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -1155,7 +1155,7 @@ define([
     it('test select displayed columns', function() {
       registry.scan(this.$el);
       this.clock.tick(500);
-      var $row = this.$el.find('table thead tr').eq(1);
+      var $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(6);
       expect($row.find('th').eq(1).text().trim()).to.equal('Title');
       expect($row.find('th').eq(2).text().trim()).to.equal('Last modified');
@@ -1179,7 +1179,7 @@ define([
       $popover.find('button').trigger('click');
       this.clock.tick(500);
 
-      $row = this.$el.find('table thead tr').eq(1);
+      $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(7);
       expect($row.find('th').eq(5).text().trim()).to.equal('Object Size');
       expect($row.find('th').eq(6).text().trim()).to.equal('Actions');
@@ -1191,7 +1191,7 @@ define([
       $popover.find('button').trigger('click');
       this.clock.tick(500);
 
-      $row = this.$el.find('table thead tr').eq(1);
+      $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(6);
       expect($.parseJSON($.cookie('_fc_activeColumns')).value).to.eql(
           ["ModificationDate", "EffectiveDate", "review_state"]);
@@ -1461,7 +1461,7 @@ define([
                '{"value":["ModificationDate","EffectiveDate","review_state",' +
                '"getObjSize"]}');
       this.clock.tick(500);
-      var $row = this.$el.find('table thead tr').eq(1);
+      var $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(6);
       expect($row.find('th').eq(5).text().trim()).to.equal('Actions');
 
@@ -1481,7 +1481,7 @@ define([
       $popover.find('button').trigger('click');
       this.clock.tick(500);
 
-      $row = this.$el.find('table thead tr').eq(1);
+      $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(7);
       expect($row.find('th').eq(5).text().trim()).to.equal('Type');
       expect($row.find('th').eq(6).text().trim()).to.equal('Actions');
@@ -1496,7 +1496,7 @@ define([
       $popover.find('button').trigger('click');
       this.clock.tick(500);
 
-      $row = this.$el.find('table thead tr').eq(1);
+      $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(6);
       expect($.parseJSON($.cookie('_fc_activeColumnsCustom')).value).to.eql(
           ["ModificationDate", "EffectiveDate", "review_state"]);
@@ -1597,7 +1597,7 @@ define([
     it('test select displayed columns', function() {
       registry.scan(this.$el);
       this.clock.tick(500);
-      var $row = this.$el.find('table thead tr').eq(1);
+      var $row = this.$el.find('table thead tr').eq(0);
       expect($row.find('th').length).to.equal(4);
       expect($row.find('th').eq(1).text().trim()).to.equal('Title');
       expect($row.find('th').eq(2).text().trim()).to.equal('Object Size');


### PR DESCRIPTION
Some changes which add to previous commits:

- The column count for the datatables initialization was wrong and led to a bunch of errors.

- Datatable CSS imports need to be with (inline) option, otherwise only a CSS import directive is included which leads to 404 errors.

- The Drag & Drop status message was not very clear to me. IMO thats better (@tkimnguyen plz have a look at that change)


Two new things:

- pat-structure: Use more tooltips in the actions menu.
- pat-structure: Move breadcrumbs out of folder contents table.