### PR TITLE
Fixi18n

### DIFF
--- a/src/core/i18n.js
+++ b/src/core/i18n.js
@@ -14,14 +14,6 @@ const i18n = function () {
     self.baseUrl = $("body").attr("data-i18ncatalogurl");
     self.currentLanguage = $("html").attr("lang") || "en";
 
-    // Fix for country specific languages
-    if (self.currentLanguage.split("-").length > 1) {
-        self.currentLanguage =
-            self.currentLanguage.split("-")[0] +
-            "_" +
-            self.currentLanguage.split("-")[1].toUpperCase();
-    }
-
     self.storage = null;
     self.catalogs = {};
     self.ttl = 24 * 3600 * 1000;

--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -124,7 +124,7 @@ export default class TinyMCE {
         var lang = i18n.currentLanguage;
         if (lang !== "en" && self.options.tiny.language !== "en") {
             try {
-                await import(`tinymce-i18n/langs6/${lang}`);
+                await import(`tinymce-i18n/langs7/${lang}`);
             } catch {
                 log.debug("Could not load TinyMCE language: ", lang);
                 try {
@@ -135,7 +135,7 @@ export default class TinyMCE {
                         lang = lang + "_" + lang.toUpperCase();
                     }
                     log.debug("Trying with: ", lang);
-                    await import(`tinymce-i18n/langs6/${lang}`);
+                    await import(`tinymce-i18n/langs7/${lang}`);
                     self.options.tiny.language = lang;
                 } catch {
                     log.debug("Could not load TinyMCE language. Fallback to English");

--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -122,6 +122,15 @@ export default class TinyMCE {
         var self = this;
         var i18n = new I18n();
         var lang = i18n.currentLanguage;
+
+        // Fix for country specific languages
+        if (lang.split("-").length > 1) {
+            lang =
+                lang.split("-")[0] +
+                "_" +
+                lang.split("-")[1].toUpperCase();
+        }
+
         if (lang !== "en" && self.options.tiny.language !== "en") {
             try {
                 await import(`tinymce-i18n/langs7/${lang}`);


### PR DESCRIPTION
a old fix for language identifier is moved to a new place. the language identifiers with "minus" e.g. "en-us" are transformed to "en_us", but this is not the standard, and not really wanted. but tinymce use the transformed identifiers as file labels.