### PR TITLE
fix(pat-select2): Do not replace multi select fields for pat-querystring.

### DIFF
--- a/src/pat/relateditems/relateditems.js
+++ b/src/pat/relateditems/relateditems.js
@@ -513,7 +513,6 @@ export default Base.extend({
         this.selectionTemplate = (await import("./templates/selection.xml")).default; // prettier-ignore
         this.toolbarTemplate = (await import("./templates/toolbar.xml")).default; // prettier-ignore
 
-        this.$select2_el = this.$el;
         this.browsing = this.options.mode !== "search";
 
         // Remove trailing slash

--- a/src/pat/select2/select2.test.js
+++ b/src/pat/select2/select2.test.js
@@ -312,7 +312,7 @@ describe("Select2", function () {
         document.body.innerHTML = `
           <div>
             <select multiple class="pat-select2" id="test-select2" name="test-name"
-                    data-pat-select2="{&quot;orderable&quot;: true, &quot;separator&quot;: &quot;;&quot;}">
+                    data-pat-select2="{&quot;orderable&quot;: true, &quot;multiple&quot;: true, &quot;separator&quot;: &quot;;&quot;}">
               <option value="1" selected>One</value>
               <option value="2">Two</value>
               <option value="3" selected>Three</value>


### PR DESCRIPTION
A select[multiple] field without the multiple pattern option set is no longer replaced with a input[type=hidden].
This fixes a problem in pat-querystring where switching from one criteria to another duplicated the Select2 fields. Select2 deals just fine with select[multiple] fields. The replacement part should be evaluated for validity and eventually removed for a future Mockup release.