### PR TITLE
maint(pat tinymce): Cleanup old code no longer needed. closes gh-1198

### DIFF
--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -279,22 +279,6 @@ export default class TinyMCE {
             }
         }
 
-        /* If TinyMCE is rendered inside of a modal, set an ID on
-            * .plone-modal-dialog and use that as the ui_container
-            * setting for TinyMCE to anchor it there. This ensures that
-            * sub-menus are displayed relative to the modal rather than
-            * the document body.
-            * Generate a random id and append it, because there might be
-            * more than one TinyMCE in the DOM.
-            */
-        var modal_container = self.$el.parents(".plone-modal-dialog");
-
-        if (modal_container.length > 0) {
-            var random_id = Math.random().toString(36).substring(2, 15);
-            modal_container.attr("id", "tiny-ui-container-" + random_id);
-            tinyOptions["ui_container"] = "#tiny-ui-container-" + random_id;
-        }
-
         tinymce.init(tinyOptions);
         self.tiny = tinymce.get(self.tinyId);
 


### PR DESCRIPTION
@petschki I have verified, by creating a Mosaic tile with 2 RichText fields, with an edit view, instead of inline rendering.
I can confirm that `self.$el.parents(".plone-modal-dialog");` is always length 0, so that code is no longer used.

Both tinymce work fine

I created this test product, and included it in buildout.coredev along with mosaic to test https://github.com/frapell/mosaic.tiles