### PR TITLE
Fix toolbar being updated only on the first navigation action

### DIFF
--- a/mockup/patterns/toolbar/pattern.js
+++ b/mockup/patterns/toolbar/pattern.js
@@ -514,10 +514,12 @@ define([
           $.ajax({
             url: $('body').attr('data-portal-url') + path + '/@@render-toolbar',
           }).done(function(data) {
-            var $el = $(utils.parseBodyTag(data));
-            $el = $el.find('#edit-zone').length ? $el.find('#edit-zone') : $el;
-            that.$el.replaceWith($el);
-            Registry.scan($el);
+            var $newel = $(utils.parseBodyTag(data));
+            var hasedit = $newel.find('#edit-zone').length;
+            $newel = hasedit ? $newel.find('#edit-zone') : $newel;
+            var $replacetoolbar = $('#edit-bar').find('#edit-zone');
+            $replacetoolbar.replaceWith($newel);
+            Registry.scan($newel);
           });
         });
 

--- a/mockup/patterns/toolbar/pattern.js
+++ b/mockup/patterns/toolbar/pattern.js
@@ -244,7 +244,7 @@ define([
           }
         });
 
-      $('body').off('click').on('click', function(event) {
+      $('body').off('click.closetoolbarsubmenus').on('click.closetoolbarsubmenus', function(event) {
         var $el = that.$container.find(event.target);
         // we need to check if the target isn't the nav which can be
         // triggered if we click on the portal-header and plone-toolbar-more-subset
@@ -509,8 +509,8 @@ define([
          This is for usability so the menu changes along with
          the folder contents context */
       $('body')
-        .off('structure-url-changed')
-        .on('structure-url-changed', function(e, path) {
+        .off('structure-url-changed.toolbar')
+        .on('structure-url-changed.toolbar', function(e, path) {
           $.ajax({
             url: $('body').attr('data-portal-url') + path + '/@@render-toolbar',
           }).done(function(data) {

--- a/mockup/patterns/toolbar/pattern.js
+++ b/mockup/patterns/toolbar/pattern.js
@@ -244,7 +244,7 @@ define([
           }
         });
 
-      $('body').on('click', function(event) {
+      $('body').off('click').on('click', function(event) {
         var $el = that.$container.find(event.target);
         // we need to check if the target isn't the nav which can be
         // triggered if we click on the portal-header and plone-toolbar-more-subset

--- a/news/3191.bugfix
+++ b/news/3191.bugfix
@@ -1,0 +1,1 @@
+Fix plone toolbar action links being updated only on the first navigation action in the folder_contents structure pattern. [fredvd]


### PR DESCRIPTION
Main issue: this fixes the links in the plone toolbar becoming outdated when one navigates more than once in in the folder contents view. 

But wait, there's more...

What still is very strange and I think unwanted is that the toolbar updating is done twice.  And it's not only the toolbar, for every navigation click in folder_contents, 3 ajax calls are made twice to the backend for:
* `@@render-toolbar`  (toolbar itself)
* `@@fc-contextInfo` (actions in the toolbar)
* `@@getVocabulary`   (folder_contents main table)

### Double event handlers? ###

When I inspect the registered event handlers on the body element in the Firefox devtools, the toolbar structure-changed event is present twice , once from jquery and once from DOM2|bubbling, but I have no clue if this causes the double refresh of the toolbar. 
<img width="723" alt="folder_contents first load events on body" src="https://user-images.githubusercontent.com/394784/97061658-dbfd7d00-1597-11eb-9490-6f86200b1709.png">


Also: another click event handler in the Toolbar component is not properly unregistered before it's reregistered and pile up on the body tag when navigating :

https://github.com/plone/mockup/blob/590d229599433bac4f2265ce7dfa7857c408bf17/mockup/patterns/toolbar/pattern.js#L247

Changing this line 247 to::

       $('body').off('click').on('click', function(event) {

Solves the click events not being cleaned up, but this is rather new for me, I'm already happy I kind of found the toolbar update isssue. :-)  If somebody more knowledgable could confirm this is the case? 
