### PR TITLE
Fix select2/relateditems sorting issue

### DIFF
--- a/src/pat/relateditems/relateditems.js
+++ b/src/pat/relateditems/relateditems.js
@@ -98,7 +98,7 @@ export default Base.extend({
             template = $(self.options[tpl + "TemplateSelector"]).html();
         }
         if (!template) {
-            if(self.options[tpl + "Template"]) {
+            if (self.options[tpl + "Template"]) {
                 template = self.options[tpl + "Template"];
             } else {
                 template = self[tpl + "Template"];
@@ -566,8 +566,6 @@ export default Base.extend({
             return $selection;
         };
 
-        Select2.prototype.initializeOrdering.call(self);
-
         const icon_level_up = await utils.resolveIcon("arrow-left-circle");
         const icon_level_down = await utils.resolveIcon("arrow-right-circle");
 
@@ -687,7 +685,8 @@ export default Base.extend({
             return item.UID;
         };
 
-        Select2.prototype.initializeSelect2.call(self);
+        await Select2.prototype.initializeSelect2.call(self);
+        await Select2.prototype.initializeOrdering.call(self);
 
         self.$toolbar = $('<div class="toolbar d-flex" />');
         self.$container.prepend(self.$toolbar);

--- a/src/pat/select2/select2.js
+++ b/src/pat/select2/select2.js
@@ -80,17 +80,13 @@ export default Base.extend({
             delete self.options.tags;
         }
     },
-    initializeOrdering: function () {
+    initializeOrdering: async function () {
         if (!this.options.orderable) {
             return;
         }
-        // TODO: fix sorting!
-        this.$el.on("change", async () => {
-            let Sortable = await import("sortablejs");
-            Sortable = Sortable.default;
-
+        const Sortable = (await import("sortablejs")).default;
+        const _initializeOrdering = () => {
             const sortable_el = this.$select2[0].querySelector(".select2-choices");
-
             new Sortable(sortable_el, {
                 draggable: "li",
                 dragClass: "select2-choice-dragging",
@@ -98,7 +94,9 @@ export default Base.extend({
                 onStart: () => this.$el.select2("onSortStart"),
                 onEnd: () => this.$el.select2("onSortEnd"),
             });
-        });
+        };
+        this.$el.on("change", _initializeOrdering.bind(this));
+        _initializeOrdering();
     },
     initializeSelect2: async function () {
         import("select2/select2.css");
@@ -244,7 +242,7 @@ export default Base.extend({
 
         self.initializeValues();
         self.initializeTags();
-        self.initializeOrdering();
         await self.initializeSelect2();
+        await self.initializeOrdering();
     },
 });


### PR DESCRIPTION
Alternative approach to: https://github.com/plone/mockup/pull/1214
Fixes: https://github.com/plone/mockup/issues/1205

@mauritsvanrees based on your analysis I built an alternative, more appropriate approach to the sorting issue.
``initializeOrdering`` is called after ``initializeSelect2`` and also initializes existing items without a ``change`` event.
I added you as co-author.

@mauritsvanrees Please review, test and eventually approve.