### PR TITLE
Change the regex to extract the widgets.pot file

### DIFF
--- a/mockup/Gruntfile.js
+++ b/mockup/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function (grunt) {
             }
             console.log("reading file: " + filepath);
             var file = fs.readFileSync(filepath, { encoding: "utf-8" });
-            var re = /_t\((("[^"]+")|('[^']+'))(,\W{.*})?\)?\)/g;
+            var re = /_t\(\n?\s*(("[^"]+")|('[^']+'))(,\W{\n.*\n.*})?\)?\n?\s*\)/g;
             var m = re.exec(file);
             while (m) {
                 if (m) {


### PR DESCRIPTION
We are changing the regex to catch multiline msgids like this one:


See the updated widgets.pot file here:
https://github.com/collective/plone.app.locales/pull/336/files#diff-7f16dfc1665a7f292e8b762726494c0c6c918470959fedb05c41affa247644f2L441