### PR TITLE
WIP: Refactor patterns so all logic goes outside the templates

### DIFF
--- a/src/pat/relateditems/templates/recentlyused.xml
+++ b/src/pat/relateditems/templates/recentlyused.xml
@@ -1,15 +1,7 @@
 <li class="pat-relateditems-recentlyused dropdown-item">
   <a class="pat-relateditems-recentlyused-select" data-uid="<%- UID %>">
-    <span
-      class="pat-relateditems-recentlyused-title <%- portal_type ? 'contenttype-' + portal_type.toLowerCase() : '' %> <%- review_state ? 'state-' + review_state : '' %>"
-      title="<%- portal_type %>">
-      <%- Title %>
-    </span>
+    <span class="<%- itemclass %>" title="<%- portal_type %>"><%- Title %></span>
     <span class="pat-relateditems-recentlyused-path"><%- path %></span>
-    <% if (getURL && (getIcon || portal_type === "Image")) { %>
-      <span class="pat-relateditems-recentlyused-image">
-        <img src="<%- getURL %>/@@images/image/tile" />
-      </span>
-    <% } %>
+    <span class="pat-relateditems-recentlyused-image"><%= imgsrc %></span>
   </a>
 </li>

--- a/src/pat/relateditems/templates/result.xml
+++ b/src/pat/relateditems/templates/result.xml
@@ -1,41 +1,18 @@
-<div class="pat-relateditems-result <%- oneLevelUp ? 'one-level-up' : '' %>">
+<div class="<%- div_class %>">
   <div class="pat-relateditems-result-browse-wrapper">
-  <% if (!oneLevelUp) { %>
-    <a
-      class="pat-relateditems-result-select<%- selectable ? ' selectable' : '' %><%- oneLevelUp ? ' one-level-up' : '' %>"
-      data-path="<%- path %>">
-  <% } %>
+    <%= not_one_level_up_open_a %>
+
       <div class="pat-relateditems-result-info">
         <span
-          class="pat-relateditems-result-title <%- portal_type ? 'contenttype-' + portal_type.toLowerCase() : '' %> <%- review_state ? 'state-' + review_state : '' %>"
+          class="<%- span_title_class %>"
           title="<%- portal_type %>">
           <%- Title %>
         </span>
-        <span class="pat-relateditems-result-path"><%- oneLevelUp ? currentPath : path %></span>
+        <span class="pat-relateditems-result-path"><%- result_path %></span>
       </div>
-      <% if (is_folderish) { %>
-        <a
-          class="pat-relateditems-result-browse"
-          data-path="<%- path %>"
-          title="<%- oneLevelUp ? one_level_up : open_folder %>">
-          <%= oneLevelUp ? iconLevelUp : iconLevelDown %>
-        </a>
-      <% } %>
-  <% if (!oneLevelUp) { %>
-    </a>
-  <% } %>
+      <%= browse_folder_a %>
+    <%= not_one_level_up_close_a %>
+
   </div>
-  <% if (getURL && (getIcon || portal_type === "Image")) { %>
-    <% if (!oneLevelUp) { %>
-    <a
-      class="pat-relateditems-result-select<%- selectable ? ' selectable' : '' %><%- oneLevelUp ? ' one-level-up' : '' %>"
-      data-path="<%- path %>">
-    <% } %>
-    <div class="pat-relateditems-result-image">
-      <img src="<%- getURL %>/@@images/image/thumb" />
-    </div>
-    <% if (!oneLevelUp) { %>
-    </a>
-    <% } %>
-  <% } %>
+  <%= append_if_image %>
 </div>

--- a/src/pat/relateditems/templates/selection.xml
+++ b/src/pat/relateditems/templates/selection.xml
@@ -7,9 +7,5 @@
     </span>
     <span class="pat-relateditems-item-path"><%- path %></span>
   </div>
-  <% if (getURL && (getIcon || portal_type === "Image")) { %>
-    <div class="pat-relateditems-item-image">
-      <img src="<%- getURL %>/@@images/image/thumb" />
-    </div>
-  <% } %>
+  <%= imgsrc %>
 </div>

--- a/src/pat/relateditems/templates/toolbar.xml
+++ b/src/pat/relateditems/templates/toolbar.xml
@@ -1,50 +1,5 @@
-<% if (mode!=='auto') { %>
-<div class="btn-group mode-selector" role="group">
-  <button type="button" class="mode search btn <% if (mode=='search') { %>btn-primary<% } else {%>btn-default<% } %>"><%- searchModeText %></button>
-  <button type="button" class="mode browse btn <% if (mode=='browse') { %>btn-primary<% } else {%>btn-default<% } %>"><%- browseModeText %></button>
-</div>
-<% } %>
 <div class="path-wrapper flex-grow-1">
   <span class="pat-relateditems-path-label"><%- searchText %></span>
   <a class="crumb" href="/"><%= icon_root %></a>
   <%= items %>
 </div>
-
-<% if (recentlyUsedItems) { %>
-<div class="recentlyUsed dropdown ms-2">
-  <button type="button" class="recentlyUsed dropdown-toggle btn btn-primary btn-sm" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <%= icon_recently_used %>
-    <%- recentlyUsedText %>
-    <span class="caret"/>
-  </button>
-  <ul class="dropdown-menu dropdown-menu-end">
-    <%= recentlyUsedItems %>
-  </ul>
-</div>
-<% } %>
-
-<% if (favorites.length > 0) { %>
-<div class="favorites dropdown dropdown-menu-end ms-2">
-  <button type="button" class="favorites dropdown-toggle btn btn-primary btn-sm" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <%= icon_favorites %>
-    <%- favText %>
-    <span class="caret"/>
-  </button>
-  <ul class="dropdown-menu">
-    <%= favItems %>
-  </ul>
-</div>
-<% } %>
-
-<% if (upload) { %>
-<div class="upload dropdown dropdown-menu-end ms-2">
-  <button type="button" class="upload dropdown-toggle btn btn-primary btn-sm" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <%= icon_upload %>
-    <%- upload_text %>
-    <span class="caret"/>
-  </button>
-  <ul class="dropdown-menu">
-    <div class="pat-upload"></div>
-  </ul>
-</div>
-<% } %>

--- a/src/pat/relateditems/templates/toolbar_favorites.xml
+++ b/src/pat/relateditems/templates/toolbar_favorites.xml
@@ -1,0 +1,10 @@
+<div class="favorites dropdown dropdown-menu-end ms-2">
+  <button type="button" class="favorites dropdown-toggle btn btn-primary btn-sm" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= icon_favorites %>
+    <%- favText %>
+    <span class="caret"/>
+  </button>
+  <ul class="dropdown-menu">
+    <%= favItems %>
+  </ul>
+</div>

--- a/src/pat/relateditems/templates/toolbar_not_auto.xml
+++ b/src/pat/relateditems/templates/toolbar_not_auto.xml
@@ -1,0 +1,4 @@
+<div class="btn-group mode-selector" role="group">
+  <button type="button" class="mode search btn <%- searchModeClass %>"><%- searchModeText %></button>
+  <button type="button" class="mode browse btn <%- browseModeClass %>"><%- browseModeText %></button>
+</div>

--- a/src/pat/relateditems/templates/toolbar_recently_used.xml
+++ b/src/pat/relateditems/templates/toolbar_recently_used.xml
@@ -1,0 +1,10 @@
+<div class="recentlyUsed dropdown ms-2">
+  <button type="button" class="recentlyUsed dropdown-toggle btn btn-primary btn-sm" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= icon_recently_used %>
+    <%- recentlyUsedText %>
+    <span class="caret"/>
+  </button>
+  <ul class="dropdown-menu dropdown-menu-end">
+    <%= recentlyUsedItems %>
+  </ul>
+</div>

--- a/src/pat/relateditems/templates/toolbar_upload.xml
+++ b/src/pat/relateditems/templates/toolbar_upload.xml
@@ -1,0 +1,10 @@
+<div class="upload dropdown dropdown-menu-end ms-2">
+  <button type="button" class="upload dropdown-toggle btn btn-primary btn-sm" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= icon_upload %>
+    <%- upload_text %>
+    <span class="caret"/>
+  </button>
+  <ul class="dropdown-menu">
+    <div class="pat-upload"></div>
+  </ul>
+</div>


### PR DESCRIPTION
This PR is a work in progress for gh-1306

The base idea is that `.template()` from `underscore` needs to be replaced, and so all logic from the templates need to be stripped out.

Patterns that need to be refactored:

- [ ] relateditems
- [ ] contentloader
- [ ] tinymce's link plugin
- [ ] livesearch
- [ ] upload
- [ ] recurrence
- [ ] structure
- [ ] modal

When templates do not have logic in them, it should be enough to simply replace `_.template()` with `utils.template()` and that's it, but if the template does have logic, or any JS evaluation, then it needs some refactoring