### PR TITLE
Fix plone toolbar action links not being updated

### DIFF
--- a/mockup/patterns/toolbar/pattern.js
+++ b/mockup/patterns/toolbar/pattern.js
@@ -282,7 +282,9 @@ define([
                     }
                 });
 
-            $("body").on("click", function (event) {
+            $("body")
+                .off("click.closetoolbarsubmenus")
+                .on("click.closetoolbarsubmenus", function (event) {
                 var $el = that.$container.find(event.target);
                 // we need to check if the target isn't the nav which can be
                 // triggered if we click on the portal-header and plone-toolbar-more-subset
@@ -570,20 +572,20 @@ define([
          This is for usability so the menu changes along with
          the folder contents context */
             $("body")
-                .off("structure-url-changed")
-                .on("structure-url-changed", function (e, path) {
+                .off("structure-url-changed.toolbar")
+                .on("structure-url-changed.toolbar", function (e, path) {
                     $.ajax({
                         url:
                             $("body").attr("data-portal-url") +
                             path +
                             "/@@render-toolbar",
                     }).done(function (data) {
-                        var $el = $(utils.parseBodyTag(data));
-                        $el = $el.find("#edit-zone").length
-                            ? $el.find("#edit-zone")
-                            : $el;
-                        that.$el.replaceWith($el);
-                        Registry.scan($el);
+                        var $newel = $(utils.parseBodyTag(data));
+                        var hasedit = $newel.find('#edit-zone').length;
+                        $newel = hasedit ? $newel.find("#edit-zone") : $newel;
+                        var $replacetoolbar = $('#edit-bar').find('#edit-zone');
+                        $replacetoolbar.replaceWith($newel);
+                        Registry.scan($newel);
                     });
                 });
 

--- a/mockup/patterns/toolbar/pattern.js
+++ b/mockup/patterns/toolbar/pattern.js
@@ -583,7 +583,7 @@ define([
                         var $newel = $(utils.parseBodyTag(data));
                         var hasedit = $newel.find('#edit-zone').length;
                         $newel = hasedit ? $newel.find("#edit-zone") : $newel;
-                        var $replacetoolbar = $('#edit-bar').find('#edit-zone');
+                        var $replacetoolbar = $('body').find('#edit-zone');
                         $replacetoolbar.replaceWith($newel);
                         Registry.scan($newel);
                     });

--- a/news/3191.bugfix
+++ b/news/3191.bugfix
@@ -1,0 +1,1 @@
+Fix plone toolbar action links being updated only on the first navigation action in the folder_contents structure pattern. Also clean up previous closetoolbarsubmenu's event handler before readding [fredvd]


### PR DESCRIPTION
They are only updated when in folder contents on the first navigation action
Fixes Products.CMFPlone #3191. Forward port from 3.x branch.

Also clean up previous closetoolbarsubmenu's event handler before re-adding #3191