### PR TITLE
fix(pat-select2): initialize sorting, fixes issue 1205.

### DIFF
--- a/src/pat/select2/select2.js
+++ b/src/pat/select2/select2.js
@@ -150,6 +150,7 @@ export default Base.extend({
         self.$el.parent().off("close.plone-modal.patterns");
         if (self.options.orderable) {
             self.$select2.addClass("select2-orderable");
+            self.$el.change();
         }
     },
     opened: function () {


### PR DESCRIPTION
This fixes https://github.com/plone/mockup/issues/1205, that related items are not sortable on edit.

This is probably not the cleanest fix, but it is only one line and gets the job done, so perhaps it is okay. If someone knows a cleaner way, I am happy to hear it.

Let me try to explain why this works:

- At the [end of the init function](https://github.com/plone/mockup/blob/5.0.0-alpha.21/src/pat/select2/select2.js#L240-L241) we first call `self.initializeOrdering()` and then `await self.initializeSelect2()`.
- `initializeOrdering` sets up an [on change event handler](https://github.com/plone/mockup/blob/000884f123b3f0e09040960010be07ef8d21f657/src/pat/select2/select2.js#L87) that uses `select2`.
- So at the end of `initializeSelect2`, I trigger a change event on the main element, and this calls the event handler, making sure the selected items can be ordered.

Cleaner would probably be to move the code from the event handler into a separate method, and call this function on change and at the end of `initializeSelect2`. But when I tried this, javascript complained that my function did not exist. Probably some misunderstanding on my end.