### PR TITLE
feat(core): Global lazy Intl polyfills and locale-sensitive date formatting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,8 +4,8 @@ const config = require("@patternslib/dev/jest.config.js");
 // config.setupFilesAfterEnv.push("./node_modules/@testing-library/jest-dom/extend-expect");
 config.setupFilesAfterEnv.push(path.resolve(__dirname, "./src/setup-tests.js"));
 config.transformIgnorePatterns = [
-    "/node_modules/(?!.pnpm/)(?!@patternslib/)(?!@plone/)(?!preact/)(?!screenfull/)(?!sinon/)(?!bootstrap/)(?!datatable/)(?!svelte/)(?!esm-env/).+\\.[t|j]sx?$",
-    "/node_modules/.pnpm/(?!@patternslib)(?!@plone)(?!preact)(?!screenfull)(?!sinon)(?!bootstrap)(?!datatable)(?!svelte)(?!esm-env)",
+    "/node_modules/(?!.pnpm/)(?!@patternslib/)(?!@plone/)(?!@formatjs/)(?!preact/)(?!screenfull/)(?!sinon/)(?!bootstrap/)(?!datatable/)(?!svelte/)(?!esm-env/).+\\.[t|j]sx?$",
+    "/node_modules/.pnpm/(?!@patternslib)(?!@plone)(?!@formatjs)(?!preact)(?!screenfull)(?!sinon)(?!bootstrap)(?!datatable)(?!svelte)(?!esm-env)",
 ];
 
 // Transforms. Order matters: Jest uses the first matching pattern, so the

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
     "dependencies": {
         "@11ty/eleventy-upgrade-help": "3.0.2",
+        "@formatjs/intl-datetimeformat": "^7.4.9",
         "@patternslib/pat-code-editor": "4.0.1",
         "@patternslib/patternslib": "9.10.6",
         "@plone/registry": "^2.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         version: 3.2.4(svelte@5.56.3(@typescript-eslint/types@8.57.2))
       svelte-preprocess:
         specifier: ^6.0.5
-        version: 6.0.5(@babel/core@7.29.7)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3(@typescript-eslint/types@8.57.2))(typescript@6.0.3)
+        version: 6.0.5(@babel/core@7.29.7)(postcss@8.5.15)(sass@1.101.0)(svelte@5.56.3(@typescript-eslint/types@8.57.2))(typescript@6.0.3)
       svelte-scrollto:
         specifier: ^0.2.0
         version: 0.2.0
@@ -2099,7 +2099,7 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   Select2@https://codeload.github.com/ivaynberg/select2/tar.gz/95a977f674b6938af55ec5f28b7772df93786c5c:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/ivaynberg/select2/tar.gz/95a977f674b6938af55ec5f28b7772df93786c5c}
+    resolution: {gitHosted: true, integrity: sha512-42On0yUzjhE/vNTVRT/+3wUwIpKyUGEW31PA1gFRv0j+OjgXJgo4aJVWCfjEpMa+O34PYKCfEdUN0OWaAEQ/6Q==, tarball: https://codeload.github.com/ivaynberg/select2/tar.gz/95a977f674b6938af55ec5f28b7772df93786c5c}
     version: 3.5.4
 
   a-sync-waterfall@1.0.1:
@@ -4922,8 +4922,8 @@ packages:
       webpack:
         optional: true
 
-  sass@1.100.0:
-    resolution: {integrity: sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==}
+  sass@1.101.0:
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -7676,8 +7676,8 @@ snapshots:
       prettier: 3.8.3
       regenerator-runtime: 0.14.1
       release-it: 20.2.0(@types/node@25.9.2)
-      sass: 1.100.0
-      sass-loader: 16.0.8(sass@1.100.0)(webpack@5.107.2(postcss@8.5.15))
+      sass: 1.101.0
+      sass-loader: 16.0.8(sass@1.101.0)(webpack@5.107.2(postcss@8.5.15))
       style-loader: 4.0.0(webpack@5.107.2(postcss@8.5.15))
       terser-webpack-plugin: 5.6.1(postcss@8.5.15)(webpack@5.107.2(postcss@8.5.15))
       timezone-mock: 1.4.2
@@ -11263,14 +11263,14 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.8(sass@1.100.0)(webpack@5.107.2(postcss@8.5.15)):
+  sass-loader@16.0.8(sass@1.101.0)(webpack@5.107.2(postcss@8.5.15)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      sass: 1.100.0
+      sass: 1.101.0
       webpack: 5.107.2(postcss@8.5.15)(webpack-cli@7.0.3)
 
-  sass@1.100.0:
+  sass@1.101.0:
     dependencies:
       chokidar: 5.0.0
       immutable: 5.1.6
@@ -11649,13 +11649,13 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.56.3(@typescript-eslint/types@8.57.2))
 
-  svelte-preprocess@6.0.5(@babel/core@7.29.7)(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3(@typescript-eslint/types@8.57.2))(typescript@6.0.3):
+  svelte-preprocess@6.0.5(@babel/core@7.29.7)(postcss@8.5.15)(sass@1.101.0)(svelte@5.56.3(@typescript-eslint/types@8.57.2))(typescript@6.0.3):
     dependencies:
       svelte: 5.56.3(@typescript-eslint/types@8.57.2)
     optionalDependencies:
       '@babel/core': 7.29.7
       postcss: 8.5.15
-      sass: 1.100.0
+      sass: 1.101.0
       typescript: 6.0.3
 
   svelte-scrollto@0.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@11ty/eleventy-upgrade-help':
         specifier: 3.0.2
         version: 3.0.2(posthtml@0.16.7)
+      '@formatjs/intl-datetimeformat':
+        specifier: ^7.4.9
+        version: 7.4.9
       '@patternslib/pat-code-editor':
         specifier: 4.0.1
         version: 4.0.1
@@ -989,6 +992,18 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@formatjs/bigdecimal@0.2.6':
+    resolution: {integrity: sha512-aPzKsGQOkQRHUEbyO/ZtYfr4EqaBQnSs6U4tzTla1xBnIdEHgY2GqEqso28UMwWRkzKqqTj5+/6BmuOsRkfn2A==}
+
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
+
+  '@formatjs/intl-datetimeformat@7.4.9':
+    resolution: {integrity: sha512-dpGGhYrAq+3X0ME9V161qCgQcaY1IGhKUR6y58mep53qd3sg86ai+WkjlLbP0Hr2TFpPU9Z+i4oCxh1RUvW6mA==}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
 
   '@fullcalendar/adaptive@5.11.5':
     resolution: {integrity: sha512-yGXS7u1EOKyNdNuwepDEgh2e52jaxYu9D8A4ptdKEPtBMqdStShMp/4NNN8QEJJr50a5qdJTZRA8q1HAdq2USQ==}
@@ -6899,6 +6914,19 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@formatjs/bigdecimal@0.2.6': {}
+
+  '@formatjs/fast-memoize@3.1.6': {}
+
+  '@formatjs/intl-datetimeformat@7.4.9':
+    dependencies:
+      '@formatjs/bigdecimal': 0.2.6
+      '@formatjs/intl-localematcher': 0.8.10
+
+  '@formatjs/intl-localematcher@0.8.10':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
 
   '@fullcalendar/adaptive@5.11.5':
     dependencies:

--- a/src/core/intl-loader.js
+++ b/src/core/intl-loader.js
@@ -18,7 +18,7 @@ export async function ensureIntlSupport(lang) {
         ) {
             return;
         }
-    } catch (e) {
+    } catch {
         // Fall through to loading polyfill if supportedLocalesOf fails
     }
 

--- a/src/core/intl-loader.js
+++ b/src/core/intl-loader.js
@@ -1,0 +1,42 @@
+/**
+ * Global Intl polyfill loader for Plone Mockup.
+ * Detects if the current browser supports the site's language and lazily
+ * loads the required polyfills and locale data if not.
+ */
+
+export async function ensureIntlSupport(lang) {
+    if (!lang) return;
+    const normalizedLang = lang.replace("_", "-");
+    const baseLang = normalizedLang.split("-")[0];
+
+    // Check if natively supported
+    try {
+        if (
+            typeof Intl !== "undefined" &&
+            Intl.DateTimeFormat &&
+            Intl.DateTimeFormat.supportedLocalesOf(normalizedLang).length > 0
+        ) {
+            return;
+        }
+    } catch (e) {
+        // Fall through to loading polyfill if supportedLocalesOf fails
+    }
+
+    console.info(`Locale "${normalizedLang}" not supported. Loading polyfill...`);
+
+    // Load polyfill core if needed
+    if (typeof Intl === "undefined" || !Intl.DateTimeFormat) {
+        await import("@formatjs/intl-datetimeformat/polyfill.js");
+    }
+
+    // Load specific locale data via Webpack dynamic chunk.
+    // Note: We use the base language (e.g., 'eu' from 'eu_ES') as most
+    // polyfills are grouped by base language.
+    // We use a relative path to node_modules to bypass problematic package exports
+    // that confuse Webpack 5 when using dynamic imports with template strings.
+    try {
+        await import(`../../node_modules/@formatjs/intl-datetimeformat/locale-data/${baseLang}.js`);
+    } catch (e) {
+        console.warn(`Could not load Intl data for ${baseLang}`, e);
+    }
+}

--- a/src/core/intl-loader.js
+++ b/src/core/intl-loader.js
@@ -24,18 +24,25 @@ export async function ensureIntlSupport(lang) {
 
     console.info(`Locale "${normalizedLang}" not supported. Loading polyfill...`);
 
-    // Load polyfill core if needed
-    if (typeof Intl === "undefined" || !Intl.DateTimeFormat) {
-        await import("@formatjs/intl-datetimeformat/polyfill.js");
+    // Load polyfill core if native support is missing for this locale.
+    try {
+        // Use polyfill-force to ensure we get a version that supports adding locale data,
+        // as native versions might not have the hooks for the locale-data files.
+        await import("@formatjs/intl-datetimeformat/polyfill-force.js");
+    } catch (e) {
+        console.error("Failed to load Intl polyfill core", e);
     }
 
     // Load specific locale data via Webpack dynamic chunk.
-    // Note: We use the base language (e.g., 'eu' from 'eu_ES') as most
-    // polyfills are grouped by base language.
-    // We use a relative path to node_modules to bypass problematic package exports
-    // that confuse Webpack 5 when using dynamic imports with template strings.
     try {
-        await import(`../../node_modules/@formatjs/intl-datetimeformat/locale-data/${baseLang}.js`);
+        // Use the package name with explicit .js extension.
+        // We have an alias in webpack.config.js to help resolve this path correctly
+        // without triggering package export warnings in Webpack 5.
+        await import(`@formatjs/intl-datetimeformat/locale-data/${baseLang}.js`);
+
+        if (Intl.DateTimeFormat.supportedLocalesOf(normalizedLang).length > 0) {
+            console.info(`Locale "${normalizedLang}" is now supported.`);
+        }
     } catch (e) {
         console.warn(`Could not load Intl data for ${baseLang}`, e);
     }

--- a/src/core/intl-loader.test.js
+++ b/src/core/intl-loader.test.js
@@ -1,0 +1,70 @@
+import { ensureIntlSupport } from "./intl-loader";
+
+describe("intl-loader", () => {
+    let originalDateTimeFormat;
+
+    beforeAll(() => {
+        originalDateTimeFormat = Intl.DateTimeFormat;
+        jest.spyOn(console, "info").mockImplementation(() => {});
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterAll(() => {
+        Intl.DateTimeFormat = originalDateTimeFormat;
+        console.info.mockRestore();
+        console.warn.mockRestore();
+        console.error.mockRestore();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Reset to original before each test to have a clean state
+        // Note: some polyfill effects might persist if they touch other global objects
+        Intl.DateTimeFormat = originalDateTimeFormat;
+    });
+
+    it("should detect supported locales correctly", async () => {
+        // 'en' should be supported
+        await ensureIntlSupport("en");
+        expect(console.info).not.toHaveBeenCalledWith(expect.stringContaining("not supported"));
+    });
+
+    it("should handle locale normalization", async () => {
+        await ensureIntlSupport("pt_BR");
+        // pt-BR is likely supported, but we just check it doesn't crash
+    });
+
+    it("should load polyfill and provide Basque (eu) formatting", async () => {
+        // We force a mock that says 'eu' is NOT supported
+        const mockSupportedLocalesOf = jest.fn().mockImplementation((locales) => {
+            const l = Array.isArray(locales) ? locales[0] : locales;
+            if (l.startsWith('eu')) return [];
+            return originalDateTimeFormat.supportedLocalesOf(locales);
+        });
+        
+        // We need to mock the property because it might be a getter
+        Object.defineProperty(Intl, 'DateTimeFormat', {
+            value: class extends originalDateTimeFormat {
+                static supportedLocalesOf = mockSupportedLocalesOf;
+            },
+            configurable: true
+        });
+
+        await ensureIntlSupport("eu");
+
+        expect(mockSupportedLocalesOf).toHaveBeenCalled();
+        expect(console.info).toHaveBeenCalledWith(expect.stringContaining("not supported"));
+
+        // After ensureIntlSupport, Intl.DateTimeFormat should have been replaced by the polyfill
+        // since we used polyfill-force.js (or at least it was called).
+        
+        // Verify formatting using UTC to avoid timezone shifts
+        const date = new Date(Date.UTC(2020, 5, 1)); // June 1st UTC
+        const dtf = new Intl.DateTimeFormat("eu", { month: "short", timeZone: "UTC" });
+        const formatted = dtf.format(date);
+        
+        // Basque short month for June is 'eka.'
+        expect(formatted.toLowerCase()).toContain("eka");
+    });
+});

--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -1,9 +1,10 @@
 <script>
     import utils from "@patternslib/patternslib/src/core/utils";
-    import { getContext } from "svelte";
+    import { getContext, onMount } from "svelte";
     import * as animateScroll from "svelte-scrollto";
     import { fly } from "svelte/transition";
     import _t from "../../../core/i18n-wrapper";
+    import { ensureIntlSupport } from "../../../core/intl-loader";
     import Upload from "../../upload/upload";
     import contentStore from "./ContentStore";
     import {
@@ -471,6 +472,11 @@
             },
         };
     }
+
+    onMount(async () => {
+        const lang = document.documentElement.lang || "en";
+        await ensureIntlSupport(lang);
+    });
 
     $effect(() => {
         if ($showContentBrowser) {

--- a/src/pat/filemanager/src/App.svelte
+++ b/src/pat/filemanager/src/App.svelte
@@ -122,6 +122,24 @@
 
     onMount(async () => {
         await ensureIntlSupport(getLang());
+    });
+    
+    onMount(() => {
+        contents.load();
+
+        function onPopState(event) {
+            const ctx = event.state?.contextUrl;
+            if (ctx && ctx !== contents.contextUrl) {
+                isRestoringHistory = true;
+                contents.navigateTo(ctx).finally(() => {
+                    isRestoringHistory = false;
+                });
+            }
+        }
+        window.addEventListener("popstate", onPopState);
+        return () => window.removeEventListener("popstate", onPopState);
+    });
+        await ensureIntlSupport(getLang());
         contents.load();
 
         function onPopState(event) {

--- a/src/pat/filemanager/src/App.svelte
+++ b/src/pat/filemanager/src/App.svelte
@@ -140,6 +140,24 @@
         return () => window.removeEventListener("popstate", onPopState);
     });
         await ensureIntlSupport(getLang());
+    });
+    
+    onMount(() => {
+        contents.load();
+
+        function onPopState(event) {
+            const ctx = event.state?.contextUrl;
+            if (ctx && ctx !== contents.contextUrl) {
+                isRestoringHistory = true;
+                contents.navigateTo(ctx).finally(() => {
+                    isRestoringHistory = false;
+                });
+            }
+        }
+        window.addEventListener("popstate", onPopState);
+        return () => window.removeEventListener("popstate", onPopState);
+    });
+        await ensureIntlSupport(getLang());
         contents.load();
 
         function onPopState(event) {

--- a/src/pat/filemanager/src/App.svelte
+++ b/src/pat/filemanager/src/App.svelte
@@ -120,44 +120,15 @@
 
     let isRestoringHistory = false;
 
+    // Lazily load Intl polyfills for the site language. Kept in its own
+    // async onMount so the listener-owning onMount below can stay synchronous
+    // and return its cleanup function (an async onMount returns a Promise,
+    // which Svelte ignores, leaking the listener).
     onMount(async () => {
         await ensureIntlSupport(getLang());
     });
-    
-    onMount(() => {
-        contents.load();
 
-        function onPopState(event) {
-            const ctx = event.state?.contextUrl;
-            if (ctx && ctx !== contents.contextUrl) {
-                isRestoringHistory = true;
-                contents.navigateTo(ctx).finally(() => {
-                    isRestoringHistory = false;
-                });
-            }
-        }
-        window.addEventListener("popstate", onPopState);
-        return () => window.removeEventListener("popstate", onPopState);
-    });
-        await ensureIntlSupport(getLang());
-    });
-    
     onMount(() => {
-        contents.load();
-
-        function onPopState(event) {
-            const ctx = event.state?.contextUrl;
-            if (ctx && ctx !== contents.contextUrl) {
-                isRestoringHistory = true;
-                contents.navigateTo(ctx).finally(() => {
-                    isRestoringHistory = false;
-                });
-            }
-        }
-        window.addEventListener("popstate", onPopState);
-        return () => window.removeEventListener("popstate", onPopState);
-    });
-        await ensureIntlSupport(getLang());
         contents.load();
 
         function onPopState(event) {

--- a/src/pat/filemanager/src/App.svelte
+++ b/src/pat/filemanager/src/App.svelte
@@ -1,6 +1,8 @@
 <script>
     import { onMount, setContext } from "svelte";
     import logger from "@patternslib/patternslib/src/core/logging";
+    import { ensureIntlSupport } from "../../../core/intl-loader";
+    import { getLang } from "./utils/format.ts";
     import { ConfigStore } from "./stores/ConfigStore.svelte.ts";
     import { ContentsStore } from "./stores/ContentsStore.svelte.ts";
     import { ColumnsStore } from "./stores/ColumnsStore.svelte.ts";
@@ -118,7 +120,8 @@
 
     let isRestoringHistory = false;
 
-    onMount(() => {
+    onMount(async () => {
+        await ensureIntlSupport(getLang());
         contents.load();
 
         function onPopState(event) {

--- a/src/pat/filemanager/src/utils/format.ts
+++ b/src/pat/filemanager/src/utils/format.ts
@@ -19,13 +19,19 @@ export function getLang(): string {
 export function formatDate(value: unknown): string {
     const date = parseDate(value);
     if (!date) return "";
-    return new Intl.DateTimeFormat(getLang(), {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-    }).format(date);
+    const lang = getLang();
+    try {
+        return new Intl.DateTimeFormat(lang, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        }).format(date);
+    } catch (e) {
+        console.error(`Error formatting date for locale "${lang}":`, e);
+        return date.toLocaleString(); // Fallback
+    }
 }
 
 /**

--- a/src/pat/filemanager/src/utils/format.ts
+++ b/src/pat/filemanager/src/utils/format.ts
@@ -11,7 +11,7 @@ function parseDate(value: unknown): Date | null {
 }
 
 /** Detect the current UI language from the <html> tag, normalized for Intl. */
-function getLang(): string {
+export function getLang(): string {
     if (typeof document === "undefined") return "en";
     return (document.documentElement.lang || "en").replace("_", "-");
 }

--- a/src/pat/structure/structure.js
+++ b/src/pat/structure/structure.js
@@ -1,4 +1,5 @@
 import Base from "@patternslib/patternslib/src/core/base";
+import { ensureIntlSupport } from "../../core/intl-loader";
 
 export default Base.extend({
     name: "structure",
@@ -150,6 +151,8 @@ export default Base.extend({
         this.options.pattern = this;
         this.options.language =
             document.querySelector("html").getAttribute("lang") || "en";
+
+        await ensureIntlSupport(this.options.language);
 
         // the ``attributes`` options key is not compatible with backbone,
         // but queryHelper that will be constructed by the default

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,6 +166,13 @@ module.exports = () => {
         extensions: [".js", ".ts", ".json", ".wasm", ".svelte"],
         mainFields: ["browser", "module", "main"],
         conditionNames: ["svelte", "browser", "require"],
+        alias: {
+            ...config.resolve.alias,
+            "@formatjs/intl-datetimeformat/locale-data": path.resolve(
+                __dirname,
+                "node_modules/@formatjs/intl-datetimeformat/locale-data"
+            ),
+        },
     };
 
     // NOTE: above doesn't work.


### PR DESCRIPTION
### Summary
This PR improves date formatting across Plone patterns and introduces a global mechanism for lazily loading  polyfills and locale data.

### Key Changes
- **Locale-Sensitive Formatting**: Updated `formatDate` in `pat-filemanager` to respect the Plone site language from `<html lang='...'>` (normalized for `Intl`).
- **Lazy Intl Polyfills**: Added `src/core/intl-loader.js` which detects if the browser natively supports the current locale. If not, it lazily fetches the `@formatjs/intl-datetimeformat` polyfill and specific locale data chunks. This ensures languages like Basque (`eu`) are correctly supported even in limited environments.
- **Pattern Integration**: The polyfill loader is now part of the initialization for `pat-filemanager`, `pat-contentbrowser`, and `pat-structure`.
- **Build Support**: Configured Webpack aliases to handle dynamic imports of locale data smoothly, enabling clean builds and efficient chunking.
- **Functional Testing**: Added `src/core/intl-loader.test.js` verifying that missing locales trigger polyfill loading and result in correct language-specific output.

### Why?
Previously, date formatting often defaulted to the browser's language, leading to UI inconsistencies in Plone sites with a different language than the user's OS. Furthermore, many browsers lack data for certain languages (like `eu`), causing formatting to fallback to English or fail. This PR provides a robust, per-language lazy-loading solution that fixes these issues for all patterns with minimal overhead.