### PR TITLE
Structure pattern: Filter UI improvements, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8.12.0
+  - 12.14.1
 env:
   global:
     - secure: "fPRKgxcbSXyiLqkUjAjPkn5eGBqMqf6c5haTZ9x76sDl1792nDyiL2FXSpiv2s8PeOqMbWgcXly0r+CLXypYkWba9nIxb4bhvtXyDoYAaoBV0lG1NbBakuOwqW/u60WpPJS1qTqmEUSEbSxdntqk7HF1yG6MdMi3PdubxMyw9h0="

--- a/mockup/Gruntfile.js
+++ b/mockup/Gruntfile.js
@@ -158,7 +158,14 @@ module.exports = function(grunt) {
       console.log('read folder: ' + path);
       var files = fs.readdirSync(path);
       files.forEach(function(filename) {
-        if (filename === 'node_modules' || filename === 'node_modules') {
+        if (
+          filename === '__pycache__' ||
+          filename === 'build' ||
+          filename === 'coverage' ||
+          filename === 'less' ||
+          filename === 'node_modules' ||
+          filename === 'tests'
+        ) {
           return;
         }
         var stats = fs.statSync(path + filename);

--- a/mockup/js/ui/views/button.js
+++ b/mockup/js/ui/views/button.js
@@ -35,7 +35,7 @@ define([
         }
         _.each(this.extraClasses, function(klass){
           this.$el.addClass(klass);
-        });
+        }.bind(this));
 
         if (this.tooltip !== null) {
 

--- a/mockup/js/utils.js
+++ b/mockup/js/utils.js
@@ -354,6 +354,13 @@ define([
     }
   };
 
+  var createElementFromHTML = function(htmlString) {
+    // From: https://stackoverflow.com/a/494348/1337474
+    var div = document.createElement('div');
+    div.innerHTML = htmlString.trim();
+    return div.firstChild;
+  };
+
   return {
     bool: bool,
     escapeHTML: escapeHTML,
@@ -367,6 +374,7 @@ define([
     parseBodyTag: parseBodyTag,
     QueryHelper: QueryHelper,
     setId: setId,
-    storage: storage
+    storage: storage,
+    createElementFromHTML: createElementFromHTML
   };
 });

--- a/mockup/patterns/structure/js/actions.js
+++ b/mockup/patterns/structure/js/actions.js
@@ -80,7 +80,8 @@ define([
         } else {
           msg = _t('Error ' + failMsg + ' "' + self.model.attributes.Title + '"');
         }
-        self.app.setStatus({text: msg, type: data.status || 'warning'});
+        self.app.clearStatus();
+        self.app.setStatus({ text: msg, type: data.status || 'warning' });
       });
     },
 

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -16,6 +16,7 @@ define([
   'mockup-patterns-structure-url/js/views/upload',
   'mockup-patterns-structure-url/js/collections/result',
   'mockup-patterns-structure-url/js/collections/selected',
+  'text!mockup-patterns-structure-url/templates/status.xml',
   'mockup-utils',
   'translate',
   'pat-logger',
@@ -24,18 +25,15 @@ define([
   TableView, SelectionWellView,
   GenericPopover, RearrangeView, SelectionButtonView,
   PagingView, ColumnsView, TextFilterView, UploadView,
-  _ResultCollection, SelectedCollection, utils, _t, logger) {
+  _ResultCollection, SelectedCollection, StatusTemplate, utils, _t, logger) {
   'use strict';
 
   var log = logger.getLogger('pat-structure');
 
   var AppView = BaseView.extend({
     tagName: 'div',
-    status: {
-      type: 'none',
-      text: '',
-      label: ''
-    },
+    statusTemplate: _.template(StatusTemplate),
+    statusMessages: [],
     sort_on: 'getObjPositionInParent',
     sort_order: 'ascending',
     additionalCriterias: [],
@@ -274,6 +272,7 @@ define([
       return this.collection.getCurrentPath();
     },
     setCurrentPath: function(path) {
+      this.clearStatus();
       this.toolbar.get('filter').clearFilter();
       this.collection.setCurrentPath(path);
     },
@@ -330,19 +329,19 @@ define([
       }
     },
     ajaxSuccessResponse: function(data, callback) {
-      var self = this;
-      self.selectedCollection.reset();
+      this.clearStatus();
+      this.selectedCollection.reset();
       if (data.status === 'success') {
-        self.collection.reset();
+        this.collection.reset();
       }
       if (data.msg) {
         // give status message somewhere...
-        self.setStatus(data.msg, data.status || 'warning');
+        this.setStatus({text: data.msg, type: data.status || 'warning'});
       }
       if (callback !== null && callback !== undefined) {
         callback(data);
       }
-      self.collection.pager();
+      this.collection.pager();
     },
     ajaxErrorResponse: function(response, url) {
       if (response.status === 404) {
@@ -450,8 +449,9 @@ define([
         },
         dataType: 'json',
         success: function(data) {
+          self.clearStatus();
           if (data.msg) {
-            self.setStatus(data.msg);
+            self.setStatus({text: data.msg});
           } else if (data.status !== 'success') {
             // XXX handle error here with something?
             self.setStatus({text: 'error moving item', type: 'error'});
@@ -459,43 +459,74 @@ define([
           self.collection.pager(); // reload it all
         },
         error: function() {
+          self.clearStatus();
           self.setStatus({text: 'error moving item', type: 'error'});
         }
       });
     },
-    setStatus: function(msg, type, btn) {
-      if (!msg) {
-        // clear it
-        this.status.text = '';
-        this.status.label = '';
-        this.status.type = 'none';
-      } else if (typeof(msg) === 'string') {
-        this.status.text = msg;
-        this.status.label = '';
-        this.status.type = type || 'warning';
+
+    clearStatus: function(status) {
+      var statusContainer = this.$el[0].querySelector('.fc-status-container');
+
+      if (status) {
+        // remove specific status, also those marked with ``fixed``.
+        try {
+          statusContainer.removeChild(status.el);
+        } catch(e) {
+          // just ignore.
+        }
+        var idx = this.statusMessages.indexOf(status);
+        if (idx > -1) {
+          this.statusMessages.splice(idx, 1);
+        }
       } else {
-        // support setting portal status messages here
-        this.status.label = msg.label || '';
-        this.status.text = msg.text;
-        this.status.type = msg.type || 'warning';
-      }
-      // still need to manually set in case rendering isn't done(especially true for tests)
-      var $status = this.$('.status');
-      if ($status.length > 0){
-          $status[0].className = 'alert alert-' + this.status.type + ' status';
-          var $text = $('<span></span>');
-          $text.text(this.status.text);
-          var $label = $('<strong></strong>');
-          $label.text(this.status.label);
-          $status.empty().append($label).append($text);
-          if (btn) { $status.append(btn) }
+        // remove all status messages except those marked with ``fixed``.
+        for (var i = 0, len = this.statusMessages.length; i < len; i++) {
+          status = this.statusMessages[i];
+          if (! status.fixed) {
+            try {
+              statusContainer.removeChild(status.el);
+            } catch(e) {
+              // just ignore.
+            }
+          }
+        }
+        this.statusMessages = [];
       }
     },
+
+    setStatus: function(status, btn, fixed) {
+      var el = this.statusTemplate({
+        label: status.label || '',
+        text: status.text,
+        type: status.type || 'warning'
+      });
+
+      el = utils.createElementFromHTML(el);
+
+      if (btn) {
+        btn = $(btn)[0];  // support jquert + bare dom elements
+        el.appendChild(btn);
+      }
+
+      var status = {
+        el: el,
+        fixed: fixed
+      };
+
+      var statusContainer = this.$el[0].querySelector('.fc-status-container');
+      statusContainer.appendChild(status.el);
+      this.statusMessages.push(status);
+
+      return status;
+    },
+
     render: function() {
       var self = this;
 
       self.$el.append(self.toolbar.render().el);
       self.$el.append(self.wellView.render().el);
+      self.$el.append(utils.createElementFromHTML('<div class="fc-status-container"></div>'));
       self.$el.append(self.columnsView.render().el);
       if (self.rearrangeView) {
         self.$el.append(self.rearrangeView.render().el);

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -274,6 +274,7 @@ define([
       return this.collection.getCurrentPath();
     },
     setCurrentPath: function(path) {
+      this.toolbar.get('filter').clearFilter();
       this.collection.setCurrentPath(path);
     },
     getAjaxUrl: function(url) {

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -464,27 +464,29 @@ define([
       });
     },
 
-    clearStatus: function(status) {
+    clearStatus: function(key) {
       var statusContainer = this.$el[0].querySelector('.fc-status-container');
+      var statusItem;
 
-      if (status) {
-        // remove specific status, also those marked with ``fixed``.
-        try {
-          statusContainer.removeChild(status.el);
-        } catch(e) {
-          // just ignore.
+      if (key) {
+        // remove specific status, even if marked with ``fixed``.
+        var toBeRemoved = this.statusMessages.filter(function (item) { return item.key === key; });
+        for (var i = 0, len = toBeRemoved.length; i < len; i++) {
+          statusItem = toBeRemoved[i];
+          try {
+            statusContainer.removeChild(statusItem.el);
+          } catch(e) {
+            // just ignore.
+          }
         }
-        var idx = this.statusMessages.indexOf(status);
-        if (idx > -1) {
-          this.statusMessages.splice(idx, 1);
-        }
+        this.statusMessages = this.statusMessages.filter(function (item) { return item.key !== key; });
       } else {
         // remove all status messages except those marked with ``fixed``.
         for (var i = 0, len = this.statusMessages.length; i < len; i++) {
-          status = this.statusMessages[i];
-          if (! status.fixed) {
+          statusItem = this.statusMessages[i];
+          if (! statusItem.fixed) {
             try {
-              statusContainer.removeChild(status.el);
+              statusContainer.removeChild(statusItem.el);
             } catch(e) {
               // just ignore.
             }
@@ -494,7 +496,16 @@ define([
       }
     },
 
-    setStatus: function(status, btn, fixed) {
+    setStatus: function(status, btn, fixed, key) {
+
+      if (
+        key &&
+        this.statusMessages.filter(function (item) { return item.key === key; }).length > 0
+      ) {
+        // Prevent two same status messages
+        return;
+      }
+
       var el = this.statusTemplate({
         label: status.label || '',
         text: status.text,
@@ -510,7 +521,8 @@ define([
 
       var status = {
         el: el,
-        fixed: fixed
+        fixed: fixed,
+        key: key // to be used for filtering to prevent double status messages.
       };
 
       var statusContainer = this.$el[0].querySelector('.fc-status-container');

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -273,7 +273,6 @@ define([
     },
     setCurrentPath: function(path) {
       this.clearStatus();
-      this.toolbar.get('filter').clearFilter();
       this.collection.setCurrentPath(path);
     },
     getAjaxUrl: function(url) {

--- a/mockup/patterns/structure/js/views/paging.js
+++ b/mockup/patterns/structure/js/views/paging.js
@@ -78,33 +78,33 @@ define([
     },
     nextResultPage: function(e) {
       e.preventDefault();
-      this.app.setStatus();
+      this.app.clearStatus();
       this.collection.requestNextPage();
     },
     previousResultPage: function(e) {
       e.preventDefault();
-      this.app.setStatus();
+      this.app.clearStatus();
       this.collection.requestPreviousPage();
     },
     gotoFirst: function(e) {
       e.preventDefault();
-      this.app.setStatus();
+      this.app.clearStatus();
       this.collection.goTo(this.collection.information.firstPage);
     },
     gotoLast: function(e) {
       e.preventDefault();
-      this.app.setStatus();
+      this.app.clearStatus();
       this.collection.goTo(this.collection.information.totalPages);
     },
     gotoPage: function(e) {
       e.preventDefault();
-      this.app.setStatus();
+      this.app.clearStatus();
       var page = $(e.target).text();
       this.collection.goTo(page);
     },
     changeCount: function(e) {
       e.preventDefault();
-      this.app.setStatus();
+      this.app.clearStatus();
       var per = $(e.target).text();
       this.collection.howManyPer(per);
       this.app.setCookieSetting('perPage', per);

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -195,10 +195,6 @@ define([
       var self = this;
       // if we have a custom query going on, we do not allow sorting.
       if (self.app.inQueryMode()) {
-        self.app.setStatus({
-          text: _t('Drag and drop reordering is disabled while filters are applied.'),
-          type: 'warning'
-        }, null, false, 'filter_dndreordering_disabled');
         self.$el.removeClass('order-support');
         return;
       }

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -96,7 +96,6 @@ define([
             return val.length > 0;
           }
         ),
-        status: self.app.status,
         activeColumns: self.app.activeColumns,
         availableColumns: self.app.availableColumns,
         datatables_options: JSON.stringify(datatables_options)
@@ -145,9 +144,12 @@ define([
                     // Restore reordering by drag and drop
                     self.addReordering();
                     // Clear the status message
-                    self.app.setStatus();
+                    self.app.clearStatus();
                   });
-        self.app.setStatus(_t('Notice: Drag and drop reordering is disabled when viewing the contents sorted by a column.'), 'warning', btn = btn);
+        self.app.setStatus({
+          text: _t('Notice: Drag and drop reordering is disabled when viewing the contents sorted by a column.'),
+          type: 'warning'
+        }, btn = btn);
         $(".pat-datatables tbody").find('tr').off("drag")
         self.$el.removeClass('order-support');
       } );

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -195,7 +195,7 @@ define([
       var self = this;
       // if we have a custom query going on, we do not allow sorting.
       if (self.app.inQueryMode()) {
-        self.app.setStatus({text: _t('Cannot order items while querying'), type: 'warning'});
+        self.app.setStatus({text: _t('Drag and drop reordering is disabled while filters are applied.'), type: 'warning'});
         self.$el.removeClass('order-support');
         return;
       }

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -149,10 +149,10 @@ define([
         self.app.setStatus({
           text: _t('Notice: Drag and drop reordering is disabled when viewing the contents sorted by a column.'),
           type: 'warning'
-        }, btn = btn);
-        $(".pat-datatables tbody").find('tr').off("drag")
+        }, btn, false, 'sorting_dndreordering_disabled');
+        $(".pat-datatables tbody").find('tr').off("drag");
         self.$el.removeClass('order-support');
-      } );
+      });
 
       return this;
     },
@@ -195,7 +195,10 @@ define([
       var self = this;
       // if we have a custom query going on, we do not allow sorting.
       if (self.app.inQueryMode()) {
-        self.app.setStatus({text: _t('Drag and drop reordering is disabled while filters are applied.'), type: 'warning'});
+        self.app.setStatus({
+          text: _t('Drag and drop reordering is disabled while filters are applied.'),
+          type: 'warning'
+        }, null, false, 'filter_dndreordering_disabled');
         self.$el.removeClass('order-support');
         return;
       }

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -34,6 +34,22 @@ define([
       this.app = this.options.app;
     },
 
+    setTerm: function(term) {
+      this.term = term;
+      this.$el[0].querySelector('.search-query').value = term;
+    },
+
+    setQuery: function(query) {
+      this.$queryString.val(JSON.stringify(query));
+      this.app.additionalCriterias = query;
+      this.app.collection.currentPage = 1;
+    },
+
+    clearFilter: function() {
+      this.setTerm('');
+      this.setQuery([]);
+    },
+
     render: function() {
       this.$el.html(this.template({_t: _t}));
       this.button = new ButtonView({

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -28,7 +28,8 @@ define([
     term: null,
     timeoutId: null,
     keyupDelay: 300,
-    statusKey: 'filter_status_message',
+    statusKeyFilter: 'textfilter_status_message_filter',
+    statusKeySorting: 'textfilter_status_message_sorting',
 
     initialize: function(options) {
       BaseView.prototype.initialize.apply(this, [options]);
@@ -36,22 +37,30 @@ define([
     },
 
     setFilterStatusMessage: function() {
-      var clear_btn = $('<button type="button" class="btn btn-danger btn-xs"></button>')
+      var clear_btn = $('<button type="button" class="btn btn-primary btn-xs"></button>')
         .text(_t('Clear filter'))
         .on('click', function() {
           this.clearFilter();
         }.bind(this));
 
+      var statusTextFilter = _t('This listing has filters applied. Not all items are shown.');
       this.app.setStatus({
-        label: _t('Some filters applied'),
-        text: _t('This listing has filters applied. Not all items are shown.'),
+        text: statusTextFilter,
+        type: 'info'
+      }, clear_btn, true, this.statusKeyFilter);
+
+      var statusTextSorting = _t('Drag and drop reordering is disabled while filters are applied.');
+      this.app.setStatus({
+        text: statusTextSorting,
         type: 'warning'
-      }, clear_btn, true, this.statusKey);
+      }, null, true, this.statusKeySorting);
+
     },
 
     clearFilterStatusMessage: function() {
       if (!this.term && !this.app.additionalCriterias.length) {
-        this.app.clearStatus(this.statusKey);
+        this.app.clearStatus(this.statusKeyFilter);
+        this.app.clearStatus(this.statusKeySorting);
       }
     },
 

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -38,7 +38,7 @@ define([
 
     setFilterStatusMessage: function() {
       var clear_btn = $('<button type="button" class="btn btn-primary btn-xs"></button>')
-        .text(_t('Clear filter'))
+        .text(_t('Clear'))
         .on('click', function() {
           this.clearFilter();
         }.bind(this));
@@ -46,7 +46,7 @@ define([
       var statusTextFilter = _t('This listing has filters applied. Not all items are shown.');
       this.app.setStatus({
         text: statusTextFilter,
-        type: 'info'
+        type: 'success',
       }, clear_btn, true, this.statusKeyFilter);
 
       var statusTextSorting = _t('Drag and drop reordering is disabled while filters are applied.');

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -35,14 +35,25 @@ define([
     },
 
     setTerm: function(term) {
+      var term_el = this.$el[0].querySelector('.search-query');
       this.term = term;
-      this.$el[0].querySelector('.search-query').value = term;
+      term_el.value = term;
+      if (term) {
+        term_el.classList.add('has-filter');
+      } else {
+        term_el.classList.remove('has-filter');
+      }
     },
 
     setQuery: function(query) {
       this.$queryString.val(JSON.stringify(query));
       this.app.additionalCriterias = query;
       this.app.collection.currentPage = 1;
+      if (query.length) {
+        this.button.$el[0].classList.add('has-filter');
+      } else {
+        this.button.$el[0].classList.remove('has-filter');
+      }
     },
 
     clearFilter: function() {
@@ -79,6 +90,11 @@ define([
         }
         self.timeoutId = setTimeout(function() {
           var criterias = $.parseJSON(self.$queryString.val());
+          if (criterias.length > 0) {
+            self.button.$el[0].classList.add('has-filter');
+          } else {
+            self.button.$el[0].classList.remove('has-filter');
+          }
           self.app.additionalCriterias = criterias;
           self.app.collection.currentPage = 1;
           self.app.collection.pager();
@@ -109,12 +125,16 @@ define([
         clearTimeout(self.timeoutId);
       }
       self.timeoutId = setTimeout(function() {
-        self.term = encodeURIComponent($(event.currentTarget).val());
+        var term_el = $(event.currentTarget);
+        self.term = encodeURIComponent(term_el.val());
         self.app.collection.currentPage = 1;
         self.app.collection.pager();
 
-        if (!self.term){
+        if (!self.term) {
+            term_el[0].classList.remove('has-filter');
             self.app.setStatus();
+        } else {
+          term_el[0].classList.add('has-filter');
         }
 
       }, this.keyupDelay);

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -96,8 +96,8 @@ define([
     render: function() {
       this.$el.html(this.template({_t: _t}));
       this.button = new ButtonView({
-        tooltip: _t('Query'),
-        icon: 'search'
+        tooltip: _t('Filter'),
+        icon: 'filter'
       });
       this.popover = new PopoverView({
         triggerView: this.button,

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -132,7 +132,7 @@ define([
 
         if (!self.term) {
             term_el[0].classList.remove('has-filter');
-            self.app.setStatus();
+            self.app.clearStatus();
         } else {
           term_el[0].classList.add('has-filter');
         }

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -110,6 +110,8 @@ define([
 
       if (set_input) {
         this.$queryString.val(query_string);
+        // TODO clear query string form
+        // this.queryString._init();
       }
       this.app.additionalCriterias = query_obj;
       this.app.collection.currentPage = 1;

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -28,7 +28,7 @@ define([
     term: null,
     timeoutId: null,
     keyupDelay: 300,
-    filterStatusMessage: null,
+    statusKey: 'filter_status_message',
 
     initialize: function(options) {
       BaseView.prototype.initialize.apply(this, [options]);
@@ -36,26 +36,22 @@ define([
     },
 
     setFilterStatusMessage: function() {
-      if (!this.filterStatusMessage) {
+      var clear_btn = $('<button type="button" class="btn btn-danger btn-xs"></button>')
+        .text(_t('Clear filter'))
+        .on('click', function() {
+          this.clearFilter();
+        }.bind(this));
 
-        var clear_btn = $('<button type="button" class="btn btn-danger btn-xs"></button>')
-          .text(_t('Clear filter'))
-          .on('click', function() {
-            this.clearFilter();
-          }.bind(this));
-
-        this.filterStatusMessage = this.app.setStatus({
-          label: _t('Some filters applied'),
-          text: _t('This listing has filters applied. Not all items are shown.'),
-          type: 'warning'
-        }, clear_btn, true);
-      }
+      this.app.setStatus({
+        label: _t('Some filters applied'),
+        text: _t('This listing has filters applied. Not all items are shown.'),
+        type: 'warning'
+      }, clear_btn, true, this.statusKey);
     },
 
     clearFilterStatusMessage: function() {
-      if (this.filterStatusMessage && !this.term && !this.app.additionalCriterias.length) {
-        this.app.clearStatus(this.filterStatusMessage);
-        this.filterStatusMessage = null;
+      if (!this.term && !this.app.additionalCriterias.length) {
+        this.app.clearStatus(this.statusKey);
       }
     },
 

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -90,8 +90,12 @@
             margin-right: 1em;
         }
         #filter {
-            width: 200px;
+            width: 20em;
             float: right;
+
+            .btn-queryfilter {
+                margin-left: 1em;
+            }
         }
         &>a.btn, .btn-group, #filter {
             margin-bottom: 0.5em;

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -155,13 +155,17 @@
             height: 31px;
         }
     }
-    .alert.status{
-        margin-bottom: 5px;
-        padding: 5px;
+    .fc-status {
+        display: flex;
+        align-items: center;
+        margin-bottom: 1em;
+        padding: 0.5em;
         color: @plone-link-color;
-
+        .fc-status-text {
+            flex-grow: 1;
+        }
         .btn {
-            margin-left: 10px;
+            margin-left: 1em;
         }
 
     }

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -79,8 +79,11 @@
         top: 0;
         z-index: 10;
         background-color: #fafafa;
-        border-bottom: 1px solid #ccc;
-        border-radius: 0;
+
+        border: none;
+        min-height: auto;
+        margin: 0;
+
 
         &>a.btn:last-of-type,
         .btn-group {

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -67,6 +67,13 @@
         .btn-sm();
     }
 
+    .btn.has-filter {
+        .btn-info();
+    }
+    input.has-filter {
+        border: 1px solid @btn-info-border;
+    }
+
     .navbar {
         position: sticky;
         top: 0;

--- a/mockup/patterns/structure/templates/status.xml
+++ b/mockup/patterns/structure/templates/status.xml
@@ -1,0 +1,4 @@
+<div class="alert alert-<%- type %> status fc-status">
+  <strong class="fc-status-label"><%- label %></strong>
+  <span class="fc-status-text"><%- text %></span>&nbsp;<% // &nbsp; to get correct height for empty alerts %>
+</div>

--- a/mockup/patterns/structure/templates/table.xml
+++ b/mockup/patterns/structure/templates/table.xml
@@ -1,8 +1,3 @@
-<div class="alert alert-<%- status.type %> status">
-  <strong><%- status.label %></strong>
-  <span><%- status.text %></span>&nbsp;<% // &nbsp; to get correct height for empty alerts %>
-</div>
-
 <div class="fc-breadcrumbs-container">
   <div class="fc-breadcrumbs" colspan="<%- activeColumns.length + 3 %>">
     <a href="#" data-path="/">

--- a/mockup/tests/pattern-structure-test.js
+++ b/mockup/tests/pattern-structure-test.js
@@ -175,8 +175,8 @@ define([
       $('a.cutItem', el).click();
       this.clock.tick(500);
 
-      expect(this.app.$('.status').text().trim()).to.equal('Cut "Dummy Object"');
-      expect(this.app.$('.status').hasClass('alert-successss'));
+      expect(this.app.$('.fc-status .fc-status-text').text().trim()).to.equal('Cut "Dummy Object"');
+      expect(this.app.$('.fc-status').hasClass('alert-successss'));
     });
 
     it('custom action menu items', function() {
@@ -206,8 +206,8 @@ define([
 
       $('a.cutItem', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text().trim()).to.equal('Cut "Dummy Object"');
-      expect(this.app.$('.status').hasClass('alert-success'));
+      expect(this.app.$('.fc-status .fc-status-text').text().trim()).to.equal('Cut "Dummy Object"');
+      expect(this.app.$('.fc-status').hasClass('alert-success'));
     });
 
     it('custom action menu items and actions.', function() {
@@ -220,7 +220,7 @@ define([
           },
           foobarClicked: function(e) {
             var self = this;
-            self.app.setStatus('Status: foobar clicked');
+            self.app.setStatus({ text: 'Status: foobar clicked' });
           }
         });
         return Actions;
@@ -255,12 +255,11 @@ define([
 
       $('a.foobar', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text().trim()).to.equal('Status: foobar clicked');
-      expect(this.app.$('.status').hasClass('alert-warning'));  // default status type
+      expect(this.app.$('.fc-status .fc-status-text').text().trim()).to.equal('Status: foobar clicked');
+      expect(this.app.$('.fc-status').hasClass('alert-warning'));  // default status type
     });
 
     it('custom action menu actions missing.', function() {
-      this.app.setStatus(null); // reset
       // Define a custom dummy "module"
       define('dummytestactions', ['backbone'], function(Backbone) {
         var Actions = Backbone.Model.extend({
@@ -270,7 +269,7 @@ define([
           },
           barbazClicked: function(e) {
             var self = this;
-            self.app.setStatus('Status: barbaz clicked');
+            self.app.setStatus({ text: 'Status: barbaz clicked' });
           }
         });
         return Actions;
@@ -309,10 +308,9 @@ define([
 
       // Broken/missing action
       var el = menu.render().el;
-      this.app.setStatus(null); // reset
       $('a.foobar', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text().trim()).to.equal('');
+      expect(this.app.$('.fc-status .fc-status-text').text().trim()).to.equal('');
     });
 
     it('custom action menu via generator.', function() {
@@ -325,7 +323,7 @@ define([
           },
           barbazClicked: function(e) {
             var self = this;
-            self.app.setStatus({text: 'Status: barbaz clicked', type: 'success'});
+            self.app.setStatus({ text: 'Status: barbaz clicked', type: 'success' });
           }
         });
         return Actions;
@@ -366,8 +364,8 @@ define([
       var el = menu.render().el;
       $('a.barbaz', el).click();
       this.clock.tick(500);
-      expect(this.app.$('.status').text().trim()).to.equal('Status: barbaz clicked');
-      expect(this.app.$('.status').hasClass('alert-success'));
+      expect(this.app.$('.fc-status .fc-status-text').text().trim()).to.equal('Status: barbaz clicked');
+      expect(this.app.$('.fc-status').hasClass('alert-success'));
     });
 
     it('custom action menu items in dropdown only', function() {
@@ -1087,8 +1085,8 @@ define([
       $popover.find('button').trigger('click');
       this.clock.tick(1000);
       expect($popover.hasClass('active')).to.equal(false);
-      expect(this.$el.find('.order-support .status').html()).to.contain('rearrange');
-      expect(this.app.$('.status').hasClass('alert-successss'));
+      expect(this.$el.find('.order-support .fc-status').html()).to.contain('rearrange');
+      expect(this.app.$('.fc-status').hasClass('alert-successss'));
     });
 
     it('test select all', function() {
@@ -1229,7 +1227,7 @@ define([
         'Set as default page');
       $('a.set-default-page', item).click();
       this.clock.tick(1000);
-      expect(this.$el.find('.order-support .status').html()).to.contain('defaulted');
+      expect(this.$el.find('.fc-status').html()).to.contain('defaulted');
     });
 
     it('test itemRow actionmenu paste click', function() {
@@ -1245,7 +1243,7 @@ define([
       expect($('a.pasteItem', item0).text().trim()).to.equal('Paste');
       $('a.pasteItem', item0).click();
       this.clock.tick(1000);
-      expect(this.$el.find('.order-support .status').html()).to.contain('Pasted into "Folder"');
+      expect(this.$el.find('.fc-status').html()).to.contain('Pasted into "Folder"');
     });
 
     it('test itemRow actionmenu move-top click', function() {
@@ -1261,9 +1259,9 @@ define([
       $('.actionmenu a.move-top', item10).trigger('click');
       this.clock.tick(1000);
 
-      expect(this.$el.find('.order-support .status').html()).to.contain('moved');
-      expect(this.$el.find('.order-support .status').html()).to.contain('delta=top');
-      expect(this.$el.find('.order-support .status').html()).to.contain('id=item9');
+      expect(this.$el.find('.fc-status').html()).to.contain('moved');
+      expect(this.$el.find('.fc-status').html()).to.contain('delta=top');
+      expect(this.$el.find('.fc-status').html()).to.contain('id=item9');
       // No items actually moved, this is to be implemented server-side.
     });
 
@@ -1964,12 +1962,12 @@ define([
           option1: function(e) {
             e.preventDefault();
             var self = this;
-            self.app.setStatus({text: 'Status: option1 selected', type: 'success'});
+            self.app.setStatus({ text: 'Status: option1 selected', type: 'success' });
           },
           option2: function(e) {
             e.preventDefault();
             var self = this;
-            self.app.setStatus({text: 'Status: option2 selected', type: 'info'});
+            self.app.setStatus({ text: 'Status: option2 selected', type: 'info' });
           }
         });
         return Actions;
@@ -1981,14 +1979,14 @@ define([
       $('.actionmenu a.action1', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
-      expect($('.status').text()).to.contain('Status: option1 selected');
-      expect($('.status').hasClass('alert-success'));
+      expect($('.fc-status .fc-status-text').text()).to.contain('Status: option1 selected');
+      expect($('.fc-status').hasClass('alert-success'));
 
       $('.actionmenu a.action2', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
-      expect($('.status').text()).to.contain('Status: option2 selected');
-      expect($('.status').hasClass('alert-info'));
+      expect($('.fc-status').text()).to.contain('Status: option2 selected');
+      expect($('.fc-status').hasClass('alert-info'));
     });
 
     it('item link triggered', function() {
@@ -2001,7 +1999,7 @@ define([
           handleOther: function(e) {
             e.preventDefault();
             var self = this;
-            self.app.setStatus({text: 'Status: not a folder', type: 'error'});
+            self.app.setStatus({ text: 'Status: not a folder', type: 'error' });
           }
         });
         return Actions;
@@ -2015,8 +2013,8 @@ define([
       $('.title a.manage', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
-      expect($('.status').text()).to.contain('Status: not a folder');
-      expect($('.status').hasClass('alert-error'));
+      expect($('.fc-status .fc-status-text').text()).to.contain('Status: not a folder');
+      expect($('.fc-status').hasClass('alert-error'));
     });
 
   });
@@ -2311,12 +2309,12 @@ define([
           folderClicker: function(e) {
             e.preventDefault();
             var self = this;
-            self.app.setStatus('Status: folder clicked');
+            self.app.setStatus({ text: 'Status: folder clicked' });
           },
           itemClicker: function(e) {
             e.preventDefault();
             var self = this;
-            self.app.setStatus('Status: item clicked');
+            self.app.setStatus({ text: 'Status: item clicked' });
           }
         });
         return Actions;
@@ -2362,7 +2360,7 @@ define([
       $('.actionmenu a.folderClicker', folder).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
-      expect($('.status').text()).to.contain('Status: folder clicked');
+      expect($('.fc-status .fc-status-text').text()).to.contain('Status: folder clicked');
 
       var item = this.$el.find('.itemRow').eq(1);
       // Check for complete new options
@@ -2372,7 +2370,7 @@ define([
       $('.actionmenu a.itemClicker', item).trigger('click');
       this.clock.tick(1000);
       // status will be set as defined.
-      expect($('.status').text()).to.contain('Status: item clicked');
+      expect($('.fc-status .fc-status-text').text()).to.contain('Status: item clicked');
 
     });
 

--- a/news/937.feature
+++ b/news/937.feature
@@ -1,3 +1,4 @@
 Structure pattern: Reset any applied filters after changing the path.
 Show visually if a filter is set.
+Allow multiple status messages.
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -4,5 +4,5 @@ Show visually if a filter is set.
 Allow multiple status messages.
 Querystring popover button: filter icon, "Filter" tooltip.
 Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.". Fixes: https://github.com/collective/plone.app.locales/issues/173
-
+Display toolbar a bit compacter.
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -2,4 +2,5 @@ Structure pattern:
 Show statusmessage with "Clear filter" button when filters are applied.
 Show visually if a filter is set.
 Allow multiple status messages.
+Querystring popover button: filter icon, "Filter" tooltip.
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -1,2 +1,3 @@
 Structure pattern: Reset any applied filters after changing the path.
+Show visually if a filter is set.
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -1,8 +1,9 @@
 Structure pattern:
-Show statusmessage with "Clear filter" button when filters are applied.
+Filter now reads "Search" and is cleared when changing directories.
+Querystring popover button: filter instead of search icon, "Extra Filter" title.
+Show statusmessage with "Clear" button when filters are applied.
 Show visually if a filter is set.
 Allow multiple status messages.
-Querystring popover button: filter icon, "Filter" tooltip.
 Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.". Fixes: https://github.com/collective/plone.app.locales/issues/173
 Display toolbar a bit compacter.
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -3,4 +3,6 @@ Show statusmessage with "Clear filter" button when filters are applied.
 Show visually if a filter is set.
 Allow multiple status messages.
 Querystring popover button: filter icon, "Filter" tooltip.
+Change message from misleading "Cannot order items while querying" to "Drag and drop reordering is disabled while filters are applied.". Fixes: https://github.com/collective/plone.app.locales/issues/173
+
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -1,4 +1,5 @@
-Structure pattern: Reset any applied filters after changing the path.
+Structure pattern:
+Show statusmessage with "Clear filter" button when filters are applied.
 Show visually if a filter is set.
 Allow multiple status messages.
 [thet]

--- a/news/937.feature
+++ b/news/937.feature
@@ -1,0 +1,2 @@
+Structure pattern: Reset any applied filters after changing the path.
+[thet]

--- a/news/938.feature
+++ b/news/938.feature
@@ -1,0 +1,2 @@
+Upgrade node version for testing on travis.
+[thet]

--- a/news/943.bugfix
+++ b/news/943.bugfix
@@ -1,0 +1,2 @@
+For the ``i18n-dump`` Grunt task, do not read files in directories except ``mockup`` and ``js``.
+[thet]


### PR DESCRIPTION
Structure pattern:
- Show statusmessage with "Clear filter" button when filters are applied.
- Show visually if a filter is set.
- Allow multiple status messages.
- Display toolbar a bit compacter.

- Instead of clearing the filter when changing the path (initial approach from first commit) now there is a status message shown with a "Clear filter" button in it. For this to work it was necessary to allow multiple status messages. The "Clear filter" status message must always be present while other status messages must still be possible.
That way it should be very obvious that the current view is filtered.
- If a text filter is set, the filter input has a blue border.
- if a querystring is set, the magnifier icon has a blue background.
- The status messages look a bit nicer.

Applied filter:
![Screenshot from 2020-02-03 02-01-54](https://user-images.githubusercontent.com/170891/73619756-f6b94b80-462e-11ea-9207-7c82c37a0981.png)

New statusmessage design + more compact toolbar (no border-bottom, no margin-bottom, no min height):
![Screenshot from 2020-02-03 02-00-09](https://user-images.githubusercontent.com/170891/73619775-0769c180-462f-11ea-9c5b-4a90cd75963b.png)

Old statusmessage design:
![Screenshot from 2020-02-03 01-50-18](https://user-images.githubusercontent.com/170891/73619790-105a9300-462f-11ea-99aa-ee5944c6a738.png)




Merge together:
https://github.com/plone/mockup/pull/937
https://github.com/collective/plone.app.locales/pull/286