### PR TITLE
[WIP] pat-structure: badge for exclude_from_nav

### DIFF
--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -134,6 +134,7 @@
             }
         }
         .plone-item-expired,
+        .plone-item-hidden, 
         .plone-item-ineffective {
           .badge();
           font-size: 12px;
@@ -141,6 +142,9 @@
         }
         .plone-item-expired {
           background-color: @plone-toolbar-private-color;
+        }
+        .plone-item-hidden {
+          background-color: #808080;
         }
         .plone-item-ineffective {
           background-color: @plone-toolbar-internal-color;

--- a/mockup/patterns/structure/templates/tablerow.xml
+++ b/mockup/patterns/structure/templates/tablerow.xml
@@ -16,6 +16,9 @@
     <% if(expired){ %>
       <span class="plone-item-expired"><%- _t('Expired') %></span>
     <% } %>
+    <% if(attributes["exclude_from_nav"]){ %>
+      <span class="plone-item-hidden"><%- _t('Hidden') %></span>
+    <% } %>
     <% if(ineffective){ %>
       <span class="plone-item-ineffective"><%- _t('Before publishing date') %></span>
     <% } %>

--- a/news/xxxx.feature
+++ b/news/xxxx.feature
@@ -1,0 +1,2 @@
+pat-structure: Add a ``hidden`` badge for content which is excluded from the navigation.
+[thet]


### PR DESCRIPTION
pat-structure: Add a hidden badge for content which is excluded from the navigation.

Same as https://github.com/plone/mockup/pull/999
but with me as author who has signed the contributor agreement.

Not for merge now.
Also want to reconsider if "hidden" is a good term for this + maybe add some "title" attributes to further explain the badges.