### PR TITLE
`pat-querystring`: fix issue with the new select2 native events

### DIFF
--- a/src/pat/querystring/querystring.js
+++ b/src/pat/querystring/querystring.js
@@ -111,9 +111,15 @@ Criteria.prototype = {
             width: self.options.indexWidth,
             placeholder: _t("Select criteria"),
         });
-        self.$index.on("change", function (e) {
+        self.$index.on("change", function () {
+            // Read the value from the element rather than from the event's
+            // `val` property. Select2 v3 fires a jQuery `change` event carrying
+            // a `val` property, but pat-select2 also re-dispatches a native
+            // `change` event (for native listeners), which jQuery's `change`
+            // handler catches as well. On that second invocation `e.val` would
+            // be undefined. Reading `self.$index.val()` is correct in both cases.
             self.removeValue();
-            self.createOperator(e.val);
+            self.createOperator(self.$index.val());
             self.createClear();
             self.trigger("index-changed");
         });

--- a/src/pat/querystring/querystring.test.js
+++ b/src/pat/querystring/querystring.test.js
@@ -169,4 +169,41 @@ describe("Querystring", function () {
         global.fetch.mockClear();
         delete global.fetch;
     });
+
+    it("handles a native change event on the index select", async function () {
+        // Regression test: pat-select2 re-dispatches a native `change` event in
+        // addition to the Select2 v3 jQuery `change` event. jQuery's `change`
+        // handler catches both, so the index handler fires twice — once with
+        // `e.val` set (Select2) and once with `e.val` undefined (native event).
+        // The handler must read the value from the element, not from `e.val`,
+        // otherwise the native invocation passes `undefined` to createOperator
+        // and throws.
+        const criterias = await import("./test-querystringcriteria.json");
+        global.fetch = jest.fn().mockImplementation(mockFetch(criterias));
+
+        registry.scan(document.body);
+        await utils.timeout(1);
+
+        // The last criteria row is the empty one a user fills in.
+        const indexSelects = document.querySelectorAll(
+            ".querystring-criteria-index select"
+        );
+        const $index = $(indexSelects[indexSelects.length - 1]);
+        const wrapper = $index.parents(".querystring-criteria-wrapper")[0];
+
+        // Pick a value and fire ONLY a native change event (no Select2 `val`).
+        $index.val("Title");
+        $index[0].dispatchEvent(new Event("change", { bubbles: true }));
+        await utils.timeout(1);
+
+        // The operator select must have been built for the selected index.
+        const operator = wrapper.querySelector(
+            ".querystring-criteria-operator select"
+        );
+        expect(operator).not.toBeNull();
+        expect(operator.options.length).toBeGreaterThan(0);
+
+        global.fetch.mockClear();
+        delete global.fetch;
+    });
 });


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.
