### PR TITLE
Fix tinymce link/image modal with current selection

### DIFF
--- a/src/pat/relateditems/relateditems.js
+++ b/src/pat/relateditems/relateditems.js
@@ -458,9 +458,9 @@ export default Base.extend({
 
     selectItem(item) {
         this.emit("selecting");
-        const data = this.$el.select2("data");
+        const data = $(this.el).select2("data");
         data.push(item);
-        this.$el.select2("data", data, true);
+        $(this.el).select2("data", data, true);
 
         if (this.options.recentlyUsed) {
             // add to recently added items


### PR DESCRIPTION
fixes #1319 

NOTE: absolutely no clue why this makes a difference `this.$el` and `$(this.el)` but I changed it back like it was before and it works again. See commit https://github.com/plone/mockup/commit/d8f2daa9f45b6805dd9f35e791437e04bce47267#diff-0372046d8d03fc963bb3d1bedcb015a6eebdcd9cd11cfaf9d604690ba2319434L461-R458 