### PR TITLE
Fix `linkType` mismatch in link/image modal

### DIFF
--- a/src/pat/tinymce/js/links.js
+++ b/src/pat/tinymce/js/links.js
@@ -884,7 +884,7 @@ export default Base.extend({
             }
 
             linkType = self.dom.getAttrib(self.imgElm, "data-linktype");
-            if (linkType) {
+            if (linkType && (linkType in self.linkTypes)) {
                 self.linkType = linkType;
                 self.linkTypes[self.linkType].load(self.imgElm);
                 // set scale selection in link modal:


### PR DESCRIPTION
Came accross this in robot tests: When opening the "insert image" modal while an "internal link" is selected, the modal gets stuck ... checking if the linkType of the current selected dom matches the modal linkTypes fixes that.

see https://jenkins.plone.org/job/pull-request-6.0-3.8/1628/testReport/Products.CMFPlone.tests.test_robot/RobotTestCase/Scenario_A_page_is_opened_to_edit_in_TinyMCE/
