### PR TITLE
add missing aria-labels to action icons

### DIFF
--- a/mockup/patterns/structure/templates/actionmenu.xml
+++ b/mockup/patterns/structure/templates/actionmenu.xml
@@ -1,11 +1,12 @@
 <% _.each(menuOptions.button, function(menuOption){ %>
 <a class="action <%- menuOption.name %> <%- menuOption.idx %> pat-tooltip <%- menuOption.css %>"
     href="<%- menuOption.url %>"
-    title="<%- _t(menuOption.title) %>">
+    title="<%- _t(menuOption.title) %>"
+    aria-label="<%- _t(menuOption.title) %>">
   <% if (menuOption.iconCSS) { %>
   <span class="<%- menuOption.iconCSS %>"></span>
   <% } else { %>
-  <%- _t(menuOption.title) %> 
+  <%- _t(menuOption.title) %>
   <% } %>
 </a>&nbsp;
 <% }); %>

--- a/news/965.bugfix
+++ b/news/965.bugfix
@@ -1,0 +1,2 @@
+add missing title and aria-label attributes
+[erral & ionlizarazu]


### PR DESCRIPTION
Fixes #965 

@codesyntax
@codesyntax/plone
@ionlizarazu