### PR TITLE
pat-tinymce: Add enable image zoom option

### DIFF
--- a/news/1130.feature
+++ b/news/1130.feature
@@ -1,0 +1,1 @@
+Add enable image zoom option to TinyMCE, which add's a zoomable class to an image. It can be used by add-on's or custom JavaScript to make the image zoomable. [MrTango]

--- a/src/pat/tinymce/js/links.js
+++ b/src/pat/tinymce/js/links.js
@@ -512,6 +512,7 @@ export default Base.extend({
             altText: this.options.text.alt,
             imageAlignText: this.options.text.imageAlign,
             captionFromDescriptionText: this.options.text.captionFromDescription,
+            enableImageZoom: this.options.text.enableImageZoom,
             captionText: this.options.text.caption,
             scaleText: this.options.text.scale,
             imageScales: this.options.imageScales,
@@ -534,6 +535,10 @@ export default Base.extend({
         self.$alt = $('input[name="alt"]', self.modal.$modal);
         self.$align = $('select[name="align"]', self.modal.$modal);
         self.$scale = $('select[name="scale"]', self.modal.$modal);
+        self.$enableImageZoom = $(
+            'input[name="enableImageZoom"]',
+            self.modal.$modal
+        );
         self.$captionFromDescription = $(
             'input[name="captionFromDescription"]',
             self.modal.$modal
@@ -641,6 +646,7 @@ export default Base.extend({
         var self = this;
         var title = self.$title.val();
         var captionFromDescription = self.$captionFromDescription.prop("checked");
+        var enableImageZoom = self.$enableImageZoom.prop("checked");
 
         self.tiny.focus();
         self.tiny.selection.setRng(self.rng);
@@ -648,6 +654,9 @@ export default Base.extend({
         var cssclasses = ["image-richtext", self.$align.val()];
         if (captionFromDescription) {
             cssclasses.push("captioned");
+        }
+        if (enableImageZoom) {
+            cssclasses.push("zoomable");
         }
 
         var data = $.extend(
@@ -872,6 +881,9 @@ export default Base.extend({
                 self.$title.val(self.dom.getAttrib(self.imgElm, "title"));
                 self.$alt.val(self.dom.getAttrib(self.imgElm, "alt"));
 
+                if ($(self.imgElm).hasClass("zoomable")) {
+                    self.$enableImageZoom.prop("checked", true);
+                }
                 if ($(self.imgElm).hasClass("captioned")) {
                     self.$captionFromDescription.prop("checked", true);
                     self.$caption.prop("disabled", true);

--- a/src/pat/tinymce/templates/image.xml
+++ b/src/pat/tinymce/templates/image.xml
@@ -80,6 +80,12 @@
           <% }); %>
         </select>
       </div>
+      <div class="enable-zoom mb-2">
+        <input type="checkbox" name="enableImageZoom" class="form-check-input" />
+        <label for="enableImageZoom" class="form-check-label">
+          <%- enableImageZoom %>
+        </label>
+      </div>
     </div>
 
     <input type="submit" class="btn btn-secondary plone-btn me-1" name="cancel" value="<%- cancelBtn %>" />

--- a/src/pat/tinymce/tinymce.js
+++ b/src/pat/tinymce/tinymce.js
@@ -53,6 +53,7 @@ export default Base.extend({
             subject: _t("Email Subject (optional)"),
             image: _t("Image"),
             imageAlign: _t("Align"),
+            enableImageZoom: _t("Enable image zoom"),
             scale: _t("Size"),
             alt: _t("Alternative Text"),
             insertImageHelp: _t(


### PR DESCRIPTION
This allows us to enable image zoom when inserting an image with TinyMCE. It will only add a CSS class zoomable, which can be used by addons or custom JavaScript to make the image zoomable.
![plone-image-enable-zoom](https://user-images.githubusercontent.com/1113628/158132832-9299041d-8e21-470d-a0d1-a0f4ab3d1b28.png)
