### PR TITLE
fix(pat structure): do not add charset to x-www-form-urlencoded header [5.0.x]

### DIFF
--- a/src/pat/structure/js/actions.js
+++ b/src/pat/structure/js/actions.js
@@ -68,7 +68,7 @@ export default Backbone.Model.extend({
         const url = new URL(this.app.buttons.get(buttonName).options.url);
         const resp = await fetch(url, {
             headers: {
-                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "Content-Type": "application/x-www-form-urlencoded",
             },
             method: "POST",
             body: new URLSearchParams({
@@ -127,7 +127,7 @@ export default Backbone.Model.extend({
             const url = new URL(this.app.getAjaxUrl(this.app.setDefaultPageUrl));
             const resp = await fetch(url, {
                 headers: {
-                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                    "Content-Type": "application/x-www-form-urlencoded",
                 },
                 method: "POST",
                 body: new URLSearchParams({


### PR DESCRIPTION
Adding a charset to this Content-Type is illegal according to the definition, and fails with Zope master.

See https://github.com/plone/buildout.coredev/pull/844#issuecomment-1461620409
In that PR, several things in the folder contents are broken.  I talk about reordering that fails, but that is still broken with this mockup PR.  I don't know where the `x-www-form-urlencoded` is set for that part.

What the current PR *does* fix, is the cut, copy, etcetera actions in the folder contents table, at the end of an item.
The similar actions *above* the table already work without any changes, they do not have this problem.