### PR TITLE
Fix sticky position of `pat-structure` toolbar when edit toolbar is on top

### DIFF
--- a/src/pat/structure/structure.scss
+++ b/src/pat/structure/structure.scss
@@ -390,3 +390,7 @@
         }
     }
 }
+
+body.plone-toolbar-top .pat-structure .navbar {
+    top:var(--plone-toolbar-top-height);
+}


### PR DESCRIPTION
fixes #1335 