### PR TITLE
pat-resourceregistry: Add load_async and load_defer options.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- pat-resourceregistry: Add ``load_async`` and ``load_defer`` options.
+- pat-resourceregistry:
+  - Add input fiels for ``merge_with``, ``last_compilation``, ``jscompilation`` and ``csscompilation``.
+  - Add ``load_async`` and ``load_defer`` options.
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- pat-resourceregistry: Add ``load_async`` and ``load_defer`` options.
+  [thet]
 
 Bug fixes:
 

--- a/mockup/patterns/resourceregistry/js/fields.js
+++ b/mockup/patterns/resourceregistry/js/fields.js
@@ -366,6 +366,16 @@ define([
     }
   });
 
+
+  var MergeWithFieldView = ResourceSelectFieldView.extend({
+    multiple: false,
+    getSelectOptions: function() {
+      var self = this;
+      return ['', 'default', 'logged-in'];
+    }
+  });
+
+
   return {
     ResourceDisplayFieldView: ResourceDisplayFieldView,
     VariableFieldView: VariableFieldView,
@@ -376,6 +386,7 @@ define([
     BundleResourcesFieldView: BundleResourcesFieldView,
     BundleDependsFieldView: BundleDependsFieldView,
     ResourceBoolFieldView: ResourceBoolFieldView,
-    PatternFieldView: PatternFieldView
+    PatternFieldView: PatternFieldView,
+    MergeWithFieldView: MergeWithFieldView
   };
 });

--- a/mockup/patterns/resourceregistry/js/registry.js
+++ b/mockup/patterns/resourceregistry/js/registry.js
@@ -116,6 +116,14 @@ define([
       title: _t('Conditional comment'),
       description: _t('Internet Explorer conditional comment')
     }, {
+      name: 'load_async',
+      title: _t('Load JavaScript asynchronously?'),
+      view: fields.ResourceBoolFieldView
+    }, {
+      name: 'load_defer',
+      title: _t('Load JavaScript deferred?'),
+      view: fields.ResourceBoolFieldView
+    }, {
       name: 'compile',
       title: _t('Does your bundle contain any RequireJS or LESS files?'),
       view: fields.ResourceBoolFieldView

--- a/mockup/patterns/resourceregistry/js/registry.js
+++ b/mockup/patterns/resourceregistry/js/registry.js
@@ -128,20 +128,22 @@ define([
       title: _t('Does your bundle contain any RequireJS or LESS files?'),
       view: fields.ResourceBoolFieldView
     }, {
+      name: 'merge_with',
+      title: _t('Merge with'),
+      description: _t('In production, the bundle is merged together with others. Select which one here.'),
+      view: fields.MergeWithFieldView
+    }, {
       name: 'last_compilation',
       title: _t('Last compilation'),
-      description: _t('Date/Time when your bundle was last compiled. Empty, if it was never compiled.'),
-      view: fields.ResourceDisplayFieldView
+      description: _t('Date/Time when your bundle was last compiled. Empty, if it was never compiled.')
     }, {
       name: 'jscompilation',
       title: _t('Compiled JavaScript'),
-      description: _t('Automatically generated path to the compiled JavaScript.'),
-      view: fields.ResourceDisplayFieldView
+      description: _t('Automatically generated path to the compiled JavaScript.')
     }, {
       name: 'csscompilation',
       title: _t('Compiled CSS'),
-      description: _t('Automatically generated path to the compiled CSS.'),
-      view: fields.ResourceDisplayFieldView
+      description: _t('Automatically generated path to the compiled CSS.')
     }, {
       name: 'stub_js_modules',
       title: _t('Stub JS Modules'),


### PR DESCRIPTION
- pat-resourceregistry:
  - Add input fiels for ``merge_with``, ``last_compilation``, ``jscompilation`` and ``csscompilation``.
  - Add ``load_async`` and ``load_defer`` options.

the resource registry looks now like: 
![screenshot_2018-12-04 plone site 1](https://user-images.githubusercontent.com/170891/49482360-1daf9e00-f82f-11e8-8c20-7fb70f898ed3.png)


Merge:
https://github.com/plone/Products.CMFPlone/pull/2644
https://github.com/plone/mockup/pull/879
https://github.com/plone/plone.app.upgrade/pull/186