### PR TITLE
Expose patternslib registry.

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -76,3 +76,4 @@ validation_parser.parameters["error-template"].value =
     '<em class="invalid-feedback">${this.message}</em>';
 
 registry.init();
+window.__patternslib_registry = registry;


### PR DESCRIPTION
I would like to able to `re-scan` changed DOM from a 3rd party JS lib (depending on certain events). 
For thus purpose I think I have to expose the patternslib registry.

I'm not super familiar  with patternslib and mockup, so I don't know if this may expose something which should not?
I'm also happy for other suggestions on how to access the patternslib from Plone. As far I can see it's not possible right now.  

Background:
I'm working on a Plone 6 plugin and I'm currently using Plone 6.0.0a4