### PR TITLE
TinyMCE: fix positioning of sub-menus in a modal

### DIFF
--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -416,6 +416,17 @@ define([
           }
         }
 
+        /* If TinyMCE is rendered inside of a modal, set an ID on
+         * .plone-modal-dialog and use that as the ui_container
+         * setting for TinyMCE to anchor it there. This ensures that
+         * sub-menus are displayed relative to the modal rather than
+         * the document body. */
+        var modal_container = self.$el.parents(".plone-modal-dialog")
+
+        if (modal_container.length > 0) {
+            modal_container.attr("id", "tiny-ui-container");
+            tinyOptions["ui_container"] = "#tiny-ui-container";
+        }
         tinymce.init(tinyOptions);
         self.tiny = tinymce.get(self.tinyId);
 

--- a/news/867.bugfix
+++ b/news/867.bugfix
@@ -1,0 +1,1 @@
+TinyMCE: fix the position of menu dropdowns when in a modal


### PR DESCRIPTION
This uses the ui_container configuration option in TinyMCE to anchor the position of menus to the parent modal.

https://github.com/tinymce/tinymce/commit/7fd61eeac61e9a88dfe8ed3c4c0398b5ee0328e2

Closes #867