### PR TITLE
maint: Update the compatible node version to the current LTS version.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: "20"
+        node-version: "22"
         cache: "yarn"
     - name: Build mockup
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: "20"
+        node-version: "22"
         cache: 'yarn'
     - run: yarn install
     - run: make eslint

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "/webpack.config.js"
     ],
     "engines": {
-        "node": ">=12.20.0"
+        "node": ">=22"
     },
     "browserslist": [
         "defaults"


### PR DESCRIPTION
This updates the "engines" field of package.json which is a standard field as specified here: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines

Mockup would work with lower versions of Node also - e.g. Node version 18, but "22" is the current LTS version.


Related:
https://github.com/Patternslib/dev/pull/50
https://github.com/Patternslib/Patterns/pull/1252
https://github.com/plone/mockup/pull/1465
https://github.com/plone/plone.app.mosaic/pull/634
