### PR TITLE
fix(pat-select2): load language files

### DIFF
--- a/src/pat/select2/select2.js
+++ b/src/pat/select2/select2.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import Base from "@patternslib/patternslib/src/core/base";
+import I18n from "../../core/i18n";
 import utils from "../../core/utils";
 
 export default Base.extend({
@@ -103,6 +104,11 @@ export default Base.extend({
         import("select2/select2.css");
         import("./select2.scss");
         await import("select2");
+        try {
+            await import(`select2/select2_locale_${this.options.language}`);
+        } catch {
+            console.warn("Language file could not be loaded", this.options.language);
+        }
 
         var self = this;
         self.options.formatResultCssClass = function (ob) {
@@ -127,7 +133,6 @@ export default Base.extend({
                 return action;
             }
         }
-
         $(self.el).select2(self.options);
         self.$el.on("select2-selected", function (e) {
             callback(self.options.onSelected, e);
@@ -155,6 +160,8 @@ export default Base.extend({
     init: async function () {
         var self = this;
 
+        var i18n = new I18n();
+        self.options.language = i18n.currentLanguage;
         self.options.allowNewItems = self.options.hasOwnProperty("allowNewItems")
             ? JSON.parse(self.options.allowNewItems)
             : true;


### PR DESCRIPTION
Fixes #994. Similar to #1211 we need to explicitly set the language and load the language js file

Basque:
![Pantaila-argazkia 2022-08-26 15-30-02](https://user-images.githubusercontent.com/817365/186914827-7c22a35a-c331-4277-bdf8-66b88c2016df.png)


German
![Pantaila-argazkia 2022-08-26 15-28-53](https://user-images.githubusercontent.com/817365/186914858-a24f4c6b-339d-460a-969d-64ce57458bbb.png)


Spanish:
![Pantaila-argazkia 2022-08-26 15-29-42](https://user-images.githubusercontent.com/817365/186914851-4e4522ea-18f1-47e4-818c-2d806d996e08.png)


