### PR TITLE
Register jQuery and Bootstrap globally - alternative approach

### DIFF
--- a/src/index-bootstrap.js
+++ b/src/index-bootstrap.js
@@ -1,2 +1,0 @@
-// Bundle entry for Bootstrap
-import "bootstrap";

--- a/src/index-jquery.js
+++ b/src/index-jquery.js
@@ -1,2 +1,0 @@
-// Bundle entry for jQuery
-import "@patternslib/patternslib/src/globals";

--- a/src/index.js
+++ b/src/index.js
@@ -20,3 +20,16 @@ import "@patternslib/patternslib/webpack/module_federation";
 
 // And now load this bundle's actual entry point.
 import("./patterns");
+
+// Register Bootstrap and jQuery gloablly
+async function register_global_libraries() {
+    // Register Bootstrap globally
+    const bootstrap = await import("bootstrap");
+    window.bootstrap = bootstrap;
+
+    // Register jQuery globally
+    const jquery = (await import("jquery")).default;
+    window.jQuery = jquery;
+    window.$ = jquery;
+}
+register_global_libraries();

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -3,7 +3,6 @@
  */
 
 // Core
-import "@patternslib/patternslib/src/globals";
 import registry from "@patternslib/patternslib/src/core/registry";
 
 // Patternslib patterns

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ module.exports = (env, argv) => {
         entry: {
             "bundle.min": path.resolve(__dirname, "src/index.js"),
             "bootstrap.min": path.resolve(__dirname, "src/index-bootstrap.js"),
-            "jquery.min": path.resolve(__dirname, "src/index-jquery.js"),
         },
     };
 
@@ -48,16 +47,6 @@ module.exports = (env, argv) => {
             remote_entry: config.entry["bootstrap.min"],
             dependencies: {
                 bootstrap: package_json.dependencies["bootstrap"],
-            },
-        })
-    );
-    config.plugins.push(
-        mf_config({
-            name: "jquery",
-            filename: "jquery-remote.min.js",
-            remote_entry: config.entry["jquery.min"],
-            dependencies: {
-                jquery: package_json.dependencies["jquery"],
             },
         })
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,18 @@ module.exports = (env, argv) => {
                 ...patternslib_package_json.dependencies,
                 ...package_json.dependencies,
             },
+            shared: {
+                bootstrap: {
+                    singleton: true,
+                    requiredVersion: package_json.dependencies["bootstrap"],
+                    eager: true,
+                },
+                jquery: {
+                    singleton: true,
+                    requiredVersion: package_json.dependencies["jquery"],
+                    eager: true,
+                },
+            },
         })
     );
     config.plugins.push(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,6 @@ module.exports = (env, argv) => {
     let config = {
         entry: {
             "bundle.min": path.resolve(__dirname, "src/index.js"),
-            "bootstrap.min": path.resolve(__dirname, "src/index-bootstrap.js"),
         },
     };
 
@@ -37,16 +36,6 @@ module.exports = (env, argv) => {
                     requiredVersion: package_json.dependencies["jquery"],
                     eager: true,
                 },
-            },
-        })
-    );
-    config.plugins.push(
-        mf_config({
-            name: "bootstrap",
-            filename: "bootstrap-remote.min.js",
-            remote_entry: config.entry["bootstrap.min"],
-            dependencies: {
-                bootstrap: package_json.dependencies["bootstrap"],
             },
         })
     );


### PR DESCRIPTION
Here I register jQuery and Bootstrap globally directly in the main bundle - making the jquery and bootstrap bundles obsolete.

jquery and bootstrap are available before DOMContentLoaded.

This increases the initial bundle size significantly:‌ from 93k to 269k.

Some thoughts:
- We could split out Bootstrap into a own bundle without module federation and provide it optionally (but we're using some bootstrap js in mockup already, so there will be some code duplication).
- We could provide two alternative main bundles - one with the global registrations and one without. Integrators can then choose which one they use.
- We don't care about the bundle size - < 300k are not that awful much in the end...
- For customized sites we can always build our own bundle, optimize it for size and not use the default Plone bundle.

If we go with this approach we need to remove the bootstrap and jquery bundles from plone.staticresources too and provide an upgrade step.

Any thoughts @petschki @MrTango @agitator ?

Fixes: https://github.com/plone/mockup/issues/1175