### PR TITLE
pat-filemanager: use current page language to render the datetime

### DIFF
--- a/src/pat/filemanager/src/utils/format.test.ts
+++ b/src/pat/filemanager/src/utils/format.test.ts
@@ -16,12 +16,12 @@ describe("formatDate", () => {
         expect(formatDate(PAST)).not.toBe("");
     });
 
-    it("respects the document language (de)", () => {
+    it("respects the document language (es)", () => {
         const originalLang = document.documentElement.lang;
-        document.documentElement.lang = "de";
+        document.documentElement.lang = "es";
         const formatted = formatDate(PAST);
-        // "Jan." is the short month in German for January (January 1st, 2020)
-        expect(formatted).toContain("Jan.");
+        // "ene" is the short month in Spanish for January (January 1st, 2020)
+        expect(formatted).toContain("ene");
         document.documentElement.lang = originalLang;
     });
 

--- a/src/pat/filemanager/src/utils/format.test.ts
+++ b/src/pat/filemanager/src/utils/format.test.ts
@@ -15,6 +15,24 @@ describe("formatDate", () => {
     it("formats a real date string", () => {
         expect(formatDate(PAST)).not.toBe("");
     });
+
+    it("respects the document language (de)", () => {
+        const originalLang = document.documentElement.lang;
+        document.documentElement.lang = "de";
+        const formatted = formatDate(PAST);
+        // "Jan." is the short month in German for January (January 1st, 2020)
+        expect(formatted).toContain("Jan.");
+        document.documentElement.lang = originalLang;
+    });
+
+    it("respects the document language (en)", () => {
+        const originalLang = document.documentElement.lang;
+        document.documentElement.lang = "en";
+        const formatted = formatDate(PAST);
+        // "Jan" is the short month in English for January
+        expect(formatted).toContain("Jan");
+        document.documentElement.lang = originalLang;
+    });
 });
 
 describe("formatSize", () => {

--- a/src/pat/filemanager/src/utils/format.ts
+++ b/src/pat/filemanager/src/utils/format.ts
@@ -10,10 +10,16 @@ function parseDate(value: unknown): Date | null {
     return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/** Detect the current UI language from the <html> tag, normalized for Intl. */
+function getLang(): string {
+    if (typeof document === "undefined") return "en";
+    return (document.documentElement.lang || "en").replace("_", "-");
+}
+
 export function formatDate(value: unknown): string {
     const date = parseDate(value);
     if (!date) return "";
-    return new Intl.DateTimeFormat(undefined, {
+    return new Intl.DateTimeFormat(getLang(), {
         year: "numeric",
         month: "short",
         day: "numeric",


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

My personal war here: the datetime in the new filemanager is shown in the browser language (because of the `undefined`  first parameter to `Intl.DateTimeFormat`).

That's why I introduce a `getLang` and get the language of the content.
