### PR TITLE
Add image caption support

### DIFF
--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -483,6 +483,7 @@ define([
         externalImageText: this.options.text.externalImageText,
         altText: this.options.text.alt,
         imageAlignText: this.options.text.imageAlign,
+        captionFromDescriptionText: this.options.text.captionFromDescription,
         captionText: this.options.text.caption,
         scaleText: this.options.text.scale,
         imageScales: this.options.imageScales,
@@ -503,9 +504,10 @@ define([
       self.$subject = $('input[name="subject"]', self.modal.$modal);
 
       self.$alt = $('input[name="alt"]', self.modal.$modal);
-      self.$caption = $('textarea[name="caption"]', self.modal.$modal);
       self.$align = $('select[name="align"]', self.modal.$modal);
       self.$scale = $('select[name="scale"]', self.modal.$modal);
+      self.$captionFromDescription = $('input[name="captionFromDescription"]', self.modal.$modal);
+      self.$caption = $('textarea[name="caption"]', self.modal.$modal);
 
       /* load up all the link types */
       _.each(self.options.linkTypes, function(type) {
@@ -525,6 +527,15 @@ define([
           }
         });
       });
+
+      self.$captionFromDescription.change(function () {
+        if (this.checked) {
+          self.$caption.prop('disabled', true);
+        } else {
+          self.$caption.prop('disabled', false);
+        }
+      });
+
     },
 
     getLinkUrl: function() {
@@ -584,15 +595,21 @@ define([
     updateImage: function(src) {
       var self = this;
       var title = self.$title.val();
+      var captionFromDescription = self.$captionFromDescription.prop('checked')
 
       self.tiny.focus();
       self.tiny.selection.setRng(self.rng);
+
+      var cssclasses = ['image-richtext', self.$align.val()];
+      if (captionFromDescription) {
+        cssclasses.push('captioned');
+      }
 
       var data = $.extend(true, {}, {
         src: src,
         title: title ? title : null,
         alt: self.$alt.val(),
-        'class': self.$align.val() + ' image-richtext',
+        'class': cssclasses.join(' '),
         'data-linkType': self.linkType,
         'data-scale': self.$scale.val(),
       }, self.linkTypes[self.linkType].attributes());
@@ -624,7 +641,7 @@ define([
       var html_inner = self.dom.createHTML('img', data);
       var caption = self.$caption.val();
       var html_string;
-      if (caption) {
+      if (caption && ! captionFromDescription) {
         html_inner += '\n' + self.dom.createHTML('figcaption', {}, caption);
         //html_inner += '\n' + self.dom.createHTML('figcaption', { class: 'mceNonEditable' }, caption);
         html_string = self.dom.createHTML('figure', {}, html_inner);
@@ -778,18 +795,23 @@ define([
           caption = self.selectedElm;
         }
 
-        self.captionElm = caption;
-        if (self.captionElm) {
-          self.$caption.val(self.captionElm.innerHTML);
-        }
-
         self.imgElm = img;
         self.figureElm = figure;
+        self.captionElm = caption;
 
         if (self.imgElm) {
           var src = self.dom.getAttrib(self.imgElm, 'src');
           self.$title.val(self.dom.getAttrib(self.imgElm, 'title'));
           self.$alt.val(self.dom.getAttrib(self.imgElm, 'alt'));
+
+          if ($(self.imgElm).hasClass('captioned')) {
+            self.$captionFromDescription.prop('checked', true);
+            self.$caption.prop('disabled', true);
+          }
+          if (self.captionElm) {
+            self.$caption.val(self.captionElm.innerHTML);
+          }
+
           linkType = self.dom.getAttrib(self.imgElm, 'data-linktype');
           if (linkType) {
             self.linkType = linkType;

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -173,9 +173,6 @@ define([
   var ImageLink = InternalLink.extend({
     name: 'imagelinktype',
     trigger: '.pat-imagelinktype-dummy',
-    originalSrc: function() {
-      return this.tinypattern.generateImageUrl(this.value());
-    },
     toUrl: function() {
       var value = this.value();
       return this.tinypattern.generateImageUrl(value, this.linkModal.$scale.val());
@@ -601,7 +598,6 @@ define([
         'class': self.$align.val() + ' image-richtext',
         'data-linkType': self.linkType,
         'data-scale': self.$scale.val(),
-        'data-src': this.linkTypes[this.linkType].originalSrc ? this.linkTypes[this.linkType].originalSrc() : src,
       }, self.linkTypes[self.linkType].attributes());
       if (self.imgElm && !self.imgElm.getAttribute('data-mce-object')) {
         data.width = self.dom.getAttrib(self.imgElm, 'width');

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -484,7 +484,6 @@ define([
         altText: this.options.text.alt,
         imageAlignText: this.options.text.imageAlign,
         captionText: this.options.text.caption,
-        imageCaption: this.options.imageCaption,
         scaleText: this.options.text.scale,
         imageScales: this.options.imageScales,
         cancelBtn: this.options.text.cancelBtn,
@@ -504,9 +503,7 @@ define([
       self.$subject = $('input[name="subject"]', self.modal.$modal);
 
       self.$alt = $('input[name="alt"]', self.modal.$modal);
-      if (this.options.imageCaption) {
-        self.$caption = $('textarea[name="caption"]', self.modal.$modal);
-      }
+      self.$caption = $('textarea[name="caption"]', self.modal.$modal);
       self.$align = $('select[name="align"]', self.modal.$modal);
       self.$scale = $('select[name="scale"]', self.modal.$modal);
 
@@ -616,16 +613,16 @@ define([
       if (self.imgElm) {
         self.dom.remove(self.imgElm);
       }
-      if (this.options.imageCaption && self.captionElm) {
+      if (self.captionElm) {
         self.dom.remove(self.captionElm);
       }
-      if (this.options.imageCaption && self.figureElm) {
+      if (self.figureElm) {
         self.dom.remove(self.figureElm);
       }
 
       data.id = '__mcenew';
       var html_inner = self.dom.createHTML('img', data);
-      var caption = this.options.imageCaption ? self.$caption.val() : false;
+      var caption = self.$caption.val();
       var html_string;
       if (caption) {
         html_inner += '\n' + self.dom.createHTML('figcaption', {}, caption);
@@ -781,11 +778,9 @@ define([
           caption = self.selectedElm;
         }
 
-        if (this.options.imageCaption) {
-          self.captionElm = caption;
-          if (self.captionElm) {
-            self.$caption.val(self.captionElm.innerHTML);
-          }
+        self.captionElm = caption;
+        if (self.captionElm) {
+          self.$caption.val(self.captionElm.innerHTML);
         }
 
         self.imgElm = img;

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -503,7 +503,7 @@ define([
       self.$subject = $('input[name="subject"]', self.modal.$modal);
 
       self.$alt = $('input[name="alt"]', self.modal.$modal);
-      self.$caption = $('input[name="caption"]', self.modal.$modal);
+      self.$caption = $('textarea[name="caption"]', self.modal.$modal);
       self.$align = $('select[name="align"]', self.modal.$modal);
       self.$scale = $('select[name="scale"]', self.modal.$modal);
 

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -756,10 +756,8 @@ define([
         self.data.title = value;
       }
 
-      self.selection = self.tiny.selection;
       self.tiny.focus();
-      var selectedElm = self.selection.getNode();
-      self.anchorElm = self.dom.getParent(selectedElm, 'a[href]');
+      self.anchorElm = self.dom.getParent(self.selectedElm, 'a[href]');
 
       var linkType
       if (self.isImageMode()) {
@@ -767,18 +765,20 @@ define([
         var figure;
         var img;
         var caption;
-        if (selectedElm.nodeName === 'FIGURE') {
-          figure = selectedElm;
+        if (self.selectedElm.nodeName === 'FIGURE') {
+          figure = self.selectedElm;
           img = figure.querySelector('img');
           caption = figure.querySelector('figcaption');
-        } else if (selectedElm.nodeName === 'IMG') {
-          figure = selectedElm.closest('figure');
-          img = selectedElm;
-          caption = figure.querySelector('figcaption');
-        } else if (selectedElm.nodeName === 'FIGCAPTION') {
-          figure = selectedElm.closest('figure');
-          img = figure.querySelector('img');
-          caption = selectedElm;
+        } else if (self.selectedElm.nodeName === 'IMG') {
+          figure = $(self.selectedElm).closest('figure');
+          figure = figure.length ? figure[0] : undefined;
+          img = self.selectedElm;
+          caption = figure ? figure.querySelector('figcaption') : undefined;
+        } else if (self.selectedElm.nodeName === 'FIGCAPTION') {
+          figure = $(self.selectedElm).closest('figure');
+          figure = figure.length ? figure[0] : undefined;
+          img = figure ? figure.querySelector('img') : undefined;
+          caption = self.selectedElm;
         }
 
         if (this.options.imageCaption) {

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -482,8 +482,9 @@ define([
         externalImage: this.options.text.externalImage,
         externalImageText: this.options.text.externalImageText,
         altText: this.options.text.alt,
-        captionText: this.options.text.caption,
         imageAlignText: this.options.text.imageAlign,
+        captionText: this.options.text.caption,
+        imageCaption: this.options.imageCaption,
         scaleText: this.options.text.scale,
         imageScales: this.options.imageScales,
         cancelBtn: this.options.text.cancelBtn,
@@ -503,7 +504,9 @@ define([
       self.$subject = $('input[name="subject"]', self.modal.$modal);
 
       self.$alt = $('input[name="alt"]', self.modal.$modal);
-      self.$caption = $('textarea[name="caption"]', self.modal.$modal);
+      if (this.options.imageCaption) {
+        self.$caption = $('textarea[name="caption"]', self.modal.$modal);
+      }
       self.$align = $('select[name="align"]', self.modal.$modal);
       self.$scale = $('select[name="scale"]', self.modal.$modal);
 
@@ -610,24 +613,27 @@ define([
         };
       }
 
-      if (self.figureElm) {
-        self.dom.remove(self.figureElm);
-      }
       if (self.imgElm) {
         self.dom.remove(self.imgElm);
       }
-      if (self.captionElm) {
+      if (this.options.imageCaption && self.captionElm) {
         self.dom.remove(self.captionElm);
+      }
+      if (this.options.imageCaption && self.figureElm) {
+        self.dom.remove(self.figureElm);
       }
 
       data.id = '__mcenew';
       var html_inner = self.dom.createHTML('img', data);
-      var caption = self.$caption.val();
+      var caption = this.options.imageCaption ? self.$caption.val() : false;
+      var html_string;
       if (caption) {
         html_inner += '\n' + self.dom.createHTML('figcaption', {}, caption);
         //html_inner += '\n' + self.dom.createHTML('figcaption', { class: 'mceNonEditable' }, caption);
+        html_string = self.dom.createHTML('figure', {}, html_inner);
+      } else {
+        html_string = html_inner;
       }
-      var html_string = self.dom.createHTML('figure', {}, html_inner);
       self.tiny.insertContent(html_string);
       self.imgElm = self.dom.get('__mcenew');
       self.dom.setAttrib(self.imgElm, 'id', null);
@@ -775,13 +781,15 @@ define([
           caption = selectedElm;
         }
 
+        if (this.options.imageCaption) {
+          self.captionElm = caption;
+          if (self.captionElm) {
+            self.$caption.val(self.captionElm.innerHTML);
+          }
+        }
+
         self.imgElm = img;
         self.figureElm = figure;
-        self.captionElm = caption;
-
-        if (self.captionElm) {
-          self.$caption.val(self.captionElm.innerHTML);
-        }
 
         if (self.imgElm) {
           var src = self.dom.getAttrib(self.imgElm, 'src');

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -173,6 +173,9 @@ define([
   var ImageLink = InternalLink.extend({
     name: 'imagelinktype',
     trigger: '.pat-imagelinktype-dummy',
+    originalSrc: function() {
+      return this.tinypattern.generateImageUrl(this.value());
+    },
     toUrl: function() {
       var value = this.value();
       return this.tinypattern.generateImageUrl(value, this.linkModal.$scale.val());
@@ -597,7 +600,8 @@ define([
         alt: self.$alt.val(),
         'class': self.$align.val() + ' image-richtext',
         'data-linkType': self.linkType,
-        'data-scale': self.$scale.val()
+        'data-scale': self.$scale.val(),
+        'data-src': this.linkTypes[this.linkType].originalSrc ? this.linkTypes[this.linkType].originalSrc() : src,
       }, self.linkTypes[self.linkType].attributes());
       if (self.imgElm && !self.imgElm.getAttribute('data-mce-object')) {
         data.width = self.dom.getAttrib(self.imgElm, 'width');

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -625,6 +625,7 @@ define([
       var caption = self.$caption.val();
       if (caption) {
         html_inner += '\n' + self.dom.createHTML('figcaption', {}, caption);
+        //html_inner += '\n' + self.dom.createHTML('figcaption', { class: 'mceNonEditable' }, caption);
       }
       var html_string = self.dom.createHTML('figure', {}, html_inner);
       self.tiny.insertContent(html_string);
@@ -779,7 +780,7 @@ define([
         self.captionElm = caption;
 
         if (self.captionElm) {
-          self.$caption.val(self.captionElm.innerText);
+          self.$caption.val(self.captionElm.innerHTML);
         }
 
         if (self.imgElm) {

--- a/mockup/patterns/tinymce/js/links.js
+++ b/mockup/patterns/tinymce/js/links.js
@@ -595,7 +595,7 @@ define([
         src: src,
         title: title ? title : null,
         alt: self.$alt.val(),
-        'class': self.$align.val(),
+        'class': self.$align.val() + ' image-richtext',
         'data-linkType': self.linkType,
         'data-scale': self.$scale.val()
       }, self.linkTypes[self.linkType].attributes());

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -16,7 +16,6 @@
  *    appendToScalePart(string): Text to append to generated image scale url part. ('')
  *    linkAttribute(string): Ajax response data attribute to use for url. ('path')
  *    defaultScale(string): Scale name to default to. ('Original')
- *    imageCaption(boolean): Activate image caption support in image modal overlays
  *    inline(boolean): Show tinyMCE editor inline instead in an iframe. Use this on textarea inputs. If you want to use this pattern directly on a contenteditable, pass "inline: true" to the "tiny" options object. (false)
  *
  * Documentation:
@@ -200,7 +199,6 @@ define([
         //'autoresize_max_height': 900,
         'height': 400
       },
-      imageCaption: true,
       inline: false
     },
     addLinkClicked: function() {

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -3,7 +3,7 @@
  * Options:
  *    relatedItems(object): Related items pattern options. ({ attributes: ["UID", "Title", "Description", "getURL", "portal_type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
  *    upload(object): Upload pattern options. ({ attributes: look at upload pattern for getting the options list })
- *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", externalImage: "External Image URI"})
+ *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", caption: "Image Caption", externalImage: "External Image URI"})
  *    imageScales(string): Image scale name/value object-array or JSON string for use in the image dialog.
  *    targetList(array): TODO ([ {text: "Open in this window / frame", value: ""}, {text: "Open in new window", value: "_blank"}, {text: "Open in parent window / frame", value: "_parent"}, {text: "Open in top frame (replaces all frames)", value: "_top"}])
  *    imageTypes(string): TODO ('Image')
@@ -151,6 +151,7 @@ define([
         externalImageText: _t('External Image URL (can be relative within this site or absolute if it starts with http:// or https://)'),
         upload: _t('Upload'),
         insertLinkHelp: _t('Specify the object to link to. It can be on this site already (Internal), an object you upload (Upload), from an external site (External), an email address (Email), or an anchor on this page (Anchor).'),
+        caption: _t('Image Caption'),
       },
       // URL generation options
       loadingBaseUrl: '../../../node_modules/tinymce-builded/js/tinymce/',

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -3,7 +3,7 @@
  * Options:
  *    relatedItems(object): Related items pattern options. ({ attributes: ["UID", "Title", "Description", "getURL", "portal_type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
  *    upload(object): Upload pattern options. ({ attributes: look at upload pattern for getting the options list })
- *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", caption: "Image Caption", externalImage: "External Image URI"})
+ *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", captionFromDescription: "Show Image Caption from Image Description", caption: "Image Caption", externalImage: "External Image URI"})
  *    imageScales(string): Image scale name/value object-array or JSON string for use in the image dialog.
  *    targetList(array): TODO ([ {text: "Open in this window / frame", value: ""}, {text: "Open in new window", value: "_blank"}, {text: "Open in parent window / frame", value: "_parent"}, {text: "Open in top frame (replaces all frames)", value: "_top"}])
  *    imageTypes(string): TODO ('Image')
@@ -151,6 +151,7 @@ define([
         externalImageText: _t('External Image URL (can be relative within this site or absolute if it starts with http:// or https://)'),
         upload: _t('Upload'),
         insertLinkHelp: _t('Specify the object to link to. It can be on this site already (Internal), an object you upload (Upload), from an external site (External), an email address (Email), or an anchor on this page (Anchor).'),
+        captionFromDescription: _t('Show Image Caption from Image Description'),
         caption: _t('Image Caption'),
       },
       // URL generation options

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -16,6 +16,7 @@
  *    appendToScalePart(string): Text to append to generated image scale url part. ('')
  *    linkAttribute(string): Ajax response data attribute to use for url. ('path')
  *    defaultScale(string): Scale name to default to. ('Original')
+ *    imageCaption(boolean): Activate image caption support in image modal overlays
  *    inline(boolean): Show tinyMCE editor inline instead in an iframe. Use this on textarea inputs. If you want to use this pattern directly on a contenteditable, pass "inline: true" to the "tiny" options object. (false)
  *
  * Documentation:
@@ -199,6 +200,7 @@ define([
         //'autoresize_max_height': 900,
         'height': 400
       },
+      imageCaption: true,
       inline: false
     },
     addLinkClicked: function() {

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -60,7 +60,13 @@
         <label><%- altText %></label>
         <input type="text" name="alt" />
       </div>
-      <div class="form-group text">
+      <div class="form-group captionFromDescription">
+        <label>
+          <input type="checkbox" name="captionFromDescription" />
+          <%- captionFromDescriptionText %>
+        </label>
+      </div>
+      <div class="form-group caption">
         <label><%- captionText %></label>
         <textarea name="caption" />
       </div>

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -60,6 +60,10 @@
         <label><%- altText %></label>
         <input type="text" name="alt" />
       </div>
+      <div class="form-group text">
+        <label><%- captionText %></label>
+        <input type="text" name="caption" />
+      </div>
       <div class="form-group align">
         <label><%- imageAlignText %></label>
         <select name="align">

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -62,7 +62,7 @@
       </div>
       <div class="form-group text">
         <label><%- captionText %></label>
-        <input type="text" name="caption" />
+        <textarea name="caption" />
       </div>
       <div class="form-group align">
         <label><%- imageAlignText %></label>

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -60,12 +60,10 @@
         <label><%- altText %></label>
         <input type="text" name="alt" />
       </div>
-      <% if (imageCaption) { %>
       <div class="form-group text">
         <label><%- captionText %></label>
         <textarea name="caption" />
       </div>
-      <% } %>
       <div class="form-group align">
         <label><%- imageAlignText %></label>
         <select name="align">

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -60,10 +60,12 @@
         <label><%- altText %></label>
         <input type="text" name="alt" />
       </div>
+      <% if (imageCaption) { %>
       <div class="form-group text">
         <label><%- captionText %></label>
         <textarea name="caption" />
       </div>
+      <% } %>
       <div class="form-group align">
         <label><%- imageAlignText %></label>
         <select name="align">

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -336,6 +336,47 @@ define([
       pattern.imageModal.$scale.find('[value="customscale"]')[0].selected = true;
       expect(pattern.imageModal.getLinkUrl()).to.equal('resolveuid/foobar/@@images/image/customscale');
     });
+    it('test add image with and without caption', function() {
+      var pattern = createTinymce({
+        prependToUrl: 'resolveuid/',
+        linkAttribute: 'UID',
+        prependToScalePart: '/@@images/image/'
+      });
+
+      // Add an image caption.
+      pattern.addImageClicked();
+      pattern.imageModal.linkTypes.image.getEl().select2('data', {
+        UID: 'foobar',
+        portal_type: 'Document',
+        Title: 'Foobar',
+        path: '/foobar'
+      });
+      pattern.imageModal.$caption.val('hello.');
+      pattern.imageModal.$button.click();
+      var content = pattern.tiny.getContent();
+
+      expect(content).to.contain('<figure><img');
+      expect(content).to.contain('<figcaption>hello.</figcaption>');
+      expect(content).to.contain('image-richtext');// new image-richtext class.
+
+      // Remove the image caption. The <img> isn't wrapped then in a <figure> tag.
+      pattern.addImageClicked();
+      pattern.imageModal.linkTypes.image.getEl().select2('data', {
+        UID: 'foobar',
+        portal_type: 'Document',
+        Title: 'Foobar',
+        path: '/foobar'
+      });
+      pattern.imageModal.$caption.val('');
+      pattern.imageModal.$button.click();
+      content = pattern.tiny.getContent();
+
+      expect(content).to.not.contain('<figure>');
+      expect(content).to.not.contain('<figcaption>');
+      expect(content).to.contain('<img');
+      expect(content).to.contain('image-richtext'); // new image-richtext class.
+
+    });
 
     it('test adds data attributes', function() {
       var pattern = createTinymce();

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -376,6 +376,23 @@ define([
       expect(content).to.contain('<img');
       expect(content).to.contain('image-richtext'); // new image-richtext class.
 
+      // Use image captions from the image description.
+      pattern.addImageClicked();
+      pattern.imageModal.linkTypes.image.getEl().select2('data', {
+        UID: 'foobar',
+        portal_type: 'Document',
+        Title: 'Foobar',
+        path: '/foobar'
+      });
+      pattern.imageModal.$captionFromDescription.prop('checked', true);
+      pattern.imageModal.$button.click();
+      content = pattern.tiny.getContent();
+
+      expect(content).to.not.contain('<figure>');
+      expect(content).to.not.contain('<figcaption>');
+      expect(content).to.contain('<img');
+      expect(content).to.contain('image-richtext'); // new image-richtext class.
+      expect(content).to.contain('captioned'); // new image-richtext class.
     });
 
     it('test adds data attributes', function() {

--- a/news/911.feature
+++ b/news/911.feature
@@ -1,3 +1,4 @@
-Allow ``figcaption`` in rich text editor as a valid tag.
-Allows for adding image captions.
+TinyMCE: Add support for image captions.
+If an image caption is given, the ``<img>`` tag is wrapped within a ``<figure>`` tag and a ``<figcaption>`` tag is added.
+The image has an additional class ``image-richtext`` for further reuse.
 [thet]

--- a/news/911.feature
+++ b/news/911.feature
@@ -1,0 +1,3 @@
+Allow ``figcaption`` in rich text editor as a valid tag.
+Allows for adding image captions.
+[thet]


### PR DESCRIPTION
In the TinyMCE Image dialog:
- Adds an option for image captioning support from the description of the image ("Show Image Caption from Image Description") (uses an plone.outputfilters filter),
- Adds an textfield for manual image captions,
- Wraps the image in a ``<figure>`` tag and adds a ``<figcaption>`` if "Show Image Caption from Image Description" is not checked and the manual caption is present.
- If no caption is present, only the image tag is added.

Re-adds image caption support, which was present until Plone 5.

Screenshot:
![Screenshot from 2019-06-20 11-39-45](https://user-images.githubusercontent.com/170891/59839290-b384c380-9350-11e9-847d-e73ba10a13f3.png)

Merge:
https://github.com/plone/mockup/pull/911
https://github.com/plone/plone.staticresources/pull/30
https://github.com/plone/Products.CMFPlone/pull/2887
https://github.com/plone/plone.outputfilters/pull/36