### PR TITLE
Fix toolbar menus missing checkmark on some browsers

### DIFF
--- a/mockup/patterns/toolbar/pattern.toolbar.less
+++ b/mockup/patterns/toolbar/pattern.toolbar.less
@@ -358,10 +358,16 @@
         }
 
         &.plonetoolbar-display-view.actionSeparator {
-            margin: 0;
+          margin: 0;
+          > :before {
+            content: '';
+          }
+          > span {
+            padding: 5px 15px;
+          }
         }
 
-        &:not(.plone-toolbar-submenu-header, .plonetoolbar-display-view.actionSeparator) {
+        &:not(.plone-toolbar-submenu-header) {
           > :before {
             position: absolute;
             left: 15px;

--- a/news/1003.bugfix
+++ b/news/1003.bugfix
@@ -1,0 +1,3 @@
+Fix toolbar menus missing checkmark on some browsers
+This fixes https://github.com/plone/Products.CMFPlone/issues/1972
+[vincentfretin]


### PR DESCRIPTION
This fixes https://github.com/plone/Products.CMFPlone/issues/1972

on Chrome
Before:
![Capture d’écran de 2020-07-12 15-28-05](https://user-images.githubusercontent.com/112249/87247856-95f03380-c456-11ea-8529-3f648ff9d9a9.png)


After:
![Capture d’écran de 2020-07-12 15-55-04](https://user-images.githubusercontent.com/112249/87248146-1c594500-c458-11ea-9341-32cb732a0b2f.png)
