### PR TITLE
Add image caption support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,22 @@ Changelog
 
 .. towncrier release notes start
 
+X (2020-05-21)
+--------------
+
+Bug fixes:
+
+
+- - TinyMCE: Add support for image captions.
+  - If an image caption is given, the ``<img>`` tag is wrapped within a ``<figure>`` tag and a ``<figcaption>`` tag is added. (#977)
+
+
+X (2020-05-21)
+--------------
+
+No significant changes.
+
+
 2.7.8 (2019-05-21)
 ------------------
 

--- a/mockup/patterns/tinymce/pattern.js
+++ b/mockup/patterns/tinymce/pattern.js
@@ -3,7 +3,7 @@
  * Options:
  *    relatedItems(object): Related items pattern options. ({ attributes: ["UID", "Title", "Description", "getURL", "portal_type", "path", "ModificationDate"], batchSize: 20, basePath: "/", vocabularyUrl: null, width: 500, maximumSelectionSize: 1, placeholder: "Search for item on site..." })
  *    upload(object): Upload pattern options. ({ attributes: look at upload pattern for getting the options list })
- *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", externalImage: "External Image URI"})
+ *    text(object): Translation strings ({ insertBtn: "Insert", cancelBtn: "Cancel", insertHeading: "Insert link", title: "Title", internal: "Internal", external: "External", email: "Email", anchor: "Anchor", subject: "Subject" image: "Image", imageAlign: "Align", scale: "Size", alt: "Alternative Text", captionFromDescription: "Show Image Caption from Image Description", caption: "Image Caption", externalImage: "External Image URI"})
  *    imageScales(string): Image scale name/value object-array or JSON string for use in the image dialog.
  *    targetList(array): TODO ([ {text: "Open in this window / frame", value: ""}, {text: "Open in new window", value: "_blank"}, {text: "Open in parent window / frame", value: "_parent"}, {text: "Open in top frame (replaces all frames)", value: "_top"}])
  *    imageTypes(string): TODO ('Image')
@@ -148,6 +148,8 @@ define([
         scale: _t('Size'),
         alt: _t('Alternative Text'),
         insertImageHelp: _t('Specify an image. It can be on this site already (Internal Image), an image you upload (Upload), or from an external site (External Image).'),
+        captionFromDescription: _t('Show Image Caption from Image Description'),
+        caption: _t('Image Caption'),        
         internalImage: _t('Internal Image'),
         externalImage: _t('External Image'),
         externalImageText: _t('External Image URL (can be relative within this site or absolute if it starts with http:// or https://)'),

--- a/mockup/patterns/tinymce/templates/image.xml
+++ b/mockup/patterns/tinymce/templates/image.xml
@@ -60,6 +60,16 @@
         <label><%- altText %></label>
         <input type="text" name="alt" />
       </div>
+      <div class="form-group captionFromDescription">
+        <label>
+          <input type="checkbox" name="captionFromDescription" />
+          <%- captionFromDescriptionText %>
+        </label>
+      </div>
+      <div class="form-group caption">
+        <label><%- captionText %></label>
+        <textarea name="caption" />
+      </div>      
       <div class="form-group align">
         <label><%- imageAlignText %></label>
         <select name="align">

--- a/mockup/tests/pattern-tinymce-test.js
+++ b/mockup/tests/pattern-tinymce-test.js
@@ -336,7 +336,64 @@ define([
       pattern.imageModal.$scale.find('[value="customscale"]')[0].selected = true;
       expect(pattern.imageModal.getLinkUrl()).to.equal('resolveuid/foobar/@@images/image/customscale');
     });
+    it('test add image with and without caption', function() {
+      var pattern = createTinymce({
+        prependToUrl: 'resolveuid/',
+        linkAttribute: 'UID',
+        prependToScalePart: '/@@images/image/'
+      });
 
+      // Add an image caption.
+      pattern.addImageClicked();
+      pattern.imageModal.linkTypes.image.getEl().select2('data', {
+        UID: 'foobar',
+        portal_type: 'Document',
+        Title: 'Foobar',
+        path: '/foobar'
+      });
+      pattern.imageModal.$caption.val('hello.');
+      pattern.imageModal.$button.click();
+      var content = pattern.tiny.getContent();
+
+      expect(content).to.contain('<figure><img');
+      expect(content).to.contain('<figcaption>hello.</figcaption>');
+      expect(content).to.contain('image-richtext');// new image-richtext class.
+
+      // Remove the image caption. The <img> isn't wrapped then in a <figure> tag.
+      pattern.addImageClicked();
+      pattern.imageModal.linkTypes.image.getEl().select2('data', {
+        UID: 'foobar',
+        portal_type: 'Document',
+        Title: 'Foobar',
+        path: '/foobar'
+      });
+      pattern.imageModal.$caption.val('');
+      pattern.imageModal.$button.click();
+      content = pattern.tiny.getContent();
+
+      expect(content).to.not.contain('<figure>');
+      expect(content).to.not.contain('<figcaption>');
+      expect(content).to.contain('<img');
+      expect(content).to.contain('image-richtext'); // new image-richtext class.
+
+      // Use image captions from the image description.
+      pattern.addImageClicked();
+      pattern.imageModal.linkTypes.image.getEl().select2('data', {
+        UID: 'foobar',
+        portal_type: 'Document',
+        Title: 'Foobar',
+        path: '/foobar'
+      });
+      pattern.imageModal.$captionFromDescription.prop('checked', true);
+      pattern.imageModal.$button.click();
+      content = pattern.tiny.getContent();
+
+      expect(content).to.not.contain('<figure>');
+      expect(content).to.not.contain('<figcaption>');
+      expect(content).to.contain('<img');
+      expect(content).to.contain('image-richtext'); // new image-richtext class.
+      expect(content).to.contain('captioned'); // new image-richtext class.
+    });
     it('test adds data attributes', function() {
       var pattern = createTinymce();
       pattern.tiny.setContent('<p>blah</p>');


### PR DESCRIPTION
In the TinyMCE Image dialog:

- Adds an option for image captioning support from the description of the image ("Show Image Caption from Image Description") (uses an plone.outputfilters filter),

- Adds an textfield for manual image captions,
- Wraps the image in a &lt;figure> tag and adds a &lt;figcaption> if "Show Image Caption from Image Description" is not checked and the manual caption is present.
- If no caption is present, only the image tag is added.
Re-adds image caption support, which was present until Plone 5.

Based on 
https://github.com/plone/mockup/pull/911

Screenshot:

![image](https://user-images.githubusercontent.com/16021828/82626338-2d4eae00-9bad-11ea-8d1e-f44ac1cec9cc.png)


