### PR TITLE
fix(pat relateditems): call .stopPropagation on events for breadcrumbs links

### DIFF
--- a/src/pat/relateditems/relateditems.js
+++ b/src/pat/relateditems/relateditems.js
@@ -340,11 +340,13 @@ export default Base.extend({
 
         $("a.crumb", self.$toolbar).on("click", function (e) {
             e.preventDefault();
+            e.stopPropagation();
             self.browseTo($(this).attr("href"));
         });
 
         $("a.fav", self.$toolbar).on("click", function (e) {
             e.preventDefault();
+            e.stopPropagation();
             self.browseTo($(this).attr("href"));
         });
 


### PR DESCRIPTION
This fixes https://github.com/plone/mockup/issues/1221