### PR TITLE
feat(pat-contentbrowser): Show images in selected items without padding.

### DIFF
--- a/src/pat/contentbrowser/src/SelectedItem.svelte
+++ b/src/pat/contentbrowser/src/SelectedItem.svelte
@@ -5,8 +5,8 @@
     let { item, unselectItem } = $props();
 </script>
 
-<div class="selected-item border border-secondary-subtle rounded p-2 mb-1 bg-body-tertiary" data-uuid={item.UID}>
-    <div class="item-info">
+<div class="selected-item border border-secondary-subtle rounded mb-1 bg-body-tertiary" data-uuid={item.UID}>
+    <div class="item-info p-2">
         <!-- svelte-ignore a11y_missing_attribute -->
         <button
             class="btn btn-link btn-sm link-secondary"
@@ -35,7 +35,6 @@
         cursor: move;
     }
     .selected-item > * {
-        margin-right: 0.5rem;
         display: block;
     }
     .selected-item button {
@@ -45,6 +44,7 @@
     .selected-item .item-info {
         display: flex;
         align-items: start;
+        margin-right: 0.5rem;
     }
     .selected-item > img {
         object-fit: cover;


### PR DESCRIPTION
Now:
<img width="1240" height="228" alt="image" src="https://github.com/user-attachments/assets/36e2b482-fdfc-498f-879a-ee2858635773" />

‌Before:
<img width="1242" height="247" alt="image" src="https://github.com/user-attachments/assets/5c6478a8-d696-4c3f-8829-148426b3c8ce" />
