### PR TITLE
Update bs3 paths

### DIFF
--- a/mockup/js/grunt.js
+++ b/mockup/js/grunt.js
@@ -118,7 +118,7 @@
                         // BOOTSTRAP
                         {
                             expand: true,
-                            cwd: "node_modules/bootstrap/dist/fonts/",
+                            cwd: "node_modules/bootstrap3/dist/fonts/",
                             src: "glyphicons-halflings-regular.*",
                             dest: bundleOptions.path,
                             rename: function (dest, src) {
@@ -229,7 +229,7 @@
                     this.gruntConfig.sed[name + "-bootstrap-glyphicons"] = {
                         path: bundleOptions.path + name + ".min.css",
                         pattern:
-                            "url\\('../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular",
+                            "url\\('../node_modules/bootstrap3/dist/fonts/glyphicons-halflings-regular",
                         replacement:
                             "url('" +
                             bundleOptions.url +

--- a/mockup/less/base.less
+++ b/mockup/less/base.less
@@ -1,5 +1,5 @@
 @import "@{bowerPath}/bootstrap3/less/variables.less";
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 @import "@{bowerPath}/bootstrap3/less/mixins.less";
 @import "@{bowerPath}/bootstrap3/less/glyphicons.less";
 @import (reference) "@{bowerPath}/bootstrap3/less/modals.less";

--- a/mockup/less/docs.less
+++ b/mockup/less/docs.less
@@ -1,9 +1,9 @@
 @import "mixins.less";
 
 @import "@{bowerPath}/bootstrap3/less/variables.less";
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 @import "@{bowerPath}/bootstrap3/less/bootstrap.less";
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 
 @import "@{mockupPath}/autotoc/pattern.autotoc.less";
 @import "@{mockupPath}/datatables/pattern.datatables.less";

--- a/mockup/less/filemanager.less
+++ b/mockup/less/filemanager.less
@@ -1,4 +1,4 @@
 @import "mixins.less";
 @import "@{mockupPath}/filemanager/pattern.filemanager.less";
 @import "@{bowerPath}/bootstrap3/less/bootstrap.less";
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";

--- a/mockup/less/resourceregistry.less
+++ b/mockup/less/resourceregistry.less
@@ -1,4 +1,4 @@
 @import "mixins.less";
 @import "@{mockupPath}/resourceregistry/pattern.resourceregistry.less";
 
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";

--- a/mockup/less/structure.less
+++ b/mockup/less/structure.less
@@ -10,7 +10,7 @@
 @import "@{mockupPath}/querystring/pattern.querystring.less";
 @import "@{mockupPath}/structure/less/pattern.structure.less";
 
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 
 .modal.fade.in > .modal-dialog {
     z-index: 1010;

--- a/mockup/less/widgets.less
+++ b/mockup/less/widgets.less
@@ -7,7 +7,7 @@
 @import "@{mockupPath}/tinymce/less/pattern.tinymce.less";
 @import "@{mockupPath}/passwordstrength/pattern.passwordstrength.less";
 @import "@{mockupPath}/recurrence/pattern.recurrence.less";
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 
 #content {
     .pat-autotoc.autotabs {

--- a/mockup/patterns/querystring/pattern.querystring.less
+++ b/mockup/patterns/querystring/pattern.querystring.less
@@ -1,5 +1,5 @@
 @import "@{bowerPath}/bootstrap3/less/variables.less"; // Modify this for custom colors, font-sizes, etc
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 @import "@{bowerPath}/bootstrap3/less/glyphicons.less";
 
 #content .field .querystring-criteria-wrapper .picker__input {

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -1,5 +1,5 @@
 @import "@{bowerPath}/bootstrap3/less/variables.less"; // Modify this for custom colors, font-sizes, etc
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 @import "@{bowerPath}/bootstrap3/less/glyphicons.less";
 @import "@{mockuplessPath}/ui.less";
 

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -1,5 +1,5 @@
 @import "@{bowerPath}/bootstrap3/less/variables.less"; // Modify this for custom colors, font-sizes, etc
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
+@icon-font-path: "@{bowerPath}/bootstrap3/dist/fonts/";
 @import "@{bowerPath}/bootstrap3/less/glyphicons.less";
 @import "@{mockuplessPath}/ui.less";
 @import "@{mockupPath}/tooltip/pattern.tooltip.less";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ace-builds": "1.2.6",
     "backbone": "1.1.2",
     "backbone.paginator": "1.0.0",
-    "bootstrap": "3.4.1",
+    "bootstrap3": "https://github.com/twbs/bootstrap.git#68b0d231a13201eb14acd3dc84e51543d16e5f7e",
     "cs-jqtree-contextmenu": "0.1.0",
     "datatables.net": "1.10.16",
     "datatables.net-autofill": "2.0.0",


### PR DESCRIPTION
Also updates the fonts to bootstrap3 paths. 

Renames bootstrap to bootstap3 as done by @agitator here: https://github.com/plone/plone.staticresources/commit/e7959733fc70baa442faf3a5385a417359ce1720

@thet Would this work? For me it fixes compiling form scratch.