### PR TITLE
prevent double xhr requests with folder navigation in structure pattern

### DIFF
--- a/mockup/patterns/structure/js/views/app.js
+++ b/mockup/patterns/structure/js/views/app.js
@@ -277,7 +277,7 @@ define([
     },
     setCurrentPath: function(path) {
       this.collection.setCurrentPath(path);
-      this.textfilter.clearTerm();
+      this.textfilter.clearTerm(false);
       this.clearStatus();
     },
     getAjaxUrl: function(url) {

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -31,7 +31,8 @@ define([
       self.subsetIds = [];
       self.contextInfo = null;
 
-      $('body').on('context-info-loaded', function(event, data) {
+      $('body').off('context-info-loaded').on('context-info-loaded', function(event, data) {
+
         self.contextInfo = data;
         /* set default page info */
         self.setContextInfo();

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -66,13 +66,13 @@ define([
       }
     },
 
-    setTerm: function(term, set_input, refresh=true) {
+    setTerm: function(term, set_input, refresh) {
       var term_el = this.$el[0].querySelector('.search-query');
       this.term = encodeURIComponent(term);
       if (set_input) {
         term_el.value = term;
       }
-      if (refresh) {
+      if (refresh === undefined || refresh == true) {
         this.app.collection.currentPage = 1;
         this.app.collection.pager();
       }
@@ -128,7 +128,7 @@ define([
       }
     },
 
-    clearTerm: function(refresh=true) {
+    clearTerm: function(refresh) {
       this.setTerm('', true, refresh);
     },
 

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -66,15 +66,16 @@ define([
       }
     },
 
-    setTerm: function(term, set_input) {
+    setTerm: function(term, set_input, refresh=true) {
       var term_el = this.$el[0].querySelector('.search-query');
       this.term = encodeURIComponent(term);
       if (set_input) {
         term_el.value = term;
       }
-      this.app.collection.currentPage = 1;
-      this.app.collection.pager();
-
+      if (refresh) {
+        this.app.collection.currentPage = 1;
+        this.app.collection.pager();
+      }
       if (term) {
         term_el.classList.add('has-filter');
         this.setFilterStatusMessage();
@@ -127,8 +128,8 @@ define([
       }
     },
 
-    clearTerm: function() {
-      this.setTerm('', true);
+    clearTerm: function(refresh=true) {
+      this.setTerm('', true, refresh);
     },
 
     clearFilter: function() {

--- a/mockup/patterns/structure/js/views/textfilter.js
+++ b/mockup/patterns/structure/js/views/textfilter.js
@@ -41,7 +41,7 @@ define([
     setFilterStatusMessage: function() {
       var clear_btn = $('<button type="button" class="btn btn-primary btn-xs"></button>')
         .text(_t('Clear'))
-        .on('click', function() {
+        .off('click.textfilter').on('click.textfilter', function() {
           this.clearFilter();
         }.bind(this));
 

--- a/mockup/patterns/structure/pattern-structureupdater.js
+++ b/mockup/patterns/structure/pattern-structureupdater.js
@@ -26,7 +26,8 @@ define([
 
     init: function() {
 
-      $('body').on('context-info-loaded', function (e, data) {
+      $('body').off('context-info-loaded').on('context-info-loaded', function (e, data) {
+
         if (this.options.titleSelector) {
             $(this.options.titleSelector, this.$el).html(data.object && data.object.Title || '&nbsp;');
         }

--- a/news/3203.bugfix
+++ b/news/3203.bugfix
@@ -1,0 +1,1 @@
+Prevent a folder_contents navigation from triggering the double amount of XHR requests through the text filter. Also correctly unregister/register events with a namespace in the structure pattern.[fredvd]


### PR DESCRIPTION
Triggered by the textfilter being reset which initialises the collection pager and does a new full refresh.

Also un-reregister more eventhandlers in structure pattern