### PR TITLE
SASS 1.79 compatibility

### DIFF
--- a/src/pat/relateditems/relateditems.scss
+++ b/src/pat/relateditems/relateditems.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .pat-relateditems-container {
     position: relative;
     display: inline-block;
@@ -184,7 +186,7 @@
             padding: 0 0.15em 0 0.1em;
 
             &:hover {
-                background-color: lighten(#d8d8d8, 5%);
+                background-color: color.scale(#d8d8d8, $lightness: 5%);
             }
 
             span {

--- a/src/pat/structure/structure.scss
+++ b/src/pat/structure/structure.scss
@@ -1,8 +1,3 @@
-@import "~bootstrap/scss/mixins";
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/forms/form-control";
-
 .pat-structure {
     input.has-filter {
         border: 1px solid orange;
@@ -72,7 +67,7 @@
             border-bottom-width: 2px;
 
             th.sorting_disabled {
-                padding-right: $table-cell-padding-x !important;
+                padding-right: var(--bs-table-cell-padding-x) !important;
 
                 &:after,
                 &:before {
@@ -230,14 +225,14 @@
         }
 
         .popover-content {
-            padding: $popover-body-padding-y $popover-body-padding-x;
+            padding: var(--bs-popover-body-padding-y) var(--bs-popover-body-padding-x);
 
             form {
-                padding: $popover-body-padding-y $popover-body-padding-x;
+                padding: var(--bs-popover-body-padding-y) var(--bs-popover-body-padding-x);
                 max-height: 500px;
                 overflow-y: auto;
                 overflow-x: hidden;
-                margin: $popover-body-padding-y * -1 $popover-body-padding-x * -1 $popover-body-padding-y;
+                margin: calc(var(--bs-popover-body-padding-y) * -1) calc(var(--bs-popover-body-padding-x) * -1) var(--bs-popover-body-padding-y);
             }
         }
 
@@ -264,7 +259,7 @@
 
                 .lead-img {
                     flex-shrink: 0;
-                    margin-left: $spacer;
+                    margin-left: 1rem;
                 }
             }
 
@@ -278,9 +273,9 @@
         }
 
         &.default-page .title>div>*:first-child:before {
-            color: $danger;
+            color: var(--bs-danger);
             content: "•";
-            font-size: $font-size-lg;
+            font-size: calc(var(--bs-body-font-size) * 1.25);
             line-height: 1;
         }
     }
@@ -334,9 +329,13 @@
 
     #popover-rename {
         .form-control {
-            @extend .form-control-sm;
+            // copied from .form-control-sm from Bootstrap to avoid including
+            // bootstrap.scss only for this.
+            min-height: calc(1.5em + .5rem + calc(var(--bs-border-width) * 2));
+            padding: .25rem .5rem;
+            font-size: calc(var(--bs-body-font-size) * .875);
+            border-radius: var(--bs-border-radius-sm);
         }
-
         div.item {
             border-bottom: 1px solid var(--bs-primary);
             margin-bottom: 5px;

--- a/src/pat/upload/upload.scss
+++ b/src/pat/upload/upload.scss
@@ -1,6 +1,3 @@
-// Bootstrap dependencies:
-// - _progress.scss
-
 .upload-container {
     .upload-area {
         border: 3px dashed #ccc;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,25 +163,6 @@ module.exports = () => {
         );
     }
 
-
-    // Fix for sass-loader to silence deprecation warnings, mainly from BootstrapJS.
-    // TODO: Remove this when BootstrapJS is updated.
-    // See: https://github.com/twbs/bootstrap/pull/40864
-
-    const css_loader_rule = config.module.rules.filter(it=>it?.use?.includes?.("sass-loader"));
-    if (css_loader_rule.length > 0) {
-        const sass_loader_index = css_loader_rule[0].use.indexOf("sass-loader");
-        css_loader_rule[0].use[sass_loader_index] = {
-            loader: "sass-loader",
-            options: {
-                sassOptions: {
-                    quietDeps: true,
-                    //silenceDeprecations: ['legacy-js-api'],
-                },
-            },
-        };
-    }
-
     console.log(JSON.stringify(config, null, 4));
 
     return config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,6 +163,25 @@ module.exports = () => {
         );
     }
 
+
+    // Fix for sass-loader to silence deprecation warnings, mainly from BootstrapJS.
+    // TODO: Remove this when BootstrapJS is updated.
+    // See: https://github.com/twbs/bootstrap/pull/40864
+
+    const css_loader_rule = config.module.rules.filter(it=>it?.use?.includes?.("sass-loader"));
+    if (css_loader_rule.length > 0) {
+        const sass_loader_index = css_loader_rule[0].use.indexOf("sass-loader");
+        css_loader_rule[0].use[sass_loader_index] = {
+            loader: "sass-loader",
+            options: {
+                sassOptions: {
+                    quietDeps: true,
+                    //silenceDeprecations: ['legacy-js-api'],
+                },
+            },
+        };
+    }
+
     console.log(JSON.stringify(config, null, 4));
 
     return config;


### PR DESCRIPTION
Begin work on SASS 1.79 compatibility.

Ref:
https://github.com/twbs/bootstrap/issues/40849
https://github.com/twbs/bootstrap/pull/40865
https://github.com/twbs/bootstrap/pull/40864

IIRC (worked on that some days ago) this is not really silencing the deprecation warnings from SASS.

Probably pinning SASS to something before 1.79 is better (`resolveDependencies`).