### PR TITLE
Position the asterisk inside its parent,

### DIFF
--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -259,7 +259,7 @@
     .itemRow.default-page .title > *:first-child:before{
         content: '*';
         color: red;
-        position: fixed;
+        position: absolute;
         text-indent: -4px;
     }
 

--- a/news/895.bugfix
+++ b/news/895.bugfix
@@ -1,1 +1,1 @@
-Fix alignment of the default page objects in the structure pattern with absolute positioning.
+Fix alignment of the default page objects in the structure pattern.

--- a/news/895.bugfix
+++ b/news/895.bugfix
@@ -1,1 +1,1 @@
-Fix alignment of the default page objects in the structure pattern.
+Fix alignment of the default page objects in the structure pattern

--- a/news/895.bugfix
+++ b/news/895.bugfix
@@ -1,1 +1,1 @@
-Fix alignment of the default page objects in the structure pattern
+Fix alignment of the default page objects in the structure pattern with absolute positioning.

--- a/news/908.bugfix
+++ b/news/908.bugfix
@@ -1,0 +1,1 @@
+Absolute positioning of default page objects in the structure pattern (take 2 on issue #895)


### PR DESCRIPTION
instead of fixing it on the page.