### PR TITLE
Fix `pat-structure` folder contents sort order [5.6.x]

### DIFF
--- a/src/pat/structure/js/views/table.js
+++ b/src/pat/structure/js/views/table.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import _ from "underscore";
 import _t from "../../../../core/i18n-wrapper";
-import events from "@patternslib/patternslib/src/core/events";
 import registry from "@patternslib/patternslib/src/core/registry";
 import BaseView from "../../../../core/ui/views/base";
 import TableRowView from "./tablerow";
@@ -125,10 +124,8 @@ export default BaseView.extend({
         if (this.collection.length) {
             const container = $("tbody", this.$el);
 
-            const collection_length = this.collection.length;
-            let collection_cnt = 0;
-
-            this.collection.each(async (result) => {
+            // Create one row view per result, keeping the collection order.
+            const rowViews = this.collection.map((result) => {
                 this.dateColumns.map((col) => {
                     // empty column instead of displaying "None".
                     if (
@@ -139,41 +136,22 @@ export default BaseView.extend({
                     }
                 });
 
-                const view = new TableRowView({
+                return new TableRowView({
                     model: result,
                     app: this.app,
                     table: this,
                 });
-                await view.render();
-                container.append(view.el);
-
-                // Throw the ``table_row_rendering_finished`` event after all table rows have finished rendering.
-                collection_cnt++;
-                if (collection_cnt === collection_length) {
-                    this.el.dispatchEvent(new Event("table_row_rendering_finished"));
-                }
             });
 
-            // NOTE: this is based on the concept of awaiting an event.
-            // See this Stackoverflow answer here:
+            // Render all rows in parallel (row rendering is async because of
+            // icon resolution), but wait for all of them to finish before
+            // appending. Appending in ``rowViews`` order guarantees the DOM
+            // order matches the collection order – otherwise rows would be
+            // appended in the arbitrary order their async render resolves,
+            // which corrupts the sorting.
+            await Promise.all(rowViews.map((view) => view.render()));
+            rowViews.forEach((view) => container.append(view.el));
 
-            // https://stackoverflow.com/a/44746691/1337474
-            // When the last table row has finished rendering, throw an event.
-            // For this "table_row_rendering_finished" event we're a-waiting for.
-            // And after that we can scan the table.
-            const table_row_rendering_finished = () =>
-                new Promise((resolve) =>
-                    events.add_event_listener(
-                        this.el,
-                        "table_row_rendering_finished",
-                        "table_row_rendering_finished__listener",
-                        resolve,
-                        { once: true }
-                    )
-                );
-
-            await table_row_rendering_finished();
-            events.remove_event_listener = (this.el, "table_row_rendering_finished__listener"); // prettier-ignore
             registry.scan(this.$el);
 
             // Set the context (again) after rerendering. If render was called after a collection sync – which is the


### PR DESCRIPTION
### Problem
In pat-structure (folder_contents) the listing is sorted incorrectly once a folder contains more than a few items. The server response (@@getVocabulary) is correctly ordered — only the rendered table is scrambled.

### Root cause
The table row rendering in src/pat/structure/js/views/table.js iterates the collection with an async callback that appends each row only after await view.render(). Since collection.each does not await and row rendering is async (icon resolution, action menu), rows get appended in the order their render promises resolve rather than in collection order. With few rows this is invisible; with more rows the race scrambles the DOM order, and DataTables (order: []) does not re-sort it.

### Why it only appeared in 5.6.0+
The race has existed since 5.4.x but was masked: DataTables was initialized with order: [0, "asc"], which re-sorted rows by the hidden _sort (server order) column on every draw. [#1552](https://github.com/plone/buildout.coredev/issues/1552) changed this to order: [] — correct in intent, but it removed the safety net that had been hiding the race, so the bug became visible in 5.6.0. Not reproducible in Plone 6.1 / mockup 5.4.x.

### Fix
Build the row views in collection order, render them in parallel via Promise.all, then append them in order — so the DOM order always matches the collection order, independent of any DataTables ordering setting. The now-obsolete table_row_rendering_finished event mechanism is removed.