### PR TITLE
Structure pattern: Escape special characters when filtering

### DIFF
--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -93,7 +93,7 @@ define([
         clearTimeout(self.timeoutId);
       }
       self.timeoutId = setTimeout(function() {
-        self.term = $(event.currentTarget).val();
+        self.term = encodeURIComponent($(event.currentTarget).val());
         self.app.collection.currentPage = 1;
         self.app.collection.pager();
 

--- a/news/932.bugfix
+++ b/news/932.bugfix
@@ -1,0 +1,2 @@
+Structure pattern: Escape special characters when filtering
+[frapell]


### PR DESCRIPTION
This fixes gh-932