### PR TITLE
Fix duplicate versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "resolutions": {
     "backbone.paginator/backbone": "https://github.com/jashkenas/backbone.git#1.1.2",
     "underscore": "1.9.1",
-    "jquery": "1.12.4"
+    "jquery": "1.12.4",
+    "datatables.net": "https://github.com/DataTables/Dist-DataTables.git#1.10.16",
+    "datatables.net-bs": "https://github.com/DataTables/Dist-DataTables-Bootstrap.git#1.10.16"
   },
   "dependencies": {
     "ace-builds": "https://github.com/ajaxorg/ace-builds.git#v1.2.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "resolutions": {
     "backbone.paginator/backbone": "https://github.com/jashkenas/backbone.git#1.1.2",
-    "underscore": "1.9.1"
+    "underscore": "1.9.1",
+    "jquery": "1.12.4"
   },
   "dependencies": {
     "ace-builds": "https://github.com/ajaxorg/ace-builds.git#v1.2.6",
@@ -42,7 +43,7 @@
     "datatables.net-select-bs": "https://github.com/DataTables/Dist-DataTables-Select-Bootstrap.git#1.2.3",
     "dropzone": "https://github.com/enyo/dropzone.git#v4.3.0",
     "jqtree": "https://github.com/mbraak/jqTree.git#1.4.10",
-    "jquery": "https://github.com/jquery/jquery-dist.git#1.12.4",
+    "jquery": "1.12.4",
     "jquery-form": "https://github.com/jquery-form/form.git#4.2.2",
     "jquery.browser": "https://github.com/gabceb/jquery-browser-plugin.git#v0.1.0",
     "jquery.cookie": "https://github.com/carhartl/jquery-cookie.git#v1.4.1",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "yarn": "^1.3.2"
   },
   "resolutions": {
-    "backbone.paginator/backbone": "https://github.com/jashkenas/backbone.git#1.1.2",
+    "backbone": "https://github.com/jashkenas/backbone.git#1.1.2",
     "underscore": "1.9.1",
-    "cs-jqtree-contextmenu/jqtree": "1.4.10",
+    "jqtree": "1.4.10",
     "jquery": "1.12.4",
     "datatables.net": "https://github.com/DataTables/Dist-DataTables.git#1.10.16",
     "datatables.net-bs": "https://github.com/DataTables/Dist-DataTables-Bootstrap.git#1.10.16"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "resolutions": {
     "backbone.paginator/backbone": "https://github.com/jashkenas/backbone.git#1.1.2",
     "underscore": "1.9.1",
+    "cs-jqtree-contextmenu/jqtree": "1.4.10",
     "jquery": "1.12.4",
     "datatables.net": "https://github.com/DataTables/Dist-DataTables.git#1.10.16",
     "datatables.net-bs": "https://github.com/DataTables/Dist-DataTables-Bootstrap.git#1.10.16"
@@ -44,7 +45,7 @@
     "datatables.net-select": "https://github.com/DataTables/Dist-DataTables-Select.git#1.2.3",
     "datatables.net-select-bs": "https://github.com/DataTables/Dist-DataTables-Select-Bootstrap.git#1.2.3",
     "dropzone": "https://github.com/enyo/dropzone.git#v4.3.0",
-    "jqtree": "https://github.com/mbraak/jqTree.git#1.4.10",
+    "jqtree": "1.4.10",
     "jquery": "1.12.4",
     "jquery-form": "https://github.com/jquery-form/form.git#4.2.2",
     "jquery.browser": "https://github.com/gabceb/jquery-browser-plugin.git#v0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "node": ">=8.12.0",
     "yarn": "^1.3.2"
   },
+  "resolutions": {
+    "backbone.paginator/backbone": "https://github.com/jashkenas/backbone.git#1.1.2",
+    "underscore": "1.9.1"
+  },
   "dependencies": {
     "ace-builds": "https://github.com/ajaxorg/ace-builds.git#v1.2.6",
     "backbone": "https://github.com/jashkenas/backbone.git#1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,18 +321,11 @@ aws4@^1.2.1, aws4@^1.8.0:
     backbone "~0.9.2"
     underscore "1.3.3"
 
-"backbone@https://github.com/jashkenas/backbone.git#1.1.2":
+"backbone@https://github.com/jashkenas/backbone.git#1.1.2", backbone@~0.9.2:
   version "1.1.2"
   resolved "https://github.com/jashkenas/backbone.git#53f77901a4ea9c7cf75d3db93ddddf491998d90f"
   dependencies:
     underscore ">=1.5.0"
-
-backbone@~0.9.2:
-  version "0.9.10"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-0.9.10.tgz#12b841c29c12a55ef37d582803a0f7fb35094f8a"
-  integrity sha1-ErhBwpwSpV7zfVgoA6D3+zUJT4o=
-  dependencies:
-    underscore ">=1.4.3"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -5100,20 +5093,10 @@ underscore.string@~3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
-underscore@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.3.3.tgz#47ac53683daf832bfa952e1774417da47817ae42"
-  integrity sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI=
-
-underscore@>=1.4.3, underscore@>=1.5.0:
+underscore@1.3.3, underscore@1.9.1, underscore@>=1.5.0, underscore@~1.4.4:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
-
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,16 +2729,10 @@ istanbul@^0.4.0:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-jqtree@>=0.16:
-  version "1.4.12"
-  resolved "https://registry.yarnpkg.com/jqtree/-/jqtree-1.4.12.tgz#f93e366e46b68b893d3e4eb43ea53f73bb7e502e"
-  integrity sha512-zNdnVFFNWAmPbtVFZaAhIjhFVoYpRF/NWeVGU1THRdefjKhXFwLeVILW1R4Frr/qiGg4TTbXWAxk7V7E+Wu3ZQ==
-  dependencies:
-    jquery ">=1.9"
-
-"jqtree@https://github.com/mbraak/jqTree.git#1.4.10":
+jqtree@1.4.10, jqtree@>=0.16:
   version "1.4.10"
-  resolved "https://github.com/mbraak/jqTree.git#8e656e2a93ffa5d47e862d89853dc7544cb3a13c"
+  resolved "https://registry.yarnpkg.com/jqtree/-/jqtree-1.4.10.tgz#ef3a348773f820e0844f05e9cd905da989ea1f4d"
+  integrity sha512-SKefhiz4tPW8jal608GVcX2FgYKa1RC8b3bpOp6xd2Br26UeuunaNCZABWk9QGzKDMoZyNwbfVf9N3xDVjy5XQ==
   dependencies:
     jquery ">=1.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,14 +2777,10 @@ jqtree@>=0.16:
   dependencies:
     jquery ""
 
-jquery@, jquery@>=1.7, jquery@>=1.7.2, jquery@>=1.9:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
-"jquery@https://github.com/jquery/jquery-dist.git#1.12.4":
+jquery@, jquery@1.12.4, jquery@>=1.7, jquery@>=1.7.2, jquery@>=1.9:
   version "1.12.4"
-  resolved "https://github.com/jquery/jquery-dist.git#5e89585e0121e72ff47de177c5ef604f3089a53d"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
 
 js-yaml@3.13.1, js-yaml@~3.13.0:
   version "3.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,15 +952,7 @@ datatables.net-autofill@2.2.2, "datatables.net-autofill@https://github.com/DataT
     datatables.net "^1.10.15"
     jquery ">=1.7"
 
-datatables.net-bs@^1.10.15:
-  version "1.10.21"
-  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-1.10.21.tgz#c80e655033787512423ad78a45e8164f25417dc5"
-  integrity sha512-4mpesFXNEkLlQET3IDLclLz95Xit4Kp/jHcOM2X0nc/ijDfO3qJk3ehZ+NSEAkXZDge6ZtY5Zxq2O90ISiIjwQ==
-  dependencies:
-    datatables.net "1.10.21"
-    jquery ">=1.7"
-
-"datatables.net-bs@https://github.com/DataTables/Dist-DataTables-Bootstrap.git#1.10.16":
+datatables.net-bs@^1.10.15, "datatables.net-bs@https://github.com/DataTables/Dist-DataTables-Bootstrap.git#1.10.16":
   version "1.10.16"
   resolved "https://github.com/DataTables/Dist-DataTables-Bootstrap.git#f52ec6fb22ed55e455f1ffed1d2a3f2ea7df7bc1"
   dependencies:
@@ -1102,16 +1094,9 @@ datatables.net-select@1.2.3, "datatables.net-select@https://github.com/DataTable
     datatables.net "^1.10.15"
     jquery ">=1.7"
 
-datatables.net@1.10.16, "datatables.net@https://github.com/DataTables/Dist-DataTables.git#1.10.16":
+datatables.net@1.10.16, datatables.net@^1.10.15, "datatables.net@https://github.com/DataTables/Dist-DataTables.git#1.10.16":
   version "1.10.16"
   resolved "https://github.com/DataTables/Dist-DataTables.git#795d3f39b73da5bc3656c8ef5425931a55e6ed2e"
-  dependencies:
-    jquery ">=1.7"
-
-datatables.net@1.10.21, datatables.net@^1.10.15:
-  version "1.10.21"
-  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.21.tgz#f1d35c8e5c3eb7f5caef39e80cd5b836a8c77103"
-  integrity sha512-/bSZtxmf3GTpYcvEmwZ8q26I1yhSx8qklR2B+s1K8+/51UW/zc2zTYwJMqr/Z+iCYixAc00ildj4g2x0Qamolw==
   dependencies:
     jquery ">=1.7"
 


### PR DESCRIPTION
Fix multiple versions or wrong version of some packages when we switched from bower to yarn.
Bower dependencies installation was flat by design. With npm or yarn, this is not the case, so we need to be extra careful.