### PR TITLE
Revert "Fix alignment of the default page objects in the structure pattern"

### DIFF
--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -259,8 +259,6 @@
     .itemRow.default-page .title > *:first-child:before{
         content: '*';
         color: red;
-        position: fixed;
-        text-indent: -4px;
     }
 
 }


### PR DESCRIPTION
Reverts plone/mockup#896

`position: fixed;` makes the asterisk stay in the same position even when the page is scrolled up and down.