### PR TITLE
Show 'Page 1 of 1' instead of 'Page 1 of 0'.

### DIFF
--- a/src/pat/structure/templates/paging.xml
+++ b/src/pat/structure/templates/paging.xml
@@ -44,8 +44,10 @@
   </ul>
 
   <div class="pagination-info">
+    <% if(totalPages){ %>
     <%- _t("Page:") %> <span class="current"><%- currentPage %></span>
     <%- _t("of") %>
     <span class="total"><%- totalPages %></span>
           <%- _t("shown") %>
+    <% } %>
   </div>


### PR DESCRIPTION
This trivial PR intends to fix https://github.com/plone/mockup/issues/1412 and https://github.com/plone/Products.CMFPlone/issues/3591 by checking that `totalPages` is zero and setting it to one.