### PR TITLE
pat-inlinevalidation: Avoid submitting files

### DIFF
--- a/mockup/patterns/inlinevalidation/pattern.js
+++ b/mockup/patterns/inlinevalidation/pattern.js
@@ -98,11 +98,14 @@ define([
         var $input = $(input),
             $field = $input.closest('.field'),
             $form = $field.closest('form'),
+            $cloned_form = $form.clone(),
             fname = $field.attr('data-fieldname');
 
+        // XXX: Remove binary files so they are not uploaded to server
+        $cloned_form.find("input[type=file]").remove();
         this.queue($.proxy(function(next) {
-            $form.ajaxSubmit({
-                url: this.append_url_path($form.attr('action'), '@@formlib_validate_field'),
+            $cloned_form.ajaxSubmit({
+                url: this.append_url_path($cloned_form.attr('action'), '@@formlib_validate_field'),
                 data: {fname: fname},
                 iframe: false,
                 success: $.proxy(function (data) {
@@ -119,13 +122,16 @@ define([
         var $input = $(input),
             $field = $input.closest('.field'),
             $form = $field.closest('form'),
+            $cloned_form = $form.clone(),
             fset = $input.closest('fieldset').attr('data-fieldset'),
             fname = $field.attr('data-fieldname');
 
+        // XXX: Remove binary files so they are not uploaded to server
+        $cloned_form.find("input[type=file]").remove();
         if (fname) {
           this.queue($.proxy(function(next) {
-              $form.ajaxSubmit({
-                  url: this.append_url_path($form.attr('action'), '@@z3cform_validate_field'),
+              $cloned_form.ajaxSubmit({
+                  url: this.append_url_path($cloned_form.attr('action'), '@@z3cform_validate_field'),
                   data: {fname: fname, fset: fset},
                   iframe: false,
                   success: $.proxy(function (data) {

--- a/news/903.fix
+++ b/news/903.fix
@@ -1,0 +1,2 @@
+* pat-inlinevalidation: Avoid submitting files 
+  [frapell]


### PR DESCRIPTION
The way I am fixing this issue, is by 
1) clone the original form
2) remove any ``<input type="file">`` from it
3) submit this cloned form instead

If an error comes from the validation, it will be rendered in the original form