### PR TITLE
Put back content type icons in the Add new... menu.

### DIFF
--- a/mockup/patterns/toolbar/pattern.toolbar.less
+++ b/mockup/patterns/toolbar/pattern.toolbar.less
@@ -367,7 +367,11 @@
           }
         }
 
-        &:not(.plone-toolbar-submenu-header) {
+        &.plonetoolbar-workfow-transition,
+        &.plonetoolbar-content-action,
+        &.plonetoolbar-display-view,
+        &.plonetoolbar-portlet-manager,
+        &.user-action {
           > :before {
             position: absolute;
             left: 15px;

--- a/news/1009.bugfix
+++ b/news/1009.bugfix
@@ -1,0 +1,2 @@
+Put back content type icons in the Add new... menu. This fixes https://github.com/plone/Products.CMFPlone/issues/3163
+[vincentfretin]


### PR DESCRIPTION
This fixes https://github.com/plone/Products.CMFPlone/issues/3163
The bug was already present in Safari before https://github.com/plone/mockup/pull/1003 changes, but the bug surfaced on Chrome and Firefox with the changes in https://github.com/plone/mockup/pull/1003