### PR TITLE
pat contentbrowser: ui improvements for select button in toolbar

### DIFF
--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -342,13 +342,6 @@
         }, 500);
     }
 
-    function initToolTips(){
-        // init the tooltips for select buttons in contentbrowser
-        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
-        console.log(tooltipTriggerList, tooltipList)
-    }
-
     $: {
         if ($showContentBrowser) {
             contentItems.get({ path: $currentPath });
@@ -416,7 +409,6 @@
                         <div
                             class="levelColumn{i % 2 == 0 ? ' odd' : ' even'}"
                             in:fly|local={{ duration: 300 }}
-                            use:initToolTips
                         >
                             <div class="levelToolbar">
                                 {#if i == 0 && $config.mode == "browse"}
@@ -434,13 +426,10 @@
                                 {#if level.selectable}
                                     <button
                                         class="btn btn-primary btn-xs"
-                                        data-bs-toggle="tooltip"
-                                        data-bs-title="{level.displayPath}"
-                                        data-bs-placement="top"
-                                        data-bs-custom-class="contentbrowser-tooltip"
+                                        title="{level.displayPath}"
                                         disabled={!isSelectable(level)}
                                         on:click|preventDefault={() => addItem(level)}
-                                    >
+                                                                            >
                                         {_t("select ${level_path}", {
                                             level_path: level.Title,
                                         })}
@@ -764,11 +753,5 @@
     .loadmore {
         text-align: center;
         padding: 0.25rem 0;
-    }
-
-    /* override the default tooltip z-index, because contentbrowser is on a higher level */
-    :global(div.tooltip.contentbrowser-tooltip){
-        --bs-tooltip-zindex: 2000;
-        z-index: var(--bs-tooltip-zindex);
     }
 </style>

--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -429,7 +429,7 @@
                                         title="{level.displayPath}"
                                         disabled={!isSelectable(level)}
                                         on:click|preventDefault={() => addItem(level)}
-                                                                            >
+                                    >
                                         {_t("select ${level_path}", {
                                             level_path: level.Title,
                                         })}

--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -342,6 +342,13 @@
         }, 500);
     }
 
+    function initToolTips(){
+        // init the tooltips for select buttons in contentbrowser
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+        console.log(tooltipTriggerList, tooltipList)
+    }
+
     $: {
         if ($showContentBrowser) {
             contentItems.get({ path: $currentPath });
@@ -409,6 +416,7 @@
                         <div
                             class="levelColumn{i % 2 == 0 ? ' odd' : ' even'}"
                             in:fly|local={{ duration: 300 }}
+                            use:initToolTips
                         >
                             <div class="levelToolbar">
                                 {#if i == 0 && $config.mode == "browse"}
@@ -426,11 +434,15 @@
                                 {#if level.selectable}
                                     <button
                                         class="btn btn-primary btn-xs"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-title="{level.displayPath}"
+                                        data-bs-placement="top"
+                                        data-bs-custom-class="contentbrowser-tooltip"
                                         disabled={!isSelectable(level)}
                                         on:click|preventDefault={() => addItem(level)}
                                     >
                                         {_t("select ${level_path}", {
-                                            level_path: level.displayPath,
+                                            level_path: level.Title,
                                         })}
                                     </button>
                                 {/if}
@@ -752,5 +764,11 @@
     .loadmore {
         text-align: center;
         padding: 0.25rem 0;
+    }
+
+    /* override the default tooltip z-index, because contentbrowser is on a higher level */
+    :global(div.tooltip.contentbrowser-tooltip){
+        --bs-tooltip-zindex: 2000;
+        z-index: var(--bs-tooltip-zindex);
     }
 </style>


### PR DESCRIPTION
- use the title of content object as label of the select button
- enable a bs tooltip with the path info of selected contentobject

the old behavior was "display the path", now "display the title" and show the path in a tooltip