### PR TITLE
Fix folder contents z-index issues with toolbar and nav tabs

### DIFF
--- a/mockup/js/ui/views/popover.js
+++ b/mockup/js/ui/views/popover.js
@@ -137,6 +137,9 @@ define([
       actualHeight = $tip[0].offsetHeight;
 
       switch (placement) {
+        case 'bottom-right':
+          tp = {top: pos.top + pos.height, left: pos.left + pos.width - 40};
+          break;
         case 'bottom':
           tp = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2};
           break;
@@ -192,7 +195,8 @@ define([
 
         this.positionArrow(delta - width + actualWidth, actualWidth, 'left');
 
-      } else {
+      } else if (placement !== 'bottom-right') {
+        // If placement is bottom-right, don't override left position for the arrow that is defined in css to 20px.
         this.positionArrow(actualHeight - height, actualHeight, 'top');
       }
 

--- a/mockup/less/popover.less
+++ b/mockup/less/popover.less
@@ -12,6 +12,23 @@
     &.active {
         display: block;
     }
+    // Offset the popover to account for the popover arrow
+    &.bottom-right { margin-top: @popover-arrow-width; }
+    &.bottom-right > .arrow {
+        top: -@popover-arrow-outer-width;
+        left: 20px;
+        margin-left: -@popover-arrow-outer-width;
+        border-top-width: 0;
+        border-bottom-color: @popover-arrow-outer-fallback-color; // IE8 fallback
+        border-bottom-color: @popover-arrow-outer-color;
+        &:after {
+          top: 1px;
+          margin-left: -@popover-arrow-width;
+          content: " ";
+          border-top-width: 0;
+          border-bottom-color: @popover-arrow-color;
+        }
+    }
 }
 .backdrop-popover {
     background-color: #fff;

--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -367,7 +367,8 @@ define([
       self.columnsView = new ColumnsView({
         app: self,
         triggerView: columnsBtn,
-        id: 'structure-columns'
+        id: 'structure-columns',
+        placement: 'bottom-right'
       });
       items.push(columnsBtn);
 

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -189,6 +189,10 @@
         max-width: 650px;
     }
 
+    .popover.rearrange{
+        max-width: 400px;
+    }
+
     .upload-container .upload-area{
         width: 500px;
     }

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -85,7 +85,7 @@
     .navbar {
         position: sticky;
         top: 0;
-        z-index: 1060;
+        z-index: 10;
         background-color: #fafafa;
 
         border: none;

--- a/news/1002.bugfix
+++ b/news/1002.bugfix
@@ -1,0 +1,4 @@
+In mockup 3.2.0, the fix for 'folder contents "Configure display columns" dialog going under toolbar'
+introduced regression for Plone toolbar submenu and portal tabs subtrees.
+Revert the previous fix and use a new popover placement mode "bottom-right" for the "Configure display columns" popover.
+[vincentfretin]


### PR DESCRIPTION
My fix https://github.com/plone/mockup/commit/a6fa639b9e80ec04d9143bf451e73fd51d6ff0ae for https://github.com/plone/Products.CMFPlone/issues/3124 introduced regressions with Plone toolbar and navigation tabs that apparently was fixed before, see https://github.com/plone/Products.CMFPlone/issues/2307
This PR revert my previous fix and add a new placement mode "bottom-right' for popover that I applied to the 'Configure display column' popover

![Capture d’écran de 2020-07-12 14-45-52](https://user-images.githubusercontent.com/112249/87246558-75bc7680-c44e-11ea-9037-1a898d78c2d2.png)
