### PR TITLE
fix(pat-tinymce): set the language in tiny options

### DIFF
--- a/src/pat/tinymce/tinymce.js
+++ b/src/pat/tinymce/tinymce.js
@@ -1,4 +1,5 @@
 import Base from "@patternslib/patternslib/src/core/base";
+import I18n from "../../core/i18n";
 import _t from "../../core/i18n-wrapper";
 
 export default Base.extend({
@@ -163,11 +164,15 @@ export default Base.extend({
                 "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | unlink plonelink ploneimage",
             //'autoresize_max_height': 900,
             height: 400,
+            language: "en",
         },
         inline: false,
     },
     init: async function () {
         const implementation = (await import("./tinymce--implementation")).default;
+        var i18n = new I18n();
+        var lang = i18n.currentLanguage;
+        this.options.tiny.language = lang;
         this.instance = new implementation(this.el, this.options);
         this.instance.init();
     },


### PR DESCRIPTION
After some debugging I have noticed that although the correct language js was being loaded, we need to explicitly set the language we are using in tiny options.

This way the correct language js is applied and the editing interface shows translated. See:

German
![Pantaila-argazkia 2022-08-26 14-59-51](https://user-images.githubusercontent.com/817365/186909244-bfd1ea52-8ef9-4a70-8736-e40a37b6c81a.png)

Spanish 
![Pantaila-argazkia 2022-08-26 15-00-44](https://user-images.githubusercontent.com/817365/186909214-32597f0d-515d-4a77-906f-1de1750c5e60.png)

Basque
![Pantaila-argazkia 2022-08-26 15-00-22](https://user-images.githubusercontent.com/817365/186909229-5397c06e-e05b-411a-a7b3-861317d853dc.png)


Fixes #1209 and https://github.com/plone/Products.CMFPlone/issues/3619