### PR TITLE
Fix incorrect locale casing for pt-BR  #1501

### DIFF
--- a/src/pat/select2/select2.js
+++ b/src/pat/select2/select2.js
@@ -112,7 +112,7 @@ export default Base.extend({
             if (this.options.language && this.options.language !== "en" && !this.options.language.startsWith("en")) {
                 let lang = this.options.language.split("-");
                 // Fix for country specific languages
-                lang = (lang.length > 1) ? `${lang[0]}-${lang[1]}` : lang[0];        
+                lang = (lang.length > 1) ? `${lang[0]}-${lang[1].toUpperCase()}` : lang[0];        
                 await import(`select2/select2_locale_${lang}`);
             }
         } catch {


### PR DESCRIPTION
Problem:
When the browser language is "pt-br", the app generates a lowercase locale string,
but translation files use uppercase region codes ("pt-BR"). On case-sensitive
systems this causes the file not found error.

Solution:
Normalize locale format so region codes are always uppercase.

Testing:
- Verified Portuguese translations load correctly.
- Verified other locales remain unaffected.
