### PR TITLE
Fix recurrencewidget to initialize saved value correctly and fix RDATE and EXDATE editing

### DIFF
--- a/src/pat/recurrence/templates/form.xml
+++ b/src/pat/recurrence/templates/form.xml
@@ -44,7 +44,7 @@
             <div id="riweeklyweekdays" class="rifield row">
                 <label class="col-4 col-form-label" for="<%= name %>weeklyinterval"><%= localization.weeklyWeekdays %></label>
                 <div class="col-8">
-                    <div class="row flex-nowrap">
+                    <div class="row">
                     <% orderedWeekdays.forEach(function(weekday, idx) { %>
                         <div class="riweeklyweekday col-auto">
                             <div class="form-check">


### PR DESCRIPTION
fixes #1266 

This is also partly a code cleanup of the old jquery-recurrencewidget approach. The main fix is to save the parsed `RRULE` object to the `textarea['ical']` attribute instead of the jquery form ... this gives us a sane state during editing the recurrence widget multiple times.