### PR TITLE
fix(pat-structure): keep table rows in collection order

### DIFF
--- a/src/pat/structure/js/views/table.js
+++ b/src/pat/structure/js/views/table.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import _ from "underscore";
 import _t from "../../../../core/i18n-wrapper";
-import events from "@patternslib/patternslib/src/core/events";
 import registry from "@patternslib/patternslib/src/core/registry";
 import BaseView from "../../../../core/ui/views/base";
 import TableRowView from "./tablerow";
@@ -125,10 +124,8 @@ export default BaseView.extend({
         if (this.collection.length) {
             const container = $("tbody", this.$el);
 
-            const collection_length = this.collection.length;
-            let collection_cnt = 0;
-
-            this.collection.each(async (result) => {
+            // Create one row view per result, keeping the collection order.
+            const rowViews = this.collection.map((result) => {
                 this.dateColumns.map((col) => {
                     // empty column instead of displaying "None".
                     if (
@@ -139,41 +136,22 @@ export default BaseView.extend({
                     }
                 });
 
-                const view = new TableRowView({
+                return new TableRowView({
                     model: result,
                     app: this.app,
                     table: this,
                 });
-                await view.render();
-                container.append(view.el);
-
-                // Throw the ``table_row_rendering_finished`` event after all table rows have finished rendering.
-                collection_cnt++;
-                if (collection_cnt === collection_length) {
-                    this.el.dispatchEvent(new Event("table_row_rendering_finished"));
-                }
             });
 
-            // NOTE: this is based on the concept of awaiting an event.
-            // See this Stackoverflow answer here:
+            // Render all rows in parallel (row rendering is async because of
+            // icon resolution), but wait for all of them to finish before
+            // appending. Appending in ``rowViews`` order guarantees the DOM
+            // order matches the collection order – otherwise rows would be
+            // appended in the arbitrary order their async render resolves,
+            // which corrupts the sorting.
+            await Promise.all(rowViews.map((view) => view.render()));
+            rowViews.forEach((view) => container.append(view.el));
 
-            // https://stackoverflow.com/a/44746691/1337474
-            // When the last table row has finished rendering, throw an event.
-            // For this "table_row_rendering_finished" event we're a-waiting for.
-            // And after that we can scan the table.
-            const table_row_rendering_finished = () =>
-                new Promise((resolve) =>
-                    events.add_event_listener(
-                        this.el,
-                        "table_row_rendering_finished",
-                        "table_row_rendering_finished__listener",
-                        resolve,
-                        { once: true }
-                    )
-                );
-
-            await table_row_rendering_finished();
-            events.remove_event_listener = (this.el, "table_row_rendering_finished__listener"); // prettier-ignore
             registry.scan(this.$el);
 
             // Set the context (again) after rerendering. If render was called after a collection sync – which is the


### PR DESCRIPTION
Cherry-pick of https://github.com/plone/mockup/pull/1611

The table row rendering iterated the collection with an async callback (`collection.each(async ...)`) that appended each row only after awaiting `view.render()`. Row rendering is async (it awaits icon resolution), so rows were appended in the arbitrary order their render promises resolved rather than in collection order, corrupting the sort order of the folder contents.

This stayed hidden until 5.6.0: DataTables was initialized with `order: [0, "asc"]`, which re-sorted the rows by the hidden `_sort` column (the server order index) on every draw and thus masked the race. Commit 57cd7dd ("Fix ordering logic.") changed this to `order: []`, removing the safety net and exposing the underlying bug.

Fix the root cause: build the row views in collection order, render them all in parallel via `Promise.all`, then append them in order. This guarantees the DOM order matches the collection order regardless of the DataTables ordering settings. The now-obsolete
`table_row_rendering_finished` event dance and its `events` import are removed.

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

