### PR TITLE
fix(pat-tinymce): Ingore english language variant translations.

### DIFF
--- a/src/pat/tinymce/tinymce--implementation.js
+++ b/src/pat/tinymce/tinymce--implementation.js
@@ -303,7 +303,7 @@ export default class TinyMCE {
             lang = lang.split("-")[0] + "_" + lang.split("-")[1].toUpperCase();
         }
 
-        if (lang !== "en") {
+        if (lang.substr(0,2) !== "en") {
             // load translations from tinymce-i18n
             try {
                 await import(`tinymce-i18n/langs7/${lang}`);


### PR DESCRIPTION
For english translations, ignore country specific language varants. This fixes a probem which occured with a language variant as portal language.

TODO: verify! but I can't remember anymore.