### PR TITLE
Correctly update the context info when changing paths.

### DIFF
--- a/1041.bugfix
+++ b/1041.bugfix
@@ -1,0 +1,5 @@
+Do only remove the correct event listener on ``context-info-loaded`` before adding a new one.
+Fixes a problem where the current path was not updated for the upload popup when changing paths.
+Fixes: #1016
+Refs: #1028, #1030, #1039
+[thet]

--- a/mockup/patterns/structure/js/views/addmenu.js
+++ b/mockup/patterns/structure/js/views/addmenu.js
@@ -11,33 +11,38 @@ define([
     title: 'Add',
     className: 'btn-group addnew',
     events: {},
-    initialize: function(options) {
-      var self = this;
-      ButtonGroup.prototype.initialize.apply(self, [options]);
-      $('body').on('context-info-loaded', function(event, data) {
-        self.$items.empty();
-        _.each(data.addButtons, function(item) {
-          var view = new ButtonView({
-            id: item.id,
-            title: item.title,
-            url: item.action
-          });
-          view.render();
-          var wrap = $('<li/>');
-          // As we are reusing the whole ButtonView for render the add content
-          // list we should remove entirely the "btn btn-default" classes.
-          // This element in fact, should not have any class at all, so we
-          // remove the attribute completely
-          view.$el.removeAttr('class');
 
-          wrap.append(view.el);
-          self.$items.append(wrap);
-          view.$el.click(function(e) {
-            self.buttonClicked.apply(self, [e, view]);
-            return false;
-          });
+    context_info_loaded_handler: function(event, data) {
+      this.$items.empty();
+      var self = this;
+      _.each(data.addButtons, function(item) {
+        var view = new ButtonView({
+          id: item.id,
+          title: item.title,
+          url: item.action
+        });
+        view.render();
+        var wrap = $('<li/>');
+        // As we are reusing the whole ButtonView for render the add content
+        // list we should remove entirely the "btn btn-default" classes.
+        // This element in fact, should not have any class at all, so we
+        // remove the attribute completely
+        view.$el.removeAttr('class');
+
+        wrap.append(view.el);
+        self.$items.append(wrap);
+        view.$el.click(function(e) {
+          self.buttonClicked.apply(self, [e, view]);
+          return false;
         });
       });
+    },
+
+    initialize: function(options) {
+      ButtonGroup.prototype.initialize.apply(this, [options]);
+      $('body')
+        .off('context-info-loaded', this.context_info_loaded_handler.bind(this))
+        .on('context-info-loaded', this.context_info_loaded_handler.bind(this));
     },
     buttonClicked: function(e, button) {
       var self = this;

--- a/mockup/patterns/structure/js/views/table.js
+++ b/mockup/patterns/structure/js/views/table.js
@@ -19,6 +19,13 @@ define([
   var TableView = BaseView.extend({
     tagName: 'div',
     template: _.template(TableTemplate),
+
+    context_info_loaded_handler: function(event, data) {
+      this.contextInfo = data;
+      /* set default page info */
+      this.setContextInfo();
+    },
+
     initialize: function(options) {
       var self = this;
       BaseView.prototype.initialize.apply(self, [options]);
@@ -31,12 +38,9 @@ define([
       self.subsetIds = [];
       self.contextInfo = null;
 
-      $('body').off('context-info-loaded').on('context-info-loaded', function(event, data) {
-
-        self.contextInfo = data;
-        /* set default page info */
-        self.setContextInfo();
-      });
+      $('body')
+        .off('context-info-loaded', this.context_info_loaded_handler.bind(this))
+        .on('context-info-loaded', this.context_info_loaded_handler.bind(this));
 
       self.dateColumns = [
         'ModificationDate',

--- a/mockup/patterns/structure/js/views/upload.js
+++ b/mockup/patterns/structure/js/views/upload.js
@@ -12,14 +12,18 @@ define([
       '<input type="text" name="upload" style="display:none" />' +
       '<div class="uploadify-me"></div>'),
 
+    context_info_loaded_handler: function(event, data) {
+      this.currentPathData = data;
+    },
+
     initialize: function(options) {
       var self = this;
       self.app = options.app;
       PopoverView.prototype.initialize.apply(self, [options]);
       self.currentPathData = null;
-      $('body').on('context-info-loaded', function(event, data) {
-        self.currentPathData = data;
-      });
+      $('body')
+        .off('context-info-loaded', this.context_info_loaded_handler.bind(this))
+        .on('context-info-loaded', this.context_info_loaded_handler.bind(this));
     },
 
     render: function() {

--- a/mockup/patterns/structure/pattern-structureupdater.js
+++ b/mockup/patterns/structure/pattern-structureupdater.js
@@ -24,18 +24,19 @@ define([
       descriptionSelector: ''
     },
 
+    context_info_loaded_handler: function (e, data) {
+      if (this.options.titleSelector) {
+        $(this.options.titleSelector, this.$el).html(data.object && data.object.Title || '&nbsp;');
+      }
+      if (this.options.descriptionSelector) {
+        $(this.options.descriptionSelector, this.$el).html(data.object && data.object.Description || '&nbsp;');
+      }
+    },
+
     init: function() {
-
-      $('body').off('context-info-loaded').on('context-info-loaded', function (e, data) {
-
-        if (this.options.titleSelector) {
-            $(this.options.titleSelector, this.$el).html(data.object && data.object.Title || '&nbsp;');
-        }
-        if (this.options.descriptionSelector) {
-            $(this.options.descriptionSelector, this.$el).html(data.object && data.object.Description || '&nbsp;');
-        }
-      }.bind(this));
-
+      $('body')
+        .off('context-info-loaded', this.context_info_loaded_handler.bind(this))
+        .on('context-info-loaded', this.context_info_loaded_handler.bind(this));
     }
 
   });


### PR DESCRIPTION
Do only remove the correct event listener on ``context-info-loaded`` before adding a new one.
Fixes a problem where the current path was not updated for the upload popup when changing paths.
Fixes: #1016
Refs: #1028, #1030, #1039