### PR TITLE
Fix bugs on Moment.js lazy loading

### DIFF
--- a/mockup/patterns/moment/pattern.js
+++ b/mockup/patterns/moment/pattern.js
@@ -96,22 +96,20 @@ define([
     'mr ms-my ms my nb ne nl nn pl pt-br pt ro ru se si sk sl sq sr-cyrl ' +
     'sr sv sw ta te th tl-ph tlh tr tzl tzm-latn tzm uk uz vi zh-cn zh-tw';
 
-  lazyLoadMomentLocale(currentLanguage);
-
   function isLangSupported(lang) {
     return MOMENT_LOCALES.split(' ').indexOf(lang) !== -1;
   }
 
-  function lazyLoadMomentLocale(lang) {
+  function lazyLoadMomentLocale() {
     var LANG_FALLBACK = 'en';
 
-    if (lang === LANG_FALLBACK) {
+    if (currentLanguage === LANG_FALLBACK) {
       // English locale is built-in, no need to load
       return;
     }
 
     // Format language as expect by Moment.js, neither POSIX (like TinyMCE) nor IETF
-    lang = lang.replace('_', '-').toLowerCase();
+    var lang = currentLanguage.replace('_', '-').toLowerCase();
 
     // Use language code as fallback, otherwise built-in English locale
     lang = isLangSupported(lang) ? lang : lang.split('-')[0];
@@ -122,6 +120,8 @@ define([
 
     require(['moment-url/' + lang]);
   }
+
+  lazyLoadMomentLocale();
 
   var Moment = Base.extend({
     name: 'moment',

--- a/mockup/patterns/moment/pattern.js
+++ b/mockup/patterns/moment/pattern.js
@@ -104,7 +104,8 @@ define([
     var LANG_FALLBACK = 'en';
 
     if (currentLanguage === LANG_FALLBACK) {
-      // English locale is built-in, no need to load
+      // English locale is built-in, no need to load, so let's exit early
+      // to avoid computing fallback, which happens at every loaded page
       return;
     }
 

--- a/news/894.fix
+++ b/news/894.fix
@@ -1,0 +1,2 @@
+* Fix bugs in Moment.js lazy locales, affecting: language variant fallbacks, variable leak to global namespace, IE11 widget support
+  [davilima6]


### PR DESCRIPTION
- Avoid leaking lazyLoadMomentLocale to global namespace
- Fix bug by not lower casing mockup-i18n's currentLanguage
- Fix bug on IE11 due to lack of support for 'includes'