### PR TITLE
TinyMCE 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "js-cookie": "^3.0.5",
         "select2": "git+https://github.com/ivaynberg/select2.git#3.5.4",
         "sortablejs": "^1.15.2",
-        "tinymce": "6.8.3",
-        "tinymce-i18n": "24.1.29",
+        "tinymce": "^7.0.1",
+        "tinymce-i18n": "24.3.11",
         "underscore": "^1.13.6"
     },
     "devDependencies": {

--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -197,6 +197,8 @@ export default class TinyMCE {
         tinyOptions.skin = false;
         // do not show the "upgrade" button for plugins
         tinyOptions.promotion = false;
+        // TinyMCE 7 needs "license_key": "gpl" explicitly
+        tinyOptions.license_key = "gpl";
 
         tinyOptions.init_instance_callback = function (editor) {
             if (self.tiny === undefined || self.tiny === null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9664,15 +9664,15 @@ timezone-mock@^1.3.6:
   resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.3.6.tgz#44e4c5aeb57e6c07ae630a05c528fc4d9aab86f4"
   integrity sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==
 
-tinymce-i18n@24.1.29:
-  version "24.1.29"
-  resolved "https://registry.yarnpkg.com/tinymce-i18n/-/tinymce-i18n-24.1.29.tgz#aaf8fa7ab15d8c1c631d51454d072e53264b3c00"
-  integrity sha512-njcQUZ4UXl+IiZMpeXoIr6UEUkKCqHNQFjDgmwjxUbr3uMNff6k71hdBWGcIzIPOTvJoPSBr6wQPkWqjoMRkEg==
+tinymce-i18n@24.3.11:
+  version "24.3.11"
+  resolved "https://registry.yarnpkg.com/tinymce-i18n/-/tinymce-i18n-24.3.11.tgz#499c1c9118dc3d79f294182c0de9da8123c1c7ce"
+  integrity sha512-FH2TSbFwGi2sBejiwT5j+YPlCZ/UDtiWlh/IhcjfExEnYq10eZthTe8n1upk4zl6ICNOr9d37RHkAysM5d8ceg==
 
-tinymce@6.8.3:
-  version "6.8.3"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-6.8.3.tgz#0025a4aaa4c24dc2a3e32e83dfda705d196fd802"
-  integrity sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ==
+tinymce@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.0.1.tgz#743f4003027a13497654a5ce5ca74793815386f7"
+  integrity sha512-0a7DJnhniBx2psRuKcVQ9g4hujN6PAR4fPS0NSF1T1luH1RBDZVVEn2pGND6Ly+AW1lUm/cHOHjsasqBelMhbw==
 
 tippy.js@^6.3.7:
   version "6.3.7"


### PR DESCRIPTION
Gave it a try and currently no problems upgrading from 6 -> 7 ... going to test this more in mosaic environments.

https://www.tiny.cloud/docs/tinymce/latest/migration-from-6x/