### PR TITLE
Improve docs styles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Improve docs styles
+  [ale-rt]
 
 
 2.7.6 (2018-10-08)

--- a/mockup/less/docs.less
+++ b/mockup/less/docs.less
@@ -134,7 +134,11 @@ body {
       padding: 0.5em;
       border: 1px solid #CCC;
       display: block;
-      height: 135px;
+      overflow-y: auto;
+
+      h2 {
+        font-size: @font-size-base * 2;
+      }
 
       &:focus {
         outline: none;
@@ -311,5 +315,11 @@ body {
         padding-left: 2em;
       }
     }
+  }
+}
+
+@media (min-width: @screen-sm-min) {
+  .mockup-content .mockup-patterns .mockup-pattern-tile {
+    height: 160px;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mockup",
-  "version": "2.7.5",
+  "version": "2.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
See before and after comparison screenshots:
![image](https://user-images.githubusercontent.com/1300763/47962186-3acb3400-e019-11e8-90d6-3e6ad54bd822.png)
Note the overflow of the description of the "Textarea MimeType Selector" pattern

![image](https://user-images.githubusercontent.com/1300763/47962215-a0b7bb80-e019-11e8-8234-82c2b31b512f.png)
No need to waste vertical space on mobile

