### PR TITLE
Do not close modal if querystring criteria is removed

### DIFF
--- a/src/pat/querystring/querystring.js
+++ b/src/pat/querystring/querystring.js
@@ -74,6 +74,7 @@ Criteria.prototype = {
             .addClass(self.options.classRemoveName)
             .appendTo(self.$wrapper)
             .on("click", function (e) {
+                e.stopPropagation();
                 self.remove();
             });
 


### PR DESCRIPTION
fixes #1179 