### PR TITLE
Remove fonts from patterns to avoid multiple inline includes.

### DIFF
--- a/mockup/less/base.less
+++ b/mockup/less/base.less
@@ -1,7 +1,5 @@
 @import "@{bowerPath}/bootstrap/less/variables.less";
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
 @import "@{bowerPath}/bootstrap/less/mixins.less";
-@import "@{bowerPath}/bootstrap/less/glyphicons.less";
 @import (reference) "@{bowerPath}/bootstrap/less/modals.less";
 @import (reference) "@{bowerPath}/bootstrap/less/buttons.less";
 @import (reference) "@{bowerPath}/bootstrap/less/button-groups.less";

--- a/mockup/patterns/querystring/pattern.querystring.less
+++ b/mockup/patterns/querystring/pattern.querystring.less
@@ -1,6 +1,4 @@
 @import "@{bowerPath}/bootstrap/less/variables.less"; // Modify this for custom colors, font-sizes, etc
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
-@import "@{bowerPath}/bootstrap/less/glyphicons.less";
 
 #content .field .querystring-criteria-wrapper .picker__input {
   font-size: 16px;
@@ -28,8 +26,19 @@
     margin: 8px 4px;
     cursor: pointer;
 
-    .glyphicon();
-    .glyphicon-remove();
+      position: relative;
+      top: 1px;
+      display: inline-block;
+      font-family: "Glyphicons Halflings";
+      font-style: normal;
+      font-weight: 400;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+
+      &:before { 
+        content: "\e014"; 
+      }
   }
 
   .querystring-criteria-index {

--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -1,6 +1,4 @@
 @import '@{bowerPath}/bootstrap/less/variables.less'; // Modify this for custom colors, font-sizes, etc
-@icon-font-path: '@{bowerPath}/bootstrap/dist/fonts/';
-@import '@{bowerPath}/bootstrap/less/glyphicons.less';
 @import '@{mockuplessPath}/ui.less';
 
 @import (reference) '@{bowerPath}/bootstrap/less/mixins.less';

--- a/mockup/patterns/structure/less/pattern.structure.less
+++ b/mockup/patterns/structure/less/pattern.structure.less
@@ -1,6 +1,4 @@
 @import "@{bowerPath}/bootstrap/less/variables.less"; // Modify this for custom colors, font-sizes, etc
-@icon-font-path: "@{bowerPath}/bootstrap/dist/fonts/";
-@import "@{bowerPath}/bootstrap/less/glyphicons.less";
 @import "@{mockuplessPath}/ui.less";
 @import "@{mockupPath}/tooltip/pattern.tooltip.less";
 @import "@{mockupPath}/datatables/pattern.datatables.less";
@@ -315,7 +313,9 @@
             }
 
             a:before {
-                .glyphicon-remove-sign();
+                &:before { 
+                    content: "\e014"; 
+                }
                 color: #999;
 
                 &:hover {

--- a/news/1042.bugfix
+++ b/news/1042.bugfix
@@ -1,0 +1,2 @@
+Remove fonts from patterns to avoid multiple inline includes.
+[agitator]


### PR DESCRIPTION
Remove fonts from patterns to avoid multiple inline includes.

Glyphicons are removed as less-includes from patterns.
In Plone we add two more bundles to include the icons: https://github.com/plone/plone.staticresources/pull/131
In Mockup docs the bootstrap.less is included, so the demo patterns still have their icons: https://github.com/plone/mockup/blob/3.x/mockup/less/docs.less#L5