### PR TITLE
fix(pat-autotoc): Fix missing selector for invalidation marker

### DIFF
--- a/src/pat/autotoc/autotoc.js
+++ b/src/pat/autotoc/autotoc.js
@@ -177,7 +177,7 @@ export default Base.extend({
 
     validation_marker: function () {
         for (const tab of this.tabs) {
-            if (tab.section.querySelectorAll(":invalid").length > 0) {
+            if (tab.section.querySelectorAll(":invalid, .invalid-feedback").length > 0) {
                 tab.nav.classList.add("invalid");
             } else {
                 tab.nav.classList.remove("invalid");


### PR DESCRIPTION
extend the selector list for marking tabs with invalid class. the standard plone error snippet in forms use

```
<div class="invalid-feedback"
       tal:content="view/message">Error</div>
```

if the field with the error are not required, then the class `invalid-feedback` should use as marker.

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----


Closes #1596

