### PR TITLE
Fix alignment of the default page objects in the structure pattern

### DIFF
--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -259,6 +259,8 @@
     .itemRow.default-page .title > *:first-child:before{
         content: '*';
         color: red;
+        position: fixed;
+        text-indent: -4px;
     }
 
 }

--- a/news/895.bugfix
+++ b/news/895.bugfix
@@ -1,0 +1,1 @@
+Fix alignment of the default page objects in the structure pattern


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1300763/53285676-9f92d180-3763-11e9-9505-89f8b15e3c89.png)
After:
![image](https://user-images.githubusercontent.com/1300763/53285753-97876180-3764-11e9-9668-6782b4098304.png)

Closes #895 