### PR TITLE
pat-tinymce: Document, what the importcss_file_filter is for.

### DIFF
--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -279,6 +279,11 @@ export default class TinyMCE {
             self.$el.hide();
         }
 
+        // The `importcss_file_filter` is used to filter the CSS files
+        // from `content_css` which should be used to automatically create the
+        // styles dropdown.
+        // Also see:
+        // https://www.tiny.cloud/docs/tinymce/latest/importcss/#importcss_file_filter
         if (
             tinyOptions.importcss_file_filter &&
             typeof tinyOptions.importcss_file_filter.indexOf === "function" &&

--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -283,7 +283,7 @@ export default class TinyMCE {
         // from `content_css` which should be used to automatically create the
         // styles dropdown.
         // Also see:
-        // https://www.tiny.cloud/docs/tinymce/latest/importcss/#importcss_file_filter
+        // https://6.docs.plone.org/classic-ui/tinymce-customization.html#inject-formats-with-files-named-tinymce-formats-css
         if (
             tinyOptions.importcss_file_filter &&
             typeof tinyOptions.importcss_file_filter.indexOf === "function" &&


### PR DESCRIPTION
I was scratching my head for a while what this `importcss_file_filter` is for. Don't scratch yours!

There is intentionally no conventionalcommits compatible commit message as I think this change should not go into the changelog.

# PRs
https://github.com/plone/mockup/pull/1467
https://github.com/plone/Products.CMFPlone/pull/4184
