### PR TITLE
[a11y] focus handling in modal pattern

### DIFF
--- a/mockup/patterns/modal/pattern.js
+++ b/mockup/patterns/modal/pattern.js
@@ -552,14 +552,6 @@ define([
         });
       }
 
-      if (self.options.backdropOptions.closeOnClick === true) {
-        $(document).on('click', function(e) {
-          if (!$(e.target).closest('.' + self.options.templateOptions.classModal).length) {
-            self.hide();
-          }
-        });
-      }
-
       $(window.parent).resize(function() {
         self.positionModal();
       });
@@ -754,32 +746,42 @@ define([
 
     activateFocusTrap: function() {
       var self = this;
-      var inputs = self.$modal.find('.' + self.options.templateOptions.classBodyName).first().find(
-        'select, input, textarea, button, a'
+      var inputsBody = self.$modal.find('.' + self.options.templateOptions.classBodyName).first().find(
+        'select, input[type!=hidden], textarea, button, a'
       );
+      var inputsFooter = self.$modal.find('.' + self.options.templateOptions.classFooterName).first().find(
+        'select, input[type!=hidden], textarea, button, a'
+      );
+      var inputs=[]
+      for (var i=0; i<inputsBody.length; i++){
+        if($(inputsBody[i]).is(':visible')){
+          inputs.push(inputsBody[i])
+        }
+      }
+      for (var j=0; j<inputsFooter.length; j++){
+        if($(inputsFooter[j]).is(':visible')){
+          inputs.push(inputsFooter[j])
+        }
+      }
 
       if (inputs.length === 0) {
         inputs = self.$modal.find('.plone-modal-title');
       }
-
-      var firstInput = inputs.first();
-      var lastInput = inputs.last();
+      var firstInput = inputs[0];
+      var lastInput = inputs[inputs.length-1];
       var closeInput = self.$modal.find('.plone-modal-close').first();
-
       $(document).on('keydown', '.' + self.options.templateOptions.classDialog, function(e) {
         if (e.which === 9) {
           e.preventDefault();
 
           var $target = $(e.target)
-          var currentIndex = inputs.index($target);
-
+          var currentIndex = $.inArray($target[0],inputs);
           if (currentIndex >= 0 && currentIndex < inputs.length) {
             var nextIndex = currentIndex + (e.shiftKey ? -1 : 1);
-
             if (nextIndex < 0 || nextIndex >= inputs.length) {
               closeInput.focus();
             } else {
-              inputs.get(nextIndex).focus();
+              inputs[nextIndex].focus();
             }
           } else if (e.shiftKey) {
             lastInput.focus();
@@ -788,6 +790,13 @@ define([
           }
         }
       });
+      if (self.options.backdropOptions.closeOnClick === true) {
+        self.$modal.on('click', function(e) {
+          if (!$(e.target).closest('.' + self.options.templateOptions.classModal).length) {
+            self.hide();
+          }
+        });
+      }
 
       self.$modal.find('.plone-modal-title').focus();
     },

--- a/news/11.bugfix
+++ b/news/11.bugfix
@@ -1,0 +1,2 @@
+[a11y] focus handling in modal pattern
+[nzambello]


### PR DESCRIPTION
Fixes #11.

Working on modal pattern:
- ARIA and roles attributes
- focus trap within modal
- focus handling in general about modal
- re-assign focus on modal opening link when closing
- close on click