### PR TITLE
`pat-contentbrowser` add button improvements [5.4.x - Plone 6.1]

### DIFF
--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -536,7 +536,7 @@
                                 in:fly|local={{ duration: 500 }}
                             >
                                 <div class="levelToolbar">
-                                    {#if i == 0 && $config.mode == "browse"}
+                                    {#if i == 0 && levels.length > 1 && $config.mode == "browse"}
                                         <button
                                             type="button"
                                             class="btn btn-link btn-xs ps-0"
@@ -552,7 +552,7 @@
                                     {#if i == levels.length - 1}
                                         {#if level.selectable && !level.showFilter && !previewItem.UID}
                                             <button
-                                                class="btn btn-xs btn-outline-primary d-flex align-items-center"
+                                                class="btn btn-xs btn-primary d-flex align-items-center ps-1"
                                                 title={_t("select ${level_path}", {
                                                     level_path:
                                                         level.Title || itemId(level),
@@ -562,7 +562,7 @@
                                                     addItem(level)}
                                                 ><svg
                                                     use:resolveIcon={{
-                                                        iconName: "plus",
+                                                        iconName: "check",
                                                     }}
                                                 />
                                                 <span class="select-button-ellipsis"
@@ -734,14 +734,14 @@
                                 <div class="selectLevel me-3">
                                     {#if isSelectable(previewItem)}
                                         <button
-                                            class="btn btn-xs btn-outline-primary d-flex align-items-center"
+                                            class="btn btn-xs btn-primary d-flex align-items-center ps-1"
                                             title={_t("select ${preview_path}", {
                                                 preview_path: previewItem.Title,
                                             })}
                                             on:click|preventDefault={() =>
                                                 addItem(previewItem)}
                                             ><svg
-                                                use:resolveIcon={{ iconName: "plus" }}
+                                                use:resolveIcon={{ iconName: "check" }}
                                             />
                                             <span class="select-button-ellipsis"
                                                 >{previewItem.Title}</span
@@ -809,10 +809,10 @@
                         <div class="preview" in:fly|local={{ duration: 500 }}>
                             <div class="levelToolbar">
                                 <button
-                                    class="btn btn-xs btn-outline-primary d-flex align-items-center"
+                                    class="btn btn-xs btn-primary d-flex align-items-center ps-1"
                                     title={_t("add selected items")}
                                     on:click|preventDefault={addSelectedItems}
-                                    ><svg use:resolveIcon={{ iconName: "plus" }} />
+                                    ><svg use:resolveIcon={{ iconName: "check" }} />
                                     <span class="select-button-ellipsis"
                                         >{_t("add selected items")}</span
                                     >
@@ -1006,7 +1006,7 @@
 
     .select-button-ellipsis {
         white-space: nowrap;
-        max-width: 150px;
+        max-width: 220px;
         text-overflow: ellipsis;
         overflow: hidden;
     }


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Note: this needs backported CMFPlone robottest also, because of the changed CSS selector. See https://github.com/plone/Products.CMFPlone/commit/5f59483d2c09516f2181becaa3adf00ca2711dc1 