### PR TITLE
fix(pat-contentbrowser): Add type='button' to prevent the button to be focused by default in a form

### DIFF
--- a/src/pat/contentbrowser/src/SelectedItem.svelte
+++ b/src/pat/contentbrowser/src/SelectedItem.svelte
@@ -12,6 +12,7 @@
         <!-- svelte-ignore a11y-missing-attribute -->
         <button
             class="btn btn-link btn-sm link-secondary"
+            type="button"
             on:click|preventDefault={() => unselectItem(item.UID)}
             ><svg use:resolveIcon={{ iconName: "x-circle" }} /></button
         >


### PR DESCRIPTION
Hello,

This is a small quality-of-life improvement. By adding type="button", the button no longer steals focus in edit/add forms. This also allows users to submit the form by pressing Enter while focused in the title field.

Before this change, something odd happened: pressing Enter while focused in the title field would delete the selected content. If the field wasn’t visible (for example, inside another fieldset), this could lead to accidental deletions without the user even noticing.

Thanks! :v: 

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.

