### PR TITLE
fix(pat-tinymce): Add support for image scales as fallback for picture variants.

### DIFF
--- a/src/pat/tinymce/templates/image.xml
+++ b/src/pat/tinymce/templates/image.xml
@@ -18,11 +18,19 @@
           <div class="scale mb-2">
             <label><%- scaleText %></label>
             <select name="scale" class="form-select">
+              <% if (use_picture_variants) { %>
               <% _.each(Object.keys(pictureVariants), function(key) { %>
                 <option value="<%- key %>" <% if (key === options.defaultSrcset) { %>selected<% } %> >
                   <%- pictureVariants[key].title %>
-                </option>
+                 </option>
               <% }); %>
+              <% } else if (use_scales) { %>
+              <% for (const scale of imageScales) { %>
+                <option value="<%- scale.value %>" <% if (scale.value === options.defaultScale) { %>selected<% } %> >
+                  <%- scale.title %>
+                </option>
+              <% } %>
+              <% } %>
             </select>
           </div>
         </div>

--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -140,11 +140,17 @@ export default class TinyMCE {
         // tiny needs an id in order to initialize. Creat it if not set.
         const id = utils.setId(this.$el);
 
+        // Plone 6 picture variants.
         if (
             this.options.pictureVariants &&
             typeof this.options.pictureVariants === "string"
         ) {
             this.options.pictureVariants = JSON.parse(this.options.pictureVariants);
+        }
+
+        // BBB for Plone 5 image scales, in case no picture variants are set.
+        if (this.options.imageScales && typeof this.options.imageScales === "string") {
+            this.options.imageScales = JSON.parse(this.options.imageScales);
         }
 
         // TinyMCE editor options


### PR DESCRIPTION
picture variants are a new feature in Plone 6. Migrated sites from Plone 5 have not used that, but still contain the "data-scale" instead of the "data-picturevariant" attributes in TinyMCE edited texts. When opening the image dialog existing pictures have no size variant preselected.
This PR fixes that and falls back to the image scale selection. The fallback is activated when no picture variants are configured e.g. by setting the picture variants field in the imaging controlpanel to "{}".

This is an alternative implementation for: https://github.com/plone/mockup/pull/1493