### PR TITLE
fix(pat-select2): Show predefined value for single-select widgets.

### DIFF
--- a/src/pat/select2/select2.js
+++ b/src/pat/select2/select2.js
@@ -217,7 +217,6 @@ export default Base.extend({
                     this.options.multiple === undefined ? true : this.options.multiple;
                 this.options.ajax = this.options.ajax || {};
                 this.options.ajax.url = this.options.vocabularyUrl;
-                // XXX removing the following function does'nt break tests. dead code?
                 this.options.initSelection = ($el, callback) => {
                     const data = [];
                     const value = $el.val();

--- a/src/pat/select2/select2.js
+++ b/src/pat/select2/select2.js
@@ -221,10 +221,18 @@ export default Base.extend({
                     const data = [];
                     const value = $el.val();
                     for (const val of value.split(this.options.separator)) {
+                        if (val === "") {
+                            // Skip empty values, e.g. from an empty input.
+                            continue;
+                        }
                         const _val = utils.removeHTML(val);
                         data.push({ id: _val, text: _val });
                     }
-                    callback(data);
+                    // Select2 v3 expects a single object for single-select
+                    // widgets and an array for multi-select widgets. Passing an
+                    // array to a single select leaves `data.text` undefined and
+                    // the pre-set value is not rendered.
+                    callback(this.options.multiple ? data : data[0] || null);
                 };
             }
 

--- a/src/pat/select2/select2.test.js
+++ b/src/pat/select2/select2.test.js
@@ -123,6 +123,27 @@ describe("Select2", function () {
         expect($(el).parent().find(".select2-chosen").text()).toEqual("Europe/Vienna");
     });
 
+    it("renders the preset value of a single-select select widget", async function () {
+        document.body.innerHTML = `
+            <select class="pat-select2">
+                <option value="Europe/Paris">Europe/Paris</option>
+                <option value="Europe/Vienna" selected>Europe/Vienna</option>
+            </select>
+        `;
+
+        registry.scan(document.body);
+        await utils.timeout(1);
+
+        const el = document.querySelector("select.pat-select2");
+        // For a native <select>, select2 v3 attaches extra metadata to the
+        // data object (element, disabled, locked, ...), so match a subset.
+        expect($(el).select2("data")).toMatchObject({
+            id: "Europe/Vienna",
+            text: "Europe/Vienna",
+        });
+        expect($(el).parent().find(".select2-chosen").text()).toEqual("Europe/Vienna");
+    });
+
     it("displays the vocabulary when clicking an empty checkbox", async function () {
         document.body.innerHTML = `
           <input type="hidden"

--- a/src/pat/select2/select2.test.js
+++ b/src/pat/select2/select2.test.js
@@ -100,6 +100,29 @@ describe("Select2", function () {
         expect(select2.options.ajax.url).toEqual("select2-users-vocabulary");
     });
 
+    it("renders the preset value of a single-select input widget", async function () {
+        document.body.innerHTML = `
+            <input class="pat-select2"
+                   value="Europe/Vienna"
+                   data-pat-select2='{
+                       "multiple": false,
+                       "allowNewItems": "false",
+                       "vocabularyUrl": "select2-timezone-vocabulary"
+                   }'
+                   />
+        `;
+
+        registry.scan(document.body);
+        await utils.timeout(1);
+
+        const el = document.querySelector("input.pat-select2");
+        expect($(el).select2("data")).toEqual({
+            id: "Europe/Vienna",
+            text: "Europe/Vienna",
+        });
+        expect($(el).parent().find(".select2-chosen").text()).toEqual("Europe/Vienna");
+    });
+
     it("displays the vocabulary when clicking an empty checkbox", async function () {
         document.body.innerHTML = `
           <input type="hidden"


### PR DESCRIPTION
Single-select widgets did not show their predefined value. This is now fixed.

fixed:

<img width="724" height="268" alt="image" src="https://github.com/user-attachments/assets/f8731e37-4d0c-4310-bb70-c0984d381a37" />

not fixed:

<img width="724" height="268" alt="image" src="https://github.com/user-attachments/assets/7629d50f-fa47-41e4-8deb-61502124daa5" />



- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

