### PR TITLE
Fix 675: Remove patternslib "This pattern without a name attribute will not be…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,10 @@ Bug fixes:
 - fix small message typos
   [tkimnguyen]
 
+- Remove patternslib "This pattern without a name attribute will not be
+  registered!" warnings by setting dummy name and trigger properties.
+  [sunew]
+
 
 2.7.4 (2018-06-21)
 ------------------

--- a/mockup/patterns/thememapper/pattern.js
+++ b/mockup/patterns/thememapper/pattern.js
@@ -50,6 +50,8 @@ define([
   var inspectorTemplate = _.template(InspectorTemplate);
 
   var Inspector = Base.extend({
+    name: 'thememapper-inspector',
+    trigger: '.pat-thememapper-inspector-dummy',
     defaults: {
       name: 'name',
       ruleBuilder: null,
@@ -505,7 +507,7 @@ define([
           self.hideInspectors();
         }
       });
-      
+
       self.btns.buildRuleButton = new AnchorView({
         id: 'buildrule',
         title: _t('Build rule'),
@@ -588,7 +590,7 @@ define([
         triggerView: self.btns.buildLessButton,
         app: self
       });
-      
+
 
       self.menus.tools = new DropdownView({
         title: _t('Tools'),
@@ -601,7 +603,7 @@ define([
         icon: 'file',
         disable: function() {}
       });
-      
+
       self.buttonGroup = new ButtonGroup({
         items: [
           self.menus.tools,

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -14,6 +14,8 @@ define([
   'use strict';
 
   var LinkType = Base.extend({
+    name: 'linktype',
+    trigger: '.pat-linktype-dummy',
     defaults: {
       linkModal: null // required
     },
@@ -55,6 +57,8 @@ define([
   });
 
   var ExternalLink = LinkType.extend({
+    name: 'externallinktype',
+    trigger: '.pat-externallinktype-dummy',
     init: function() {
       LinkType.prototype.init.call(this);
       this.getEl().on('change', function(){
@@ -73,6 +77,8 @@ define([
   });
 
   var InternalLink = LinkType.extend({
+    name: 'internallinktype',
+    trigger: '.pat-internallinktype-dummy',
     init: function() {
       LinkType.prototype.init.call(this);
       this.getEl().addClass('pat-relateditems');
@@ -134,6 +140,8 @@ define([
   });
 
   var UploadLink = LinkType.extend({
+    name: 'uploadlinktype',
+    trigger: '.pat-uploadlinktype-dummy',
     /* need to do it a bit differently here.
        when a user uploads and tries to upload from
        it, you need to delegate to the real insert
@@ -163,6 +171,8 @@ define([
   });
 
   var ImageLink = InternalLink.extend({
+    name: 'imagelinktype',
+    trigger: '.pat-imagelinktype-dummy',
     toUrl: function() {
       var value = this.value();
       return this.tinypattern.generateImageUrl(value, this.linkModal.$scale.val());
@@ -170,6 +180,8 @@ define([
   });
 
   var EmailLink = LinkType.extend({
+    name: 'emaillinktype',
+    trigger: '.pat-emaillinktype-dummy',
     toUrl: function() {
       var self = this;
       var val = self.value();
@@ -201,6 +213,8 @@ define([
   });
 
   var AnchorLink = LinkType.extend({
+    name: 'anchorlinktype',
+    trigger: '.pat-anchorlinktype-dummy',
     init: function() {
       LinkType.prototype.init.call(this);
       this.$select = this.$el.find('select');


### PR DESCRIPTION
… registered!" warnings by setting dummy name and trigger properties

Fixes https://github.com/plone/mockup/issues/675

If this approach is ok, merge.