### PR TITLE
`pat-contentbrowser` UI fixes

### DIFF
--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -88,6 +88,7 @@
             // one level search mode
             updatePreview({ data: item });
         } else if (item.is_folderish) {
+            $previewUids = [item.UID];
             currentPath.set(item.path);
         } else {
             const pathParts = item.path.split("/");

--- a/src/pat/contentbrowser/src/SelectedItems.svelte
+++ b/src/pat/contentbrowser/src/SelectedItems.svelte
@@ -99,8 +99,10 @@
     style="width: {$config.width || 'auto'}"
     bind:this={ref}
 >
-    <!-- {maxSelectionsize} -->
-    <div class="content-browser-selected-items">
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div class="content-browser-selected-items"
+         on:click={() => $showContentBrowser = $selectedItems.length ? false : true }>
         {#if $selectedItems}
             {#each $selectedItems as selItem, i (selItem.UID)}
                 <div
@@ -109,10 +111,9 @@
                     data-uuid={selItem.UID}
                 >
                     <div class="item-info">
-                        <!-- svelte-ignore a11y-missing-attribute -->
                         <button
                             class="btn btn-link btn-sm link-secondary"
-                            on:click={() => unselectItem(i)}
+                            on:click|stopPropagation={() => unselectItem(i)}
                             ><svg use:resolveIcon={{ iconName: "x-circle" }} /></button
                         >
                         <div>

--- a/src/pat/contentbrowser/src/SelectedItems.svelte
+++ b/src/pat/contentbrowser/src/SelectedItems.svelte
@@ -132,11 +132,12 @@
             <p>{_t("loading selected items")}</p>
         {/if}
     </div>
-    <button
-        class="btn btn-primary"
+    <!-- svelte-ignore a11y-invalid-attribute -->
+    <a
+        class="btn btn-primary" href="#"
         style="border-radius:0 var(--bs-border-radius) var(--bs-border-radius) 0"
         on:click|preventDefault={() => ($showContentBrowser = true)}
-        >{_t("Select")}</button
+        >{_t("Select")}</a
     >
 </div>
 


### PR DESCRIPTION
- [x] fix saving form with ENTER key
- [x] active state of selected folderish items
- [x] Click on empty selected items field opens contentbrowser