### PR TITLE
toggle d-none instead of using the style attribute to show/hide the results

### DIFF
--- a/src/pat/livesearch/livesearch.js
+++ b/src/pat/livesearch/livesearch.js
@@ -214,12 +214,12 @@ export default Base.extend({
          input box, same width */
         var self = this;
 
-        self.$el.addClass("livesearch-active");
-        self.$results.show();
+        self.$results[0].classList.remove('d-none');
+        self.$el[0].classList.add('livesearch-active');
     },
     hide: function () {
-        this.$results.hide();
-        this.$el.removeClass("livesearch-active");
+        this.$el[0].classList.remove("livesearch-active");
+        this.$results[0].classList.add('d-none');
     },
     init: function () {
         // import("./livesearch.scss");
@@ -320,7 +320,6 @@ export default Base.extend({
 
         /* create result dom */
         self.$results = $('<ul class="' + self.resultsClass + '"></ul>')
-            .hide()
             .insertAfter(self.$el);
     },
 });


### PR DESCRIPTION
This commit remove `d-none` from resultsClass. After the setting `$enable-important-utilities:  false !default;` has been added to barceloneta scss, the d-none class can be overridden by the style attribute value `display: none`. For themes not using `!important` like default bootstrap, this doesn't works. Here, pat-livesearch starts with d-none and apply at init the style attribute value `display: none`.  This means that this works only with  `$enable-important-utilities:  false !default;` . Removing d-none from the list of class, make using display: block (to show the results) work in both cases. `d-none` here is useless anyway because the pattern hides the block in the init function. I've tested it with barceloneta theme (`$enable-important-utilities:  false !default;` ) and a custom theme that not does this, and removing `d-none` works as expected.