### PR TITLE
Fix error when running tests: "Some of your tests did a full page reload"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Bug fixes:
   registered!" warnings by setting dummy name and trigger properties.
   [sunew]
 
+- Fix error when running tests: "Some of your tests did a full page reload!", due to a form submit with no preventDefault.
+  [sunew]
+
 
 2.7.4 (2018-06-21)
 ------------------

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -503,6 +503,10 @@ define([
       var changed_txt = 'changed contents';
       $editable.html(changed_txt);
       var $form = $container.find('form');
+      // Avoid error when running tests: "Some of your tests did a full page reload!"
+      $container.submit(function(e) {
+        e.preventDefault();
+      });
       $container.trigger('submit');
       expect($el.val()).to.be.equal(changed_txt);
       tinymce.get(0).remove();


### PR DESCRIPTION
Was not visible in PhantomJS, but happens in Chrome and FF testruns.
(before https://github.com/plone/mockup/pull/861 that is, that causes it to appear in PhantomJS too).

Was due to a form submit with no preventDefault in a testcase.

This fix should be merged before #861 