### PR TITLE
Make Autotoc tab markup compatible with Bootstrap

### DIFF
--- a/src/pat/autotoc/autotoc.js
+++ b/src/pat/autotoc/autotoc.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import Base from "@patternslib/patternslib/src/core/base";
 import utils from "@patternslib/patternslib/src/core/utils";
+import Tab from "bootstrap/js/dist/tab";
 
 export default Base.extend({
     name: "autotoc",
@@ -10,8 +11,9 @@ export default Base.extend({
         section: "section",
         levels: "h1,h2,h3",
         IDPrefix: "autotoc-item-",
-        classTOCName: "autotoc-nav",
-        classSectionName: "autotoc-section",
+        classTOCName: "autotoc-nav nav",
+        classContentAreaName: "autotoc-content tab-content",
+        classSectionName: "autotoc-section tab-pane fade",
         classLevelPrefixName: "autotoc-level-",
         classActiveName: "active",
         scrollDuration: "slow",
@@ -26,23 +28,52 @@ export default Base.extend({
 
         var self = this;
 
-        self.$toc = $("<nav/>").addClass(self.options.classTOCName);
+        self.$nav = $("<nav/>")
+            .attr("aria-label", "Tab Navigation")
+
+        self.$toc = $("<ul/>")
+            .addClass(self.options.classTOCName)
+            .appendTo(self.$nav);
 
         if (self.options.prependTo) {
-            self.$toc.prependTo(self.options.prependTo);
+            self.$nav.prependTo(self.options.prependTo);
         } else if (self.options.appendTo) {
-            self.$toc.appendTo(self.options.appendTo);
+            self.$nav.appendTo(self.options.appendTo);
         } else {
-            self.$toc.prependTo(self.$el);
+            self.$nav.prependTo(self.$el);
         }
+
 
         if (self.options.className) {
             self.$el.addClass(self.options.className);
         }
 
-        $(self.options.section, self.$el).addClass(self.options.classSectionName);
+        $(self.options.section, self.$el)
+            .addClass(self.options.classSectionName)
+            .attr("role", "tabpanel")
+            .attr("tabindex", "0")
 
         var asTabs = self.$el.hasClass("autotabs");
+
+        if (asTabs) {
+            self.$toc.addClass("nav-tabs");
+            self.$contentArea = $("<div/>").addClass(self.options.classContentAreaName);
+            self.$contentArea.insertAfter(self.$nav);
+            $(self.options.section, self.$el).appendTo(self.$contentArea);
+            $(self.options.section, self.$el).find("legend").hide();
+        } else {
+            self.$toc.addClass([
+                "flex-column",
+                "float-end",
+                "border",
+                "mt-0",
+                "me-0",
+                "mb-3",
+                "ms-3",
+                "py-2",
+                "px-0"
+            ])
+        }
 
         var activeId = null;
 
@@ -54,39 +85,43 @@ export default Base.extend({
             if (!id || $("#" + id).length > 0) {
                 id = self.options.IDPrefix + self.name + "-" + i;
             }
+
+            const tabId = `${id}-tab`;
+            $(section).attr("id", id).attr("aria-labelledby", tabId);
+
             if (window.location.hash === "#" + id) {
-                activeId = id;
+                activeId = tabId;
             }
             if (activeId === null && $level.hasClass(self.options.classActiveName)) {
-                activeId = id;
+                activeId = tabId;
             }
             $level.data("navref", id);
+
+            const $navItem = $("<li/>");
+            $navItem
+                .addClass("nav-item")
+                .attr("role", "presentation")
+                .appendTo(self.$toc);
+
             const $nav = $("<a/>");
-            $nav.appendTo(self.$toc)
+            $nav.appendTo($navItem)
                 .text($level.text())
-                .attr("id", id)
+                .attr("id", tabId)
                 .attr("href", "#" + id)
-                .addClass(self.options.classLevelPrefixName + self.getLevel($level))
+                .attr("aria-controls", id)
+                .attr("data-bs-toggle", "tab")
+                .attr("data-bs-target", `#${id}`)
+                .addClass([
+                    "nav-link",
+                    self.options.classLevelPrefixName + self.getLevel($level),
+                ])
                 .on("click", function (e, options) {
-                    e.stopPropagation();
-                    e.preventDefault();
                     if (!options) {
                         options = {
                             doScroll: true,
                             skipHash: false,
                         };
                     }
-                    var $el = $(this);
-                    self.$toc
-                        .children("." + self.options.classActiveName)
-                        .removeClass(self.options.classActiveName);
-                    self.$el
-                        .children("." + self.options.classActiveName)
-                        .removeClass(self.options.classActiveName);
-                    $(e.target).addClass(self.options.classActiveName);
-                    $level
-                        .parents(self.options.section)
-                        .addClass(self.options.classActiveName);
                     if (
                         options.doScroll !== false &&
                         self.options.scrollDuration &&
@@ -107,10 +142,17 @@ export default Base.extend({
                     $(this).trigger("clicked");
                     if (!options.skipHash) {
                         if (window.history && window.history.pushState) {
-                            window.history.pushState({}, "", "#" + $el.attr("id"));
+                            window.history.pushState({}, "", `#${id}`);
                         }
                     }
                 });
+            if (!asTabs) {
+                $nav.addClass([
+                    "text-decoration-underline",
+                    "p-0",
+                    "mx-3",
+                ]);
+            }
             $level.data("autotoc-trigger-id", id);
 
             self.tabs.push({
@@ -121,23 +163,25 @@ export default Base.extend({
         });
 
         if (activeId) {
-            $("a#" + activeId).trigger("click", {
-                doScroll: true,
-                skipHash: true,
-            });
+            const activeTabButton = self.$toc.find("a#" + activeId)[0];
+            if (activeTabButton) {
+                const tab = Tab.getOrCreateInstance(activeTabButton);
+                tab.show();
+            }
         } else {
-            self.$toc.find("a").first().trigger("click", {
-                doScroll: false,
-                skipHash: true,
-            });
+            const firstTabButton = self.$toc.find("a").first()[0];
+            if (firstTabButton) {
+                const tab = Tab.getOrCreateInstance(firstTabButton);
+                tab.show();
+            }
         }
 
         // After DOM tree is built, initialize eventual validation
-        this.initialize_validation(self.$el);
+        this.initialize_validation();
     },
 
-    initialize_validation: function ($el) {
-        const el = $el[0];
+    initialize_validation: function () {
+        const el = this.el
 
         // Initialize only on forms
         const form = el.closest("form");

--- a/src/pat/autotoc/autotoc.scss
+++ b/src/pat/autotoc/autotoc.scss
@@ -1,69 +1,10 @@
 .pat-autotoc {
     .autotoc-nav {
-        float: right;
-        border: 1px solid #ddd;
-        padding: 0.5em 0;
-        margin: 0 0 1em 1em;
-        a {
-            display: block;
-        }
-        a:focus {
-            outline-style: none;
-        }
-        .autotoc-level-1 {
-            margin: 0 1em 0 1em;
-        }
         .autotoc-level-2 {
-            margin: 0 1em 0 2em;
+            margin-left: 2em;
         }
         .autotoc-level-3 {
-            margin: 0 1em 0 3em;
-        }
-    }
-    &.autotabs {
-        .autotoc-nav {
-            float: none;
-            padding: 0;
-            margin: 0 0 0.3em 0;
-            border: 0;
-            border-bottom: 1px solid #ddd;
-            &:after {
-                content: "";
-                display: table;
-                line-height: 0;
-            }
-            a {
-                display: inline-block;
-                margin: 0 0.5em -1px 0.5em;
-                line-height: 1.5em;
-                padding: 0.4em 0.8em;
-                text-decoration: none;
-                border-radius: 4px 4px 0 0;
-                &.active {
-                    border: 1px solid #ddd;
-                    border-bottom-color: var(--bs-body-bg);
-                    color: var(--bs-secondary-text);
-                    cursor: default;
-                }
-                &.active:hover {
-                    background-color: transparent;
-                }
-                &:hover {
-                    // background-color: #eee;
-                    background-color: var(--bs-secondary-bg);
-                    border-color: #eee;
-                    border-bottom-color: var(--bs-body-bg);
-                }
-            }
-        }
-        .autotoc-section {
-            display: none;
-            &.active {
-                display: block;
-                legend {
-                    display: none;
-                }
-            }
+            margin-left: 3em;
         }
     }
 }

--- a/src/pat/autotoc/autotoc.test.js
+++ b/src/pat/autotoc/autotoc.test.js
@@ -33,38 +33,48 @@ describe("1 - AutoTOC", function () {
         document.body.innerHTML = "";
     });
     it("by default creates TOC from h1/h2/h3", async function () {
-        expect(document.querySelectorAll("nav").length).toEqual(0);
+        expect(document.querySelectorAll(".nav").length).toEqual(0);
 
         registry.scan(document.body);
         await utils.timeout(1);
 
-        expect(document.querySelectorAll("nav").length).toEqual(1);
-        expect(document.querySelectorAll("nav > a").length).toEqual(9);
-        expect(document.querySelectorAll("nav > a.autotoc-level-1").length).toEqual(4);
-        expect(document.querySelectorAll("nav > a.autotoc-level-2").length).toEqual(4);
-        expect(document.querySelectorAll("nav > a.autotoc-level-3").length).toEqual(1);
-        expect(document.querySelectorAll("nav > a.autotoc-level-4").length).toEqual(0);
+        expect(document.querySelectorAll(".nav").length).toEqual(1);
+        expect(document.querySelectorAll(".nav > li > a").length).toEqual(9);
+        expect(
+            document.querySelectorAll(".nav > li > a.autotoc-level-1").length
+        ).toEqual(4);
+        expect(
+            document.querySelectorAll(".nav > li > a.autotoc-level-2").length
+        ).toEqual(4);
+        expect(
+            document.querySelectorAll(".nav > li > a.autotoc-level-3").length
+        ).toEqual(1);
+        expect(
+            document.querySelectorAll(".nav > li > a.autotoc-level-4").length
+        ).toEqual(0);
     });
     it("sets href and id", async () => {
         registry.scan(document.body);
         await utils.timeout(1);
 
-        expect(document.querySelectorAll("nav > a")[0].getAttribute("id")).toEqual(
-            "autotoc-item-autotoc-0"
+        expect(document.querySelectorAll(".nav > li > a")[0].getAttribute("id")).toEqual(
+            "autotoc-item-autotoc-0-tab"
         );
-        expect(document.querySelectorAll("nav > a")[0].getAttribute("href")).toEqual(
-            "#autotoc-item-autotoc-0"
-        );
+        expect(
+            document
+                .querySelectorAll(".nav > li > a")[0]
+                .getAttribute("data-bs-target")
+        ).toEqual("#autotoc-item-autotoc-0");
     });
     it("can have custom levels", async function () {
         this.$el.attr("data-pat-autotoc", "levels: h1");
-        expect($("> nav", this.$el).length).toEqual(0);
+        expect($("> .nav", this.$el).length).toEqual(0);
         registry.scan(this.$el);
         await utils.timeout(1);
 
         expect($("> nav", this.$el).length).toEqual(1);
-        expect($("> nav > a.autotoc-level-1", this.$el).length).toEqual(4);
-        expect($("> nav > a.autotoc-level-2", this.$el).length).toEqual(0);
+        expect($("> nav > ul > li > a.autotoc-level-1", this.$el).length).toEqual(4);
+        expect($("> nav > ul > li > a.autotoc-level-2", this.$el).length).toEqual(0);
     });
     it("can be appended anywhere", async function () {
         this.$el.attr("data-pat-autotoc", "levels: h1;appendTo:.placeholder");
@@ -78,21 +88,22 @@ describe("1 - AutoTOC", function () {
         expect($("div.placeholder", this.$el).children().eq(0).attr("id")).toEqual(
             "first-elem"
         );
-        expect($("div.placeholder", this.$el).children().eq(1).attr("class")).toEqual(
-            "autotoc-nav"
-        );
+        expect(
+            $("div.placeholder", this.$el).children().eq(1).find("ul").attr("class")
+        ).toContain("autotoc-nav nav flex-column");
+
     });
     it("can be prepended anywhere", async function () {
         this.$el.attr("data-pat-autotoc", "levels: h1;prependTo:.placeholder");
-        expect($("> nav", this.$el).length).toEqual(0);
-        expect($("div.placeholder > nav", this.$el).length).toEqual(0);
+        expect($("> .nav", this.$el).length).toEqual(0);
+        expect($("div.placeholder > .nav", this.$el).length).toEqual(0);
         registry.scan(this.$el);
         await utils.timeout(1);
 
-        expect($("> nav", this.$el).length).toEqual(0);
+        expect($("> .nav", this.$el).length).toEqual(0);
         expect($("div.placeholder > nav", this.$el).length).toEqual(1);
-        expect($("div.placeholder", this.$el).children().eq(0).attr("class")).toEqual(
-            "autotoc-nav"
+        expect($("div.placeholder", this.$el).children().eq(0).find("ul").attr("class")).toContain(
+            "autotoc-nav nav flex-column"
         );
         expect($("div.placeholder", this.$el).children().eq(1).attr("id")).toEqual(
             "first-elem"
@@ -102,7 +113,7 @@ describe("1 - AutoTOC", function () {
         registry.scan(this.$el);
         await utils.timeout(1);
 
-        expect($("> nav > a.active", this.$el).text()).toEqual("Title 1");
+        expect($("> nav > ul > li > a.active", this.$el).text()).toEqual("Title 1");
     });
     it("the first element with `classActiveName` will be the active", async function () {
         $("h1:eq(1)", this.$el).addClass("active");
@@ -111,7 +122,7 @@ describe("1 - AutoTOC", function () {
         registry.scan(this.$el);
         await utils.timeout(1);
 
-        expect($("> nav > a.active", this.$el).text()).toEqual("Title 2");
+        expect($("> nav > ul > li > a.active", this.$el).text()).toEqual("Title 2");
     });
     it("custom className", async function () {
         this.$el.attr("data-pat-autotoc", "className:SOMETHING");


### PR DESCRIPTION
This fixes first part of the [plone/Products.CMFPlone#4106](https://github.com/plone/Products.CMFPlone/issues/4106)

This change updates the markup and behavior of the AutoTOC to make it more compatible with Bootstrap's tab component. Key changes:

- Moves all fieldset elements inside a tab-content parent element.
- Replaces anchor (<a>) tab triggers with Bootstrap-compatible <button> elements, utilizes data-bs-toggle, data-bs-target, and other related attributes.
- Adds appropriate aria attributes for accessibility and correct tab behavior.
- Updates tab-click handling to use Bootstrap's tab JavaScript API, replacing the previous custom logic.