### PR TITLE
Allow selecting the buildout.coredev branch for robot tests

### DIFF
--- a/.github/workflows/coredev-robot-tests.yml
+++ b/.github/workflows/coredev-robot-tests.yml
@@ -1,5 +1,8 @@
 name: Robot Tests (Coredev)
 
+# Trigger commands (PR comments):
+#   /run-coredev-robottests        -> tests against the buildout.coredev default branch
+#   /run-coredev-6.3-robottests    -> tests against an explicit coredev branch (6.1, 6.2, 6.3, ...)
 on:
   issue_comment:
     types: [created]
@@ -8,17 +11,51 @@ jobs:
   create-check:
     if: >
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/run-coredev-robottests')
+      contains(github.event.comment.body, '/run-coredev') &&
+      contains(github.event.comment.body, '-robottests')
     runs-on: ubuntu-latest
     outputs:
+      matched: ${{ steps.create.outputs.matched }}
+      coredev_branch: ${{ steps.create.outputs.coredev_branch }}
       check_run_id: ${{ steps.create.outputs.check_run_id }}
       sha: ${{ steps.create.outputs.sha }}
     steps:
-      - name: Get PR SHA and create Check Run
+      - name: Parse command, get PR SHA and create Check Run
         id: create
         uses: actions/github-script@v9
         with:
           script: |
+            const body = context.payload.comment.body;
+            // "/run-coredev-robottests" or "/run-coredev-<major.minor>-robottests"
+            const match = body.match(/\/run-coredev(?:-([0-9]+\.[0-9]+))?-robottests/);
+            if (!match) {
+              core.setOutput('matched', 'false');
+              core.notice(`Comment matched the coarse filter but not the command syntax.`);
+              return;
+            }
+            const coredevBranch = match[1] || '';
+            core.setOutput('matched', 'true');
+            core.setOutput('coredev_branch', coredevBranch);
+
+            if (coredevBranch) {
+              try {
+                await github.rest.repos.getBranch({
+                  owner: 'plone',
+                  repo: 'buildout.coredev',
+                  branch: coredevBranch,
+                });
+              } catch (e) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `:x: Branch \`${coredevBranch}\` does not exist on plone/buildout.coredev.`,
+                });
+                core.setFailed(`Unknown coredev branch: ${coredevBranch}`);
+                return;
+              }
+            }
+
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -26,10 +63,13 @@ jobs:
             });
             const sha = pr.data.head.sha;
 
+            const checkName = coredevBranch
+              ? `Coredev robot tests (${coredevBranch})`
+              : 'Coredev robot tests';
             const check = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'Coredev robot tests',
+              name: checkName,
               head_sha: sha,
               status: 'in_progress',
               details_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
@@ -40,8 +80,9 @@ jobs:
 
   robot-tests:
     needs: create-check
+    if: needs.create-check.outputs.matched == 'true'
 
-    name: Coredev robot tests
+    name: Coredev robot tests ${{ needs.create-check.outputs.coredev_branch }}
     runs-on: ubuntu-latest
     env:
       PYTHONWARNINGS: ignore
@@ -61,8 +102,8 @@ jobs:
 
       - name: Info
         run: |
-          echo "Workflow triggered with comment '/run-coredev-robottests' "
-          echo "on PR #${{ github.event.issue.number }}"
+          echo "Workflow triggered by comment on PR #${{ github.event.issue.number }}"
+          echo "buildout.coredev branch: '${{ needs.create-check.outputs.coredev_branch }}' (empty = default branch)"
 
       - name: locale
         # needed for CMFPlone testUnicodeSplitter test on Ubuntu
@@ -80,6 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: plone/buildout.coredev
+          ref: ${{ needs.create-check.outputs.coredev_branch }}
           path: tests
 
       # ── 2. Node.js setup ──────────────────────────────────────────────────────
@@ -128,7 +170,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: robot-results
+          name: robot-results-${{ needs.create-check.outputs.coredev_branch || 'default' }}
           path: |
             tests/test_*
             tests/robot_*
@@ -136,7 +178,7 @@ jobs:
 
   update-check:
     needs: [create-check, robot-tests]
-    if: needs.create-check.outputs.check_run_id
+    if: always() && needs.create-check.outputs.check_run_id
     runs-on: ubuntu-latest
     steps:
       - name: Update Check Run


### PR DESCRIPTION
/run-coredev-robottests keeps testing against the default branch; /run-coredev-6.1-robottests (or 6.2, 6.3, ...) checks out that buildout.coredev branch instead. Unknown branches get an error comment. Also run update-check with always() so the check run no longer stays in_progress when the tests fail.


