### PR TITLE
Fix Folder contents default page marker and upload context. 

### DIFF
--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -31,8 +31,8 @@ define([
       self.subsetIds = [];
       self.contextInfo = null;
 
-      $('body').off('context-info-loaded').on('context-info-loaded', function(event, data) {
-
+      $('body').on('context-info-loaded', function(event, data) {
+        
         self.contextInfo = data;
         /* set default page info */
         self.setContextInfo();

--- a/mockup/patterns/structure/pattern-structureupdater.js
+++ b/mockup/patterns/structure/pattern-structureupdater.js
@@ -26,7 +26,7 @@ define([
 
     init: function() {
 
-      $('body').off('context-info-loaded').on('context-info-loaded', function (e, data) {
+      $('body').on('context-info-loaded', function (e, data) {
 
         if (this.options.titleSelector) {
             $(this.options.titleSelector, this.$el).html(data.object && data.object.Title || '&nbsp;');

--- a/news/3220.bugfix
+++ b/news/3220.bugfix
@@ -1,0 +1,2 @@
+Fix Folder contents default page marker and upload context.
+[fredvd]


### PR DESCRIPTION
Don't remove the eventlistener on this scope before re-adding, the others are then also removed.