### PR TITLE
pat-querystring: Fix path widget for old dashed UIDs (plone.uuid < 1.0.2)

### DIFF
--- a/mockup/patterns/querystring/pattern.js
+++ b/mockup/patterns/querystring/pattern.js
@@ -259,7 +259,7 @@ define([
       self.createPathOperators();
 
       // We must test if we have a "simple" path or an "advanced" one and change the widgets accordingly
-      if (index === 'path' && value && value !== '.::1' && value !== '..::1' && !value.match(/^[0-9a-f]{32}::-?[0-9]+$/)) {
+      if (index === 'path' && value && value !== '.::1' && value !== '..::1' && !value.match(/^[0-9a-f\-]{32,36}::-?[0-9]+$/)) {
         self.advanced = true;
         self.resetPathOperators();
       }

--- a/news/939.bugfix
+++ b/news/939.bugfix
@@ -1,0 +1,2 @@
+pat-querystring: Fix path widget for old dashed UIDs (plone.uuid < 1.0.2)
+[laulaz]


### PR DESCRIPTION
This refs #939