### PR TITLE
fix(modal): title extraction method (jquery removed .context)

### DIFF
--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -652,7 +652,7 @@ export default Base.extend({
         self.$wrapper.addClass("image-modal");
         var src = self.$el.attr("href");
         var srcset = self.$el.attr("data-modal-srcset") || "";
-        var title = $.trim(self.$el.context.innerText) || "Image";
+        var title = $.trim(self.$el.text()) || "Image";
         // XXX aria?
         self.$raw = $(
             "<div><h1>" +


### PR DESCRIPTION
Fixes `JSError: Uncaught TypeError: can't access property "innerText", e.$el.context is undefined ` if `data-pat-plone-modal="image: true"`