### PR TITLE
Fix close selector for default cancel buttons

### DIFF
--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -472,16 +472,18 @@ export default Base.extend({
             self.emit("before-events-setup");
 
             // Wire up events
-            $(
-                ".modal-header > .modal-close, .modal-footer > .pattern-modal-buttons > .modal-close",
-                self.$modal
-            )
-                .off("click")
-                .on("click", function (e) {
+            self.$modal[0].querySelectorAll(
+                `.modal-header > .modal-close,
+                 .modal-footer > .pattern-modal-buttons > .modal-close,
+                 .modal-footer [name="form.buttons.Cancel" i]`
+            ).forEach((el) => {
+                $(el).off("click").on("click", (e) => {
                     e.stopPropagation();
                     e.preventDefault();
                     $(e.target).trigger("destroy.plone-modal.patterns");
                 });
+            });
+
 
             // form
             if (options.form) {


### PR DESCRIPTION
Nice case-insensitive CSS selector: https://caniuse.com/css-case-insensitive ... though works only with ES6 `querySelectorAll` and not jQuery.