### PR TITLE
Fix editing weekly weekdays

### DIFF
--- a/src/pat/recurrence/recurrence.js
+++ b/src/pat/recurrence/recurrence.js
@@ -355,7 +355,6 @@ function cleanDates(dates) {
 function parseIcal(icaldata) {
     var lines = [];
     var result = {};
-    var propAndValue = [];
     var line = null;
     var nextline;
 
@@ -395,9 +394,9 @@ function parseIcal(icaldata) {
 function widgetLoadFromRfc5545(form, conf, icaldata, force) {
     var unsupportedFeatures = [];
     var i, matches, match, matchIndex, rtemplate, d, input, index;
-    var selector, selectors, field, radiobutton, start, end;
+    var selectors, field, radiobutton;
     var interval, byday, bymonth, bymonthday, count, until;
-    var day, month, year, weekday, ical;
+    var day, month, year, weekday;
 
     form.ical = parseIcal(icaldata);
     if (form.ical.RRULE === undefined) {
@@ -658,7 +657,7 @@ const RecurrenceInput = function (conf, textarea) {
     // Extend conf with non-configurable data used by templates.
     var orderedWeekdays = [];
     var now_date = new Date().toISOString().substring(0, 10);
-    var index, i;
+    var index;
 
     for (let i = 0; i < 7; i++) {
         index = i + conf.firstDay;

--- a/src/pat/recurrence/templates/form.xml
+++ b/src/pat/recurrence/templates/form.xml
@@ -44,7 +44,7 @@
             <div id="riweeklyweekdays" class="rifield row">
                 <label class="col-4 col-form-label" for="<%= name %>weeklyinterval"><%= localization.weeklyWeekdays %></label>
                 <div class="col-8">
-                    <div class="row">
+                    <div class="row flex-nowrap">
                     <% orderedWeekdays.forEach(function(weekday, idx) { %>
                         <div class="riweeklyweekday col-auto">
                             <div class="form-check">
@@ -52,7 +52,7 @@
                                     name="riweeklyweekdays<%=weekday %>"
                                     id="<%= name %>weeklyWeekdays<%=weekday %>"
                                     value="<%=weekday %>" />
-                                <label class="form-check-label" for="<%= name %>weeklyWeekdays<%= weekday %>"><%= localization.shortWeekdays[idx] %></label>
+                                <label class="form-check-label" for="<%= name %>weeklyWeekdays<%= weekday %>"><%= localization.shortWeekdays[weekday] %></label>
                             </div>
                         </div>
                     <% }) %>
@@ -285,11 +285,6 @@
         <div class="rioccurrencesactions">
             <div class="rioccurancesheader d-flex justify-content-between">
                 <h6><strong><%= localization.preview %></strong></h6>
-                <span class="refreshbutton action">
-                    <a class="btn btn-sm btn-outline-secondary rirefreshbutton" href="#" title="<%= localization.refresh %>">
-                        <%= icons.reload %>
-                    </a>
-                </span>
             </div>
         </div>
 


### PR DESCRIPTION
Editing weekly weekdays was broken due to array index/value mismatch in input name.

This also fixes reloading occurrence when changeing the weekdays checkboxes.