### PR TITLE
fix(pat-tinymce): Add a fallback for Plone 5 images without data-pict…

### DIFF
--- a/src/pat/tinymce/js/links.js
+++ b/src/pat/tinymce/js/links.js
@@ -899,10 +899,10 @@ export default Base.extend({
                 self.linkTypes[self.linkType].load(self.imgElm);
 
                 // set scale selection in link modal:
-                var pictureVariant = self.dom.getAttrib(
-                    self.imgElm,
-                    "data-picturevariant",
-                );
+                var pictureVariant =
+                    self.dom.getAttrib(self.imgElm, "data-picturevariant") ||
+                    // fallback for backwards compatibility
+                    self.dom.getAttrib(self.imgElm, "data-scale");
                 self.$scale.val(pictureVariant);
 
                 // var selectedImageUid = self.dom.getAttrib(

--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -10,6 +10,9 @@ const log = logger.getLogger("tinymce--implementation");
 let LinkModal = null;
 
 export default class TinyMCE {
+    linkModal;
+    imageModal;
+
     constructor(el, options) {
         this.el = el;
         this.$el = $(el);
@@ -17,7 +20,7 @@ export default class TinyMCE {
     }
     addLinkClicked() {
         var self = this;
-        if (self.linkModal === null) {
+        if (!self.linkModal) {
             var $el = $("<div/>").insertAfter(self.$el);
             var linkTypes = ["internal", "upload", "external", "email", "anchor"];
             if (!self.options.upload) {
@@ -38,7 +41,7 @@ export default class TinyMCE {
     }
     addImageClicked() {
         var self = this;
-        if (self.imageModal === null) {
+        if (!self.imageModal) {
             var linkTypes = ["image", "uploadImage", "externalImage"];
             if (!self.options.upload) {
                 linkTypes.splice(1, 1);
@@ -221,7 +224,6 @@ export default class TinyMCE {
         LinkModal = (await import("./js/links")).default;
 
         var self = this;
-        self.linkModal = self.imageModal = self.uploadModal = self.pasteModal = null;
         // tiny needs an id in order to initialize. Creat it if not set.
         var id = utils.setId(self.$el);
 


### PR DESCRIPTION
…urevariant attributes.

Responsive picture variants were introduced in Plone 6. Content from Plone 5 where no `data-picturevariant` was available lost had no scale selected in the image dialog.
This PR fixes that by falling back to the `data-scale` attribute. This allows old images in the TinyMCE‌ image edit dialog to have their scale preselected. The precondition for this is that the old scales are configured as picture variants.


<img width="1323" height="1323" alt="image" src="https://github.com/user-attachments/assets/4a19580f-420b-4691-968b-9d02c0d18d0b" />

I tried my best to test this feature but had to give up.
TinyMCE is untestable.