### PR TITLE
Fix TinyMCE external url handling

### DIFF
--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -278,6 +278,20 @@ export default class TinyMCE {
             }
         }
 
+        // add "urlconverter_callback" to leave external URLs/Images as is
+        tinyOptions["urlconverter_callback"] = (url, node, on_save, name) => {
+            if (url.indexOf("http") === 0) {
+                // if url starts with "http" return it as is
+                return url;
+            }
+            // otherwise default tiny behavior
+            if (self.tiny.settings.relative_urls) {
+                return self.tiny.documentBaseURI.toRelative(url);
+            }
+            url = self.tiny.documentBaseURI.toAbsolute(url, self.tiny.settings.remove_script_host);
+            return url;
+        }
+
         tinymce.init(tinyOptions);
         self.tiny = tinymce.get(self.tinyId);
 


### PR DESCRIPTION
Fixes #1116 

Add `urlconverter_callback` and skip converting external urls.

IMPLEMENTATION NOTES:
This is a quick and rough solution which checks if inserted url starts with "http" ... it would be more solid if we query the inserted element and check for the `dataset.linktype` value, but right now I have no clue, how to get the element in the callback.