### PR TITLE
Fix svelte MF shared runtime [5.6.x]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dependenciesComments": {
         "backbone": "Dependency moved to devDependencies since it requests oudated versions Underscore. Not fixing this dependencies in other bundles would make use paginator those outdated dependencies and result in a broken structure pattern.",
         "backbone.paginator": "Dependency moved to devDependencies since it requests oudated versions Underscore. Not fixing this dependencies in other bundles would make use paginator those outdated dependencies and result in a broken structure pattern.",
-        "select2": "Use the commit hash for checkout since pnpm has problems with the annotated commit #3.5.4"
+        "select2": "Use the commit hash for checkout since pnpm has problems with the annotated commit #3.5.4",
+        "svelte": "Runtime dependency: needs to be in dependencies so that it is part of the module federation shared dependencies and add-on bundles use the same Svelte runtime instance as this bundle."
     },
     "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
     "dependencies": {
@@ -44,6 +45,7 @@
         "slick-carousel": "git+https://github.com/kenwheeler/slick.git#d0716f19aa730006ee80ab026625fb1107816a97",
         "slides": "git+https://github.com/Patternslib/slides.git",
         "sortablejs": "^1.15.7",
+        "svelte": "^5.56.3",
         "tinymce": "8.6.0",
         "tinymce-i18n": "26.5.18",
         "underscore": "1.13.8"
@@ -59,7 +61,6 @@
         "npm-run-all2": "^8.0.4",
         "rimraf": "^6.1.3",
         "sinon": "^16.1.3",
-        "svelte": "^5.56.3",
         "svelte-jester": "^5.0.0",
         "svelte-loader": "^3.2.4",
         "svelte-scrollto": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "sinon": "^16.1.3",
         "svelte-jester": "^5.0.0",
         "svelte-loader": "^3.2.4",
-        "svelte-scrollto": "^0.2.0",
         "svg-inline-loader": "^0.8.2"
     },
     "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,6 @@ importers:
       svelte-loader:
         specifier: ^3.2.4
         version: 3.2.4(svelte@5.56.3)
-      svelte-scrollto:
-        specifier: ^0.2.0
-        version: 0.2.0
       svg-inline-loader:
         specifier: ^0.8.2
         version: 0.8.2
@@ -5211,13 +5208,6 @@ packages:
     resolution: {integrity: sha512-e0HdDnkYH/MDx4/IfTSka5AOFg9yYJcPuoZJB5x0l60fkHjVjNvrrxr+rJegDG9J7ZymmdHt00/hdLw+QF299w==}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0-next.0 || ^5.0.0-next.1
-
-  svelte-scrollto@0.2.0:
-    resolution: {integrity: sha512-l4K2E4jr6dXCODtZDCkpp/TzknVVoq8gecHM0UOOmihvLosczdyLuyDUhZ+U2HkhLWi7nnimuOstZSFKtXSpmA==}
-
-  svelte@3.59.2:
-    resolution: {integrity: sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==}
-    engines: {node: '>= 8'}
 
   svelte@5.56.3:
     resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
@@ -11532,12 +11522,6 @@ snapshots:
       svelte: 5.56.3
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.56.3)
-
-  svelte-scrollto@0.2.0:
-    dependencies:
-      svelte: 3.59.2
-
-  svelte@3.59.2: {}
 
   svelte@5.56.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       sortablejs:
         specifier: ^1.15.7
         version: 1.15.7
+      svelte:
+        specifier: ^5.56.3
+        version: 5.56.3
       tinymce:
         specifier: 8.6.0
         version: 8.6.0
@@ -145,9 +148,6 @@ importers:
       sinon:
         specifier: ^16.1.3
         version: 16.1.3
-      svelte:
-        specifier: ^5.56.3
-        version: 5.56.3
       svelte-jester:
         specifier: ^5.0.0
         version: 5.0.0(jest@30.4.2(@types/node@25.9.2))(svelte@5.56.3)
@@ -2059,7 +2059,7 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   Select2@https://codeload.github.com/ivaynberg/select2/tar.gz/95a977f674b6938af55ec5f28b7772df93786c5c:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/ivaynberg/select2/tar.gz/95a977f674b6938af55ec5f28b7772df93786c5c}
+    resolution: {gitHosted: true, integrity: sha512-42On0yUzjhE/vNTVRT/+3wUwIpKyUGEW31PA1gFRv0j+OjgXJgo4aJVWCfjEpMa+O34PYKCfEdUN0OWaAEQ/6Q==, tarball: https://codeload.github.com/ivaynberg/select2/tar.gz/95a977f674b6938af55ec5f28b7772df93786c5c}
     version: 3.5.4
 
   a-sync-waterfall@1.0.1:

--- a/src/pat/contentbrowser/README.md
+++ b/src/pat/contentbrowser/README.md
@@ -36,7 +36,7 @@ Show a widget to select items in an offcanvas miller-column browser.
 | recentlyUsed               | boolean | false                                   | Show the recently used items dropdown.                                                                                                           |
 | recentlyUsedKey            | integer |                                         | Storage key for saving the recently used items. This is generated with fieldname and username in the patternoptions.                             |
 | recentlyUsedMaxItems       | integer | 20                                      | Maximum items to keep in recently used list. 0: no restriction.                                                                                  |
-| customComponentKeys        | dict    | {}                                      | Register custom components. Currently only "SelectedItem" implemented                                                                            |
+| componentRegistryKeys      | dict    | {}                                      | Use custom components registered in the `@plone/registry` component registry. Currently only "selectedItem" is implemented.                      |
 | searchIndex                | string  | "SearchableText"                        | Catalog search index for filtering and search mode. (Note: only ZCTextIndex allowed)                                                             |
 
 
@@ -93,24 +93,25 @@ Show a widget to select items in an offcanvas miller-column browser.
 
 ## Register custom component
 
-Use the `customComponentKeys.selectedItem` configuration value as follows to override the `SelectedItems` compontent (only supported component currently).
+Use the `componentRegistryKeys.selectedItem` configuration value as follows to override the `SelectedItem` component (only supported component currently).
 
 ```html
 <input
     type="text"
     class="pat-contentbrowser"
     data-pat-contentbrowser='{
-        "customComponentKeys": {
-            "SelectedItem": "pat-contentbrowser.myfield.MySelectedItemComponent",
-        },
+        "componentRegistryKeys": {
+            "selectedItem": "pat-contentbrowser.myfield.MySelectedItemComponent"
+        }
     }'
 />
 ```
 
 Copy the existing component `src/SelectedItem.svelte` to your addon, customize it and register it in your JS bundle as follows:
 
-Note: the `name` of the registered component must match the `customComponentKeys.selectedItem` config value defined above.
+Note: the `name` of the registered component must match the `componentRegistryKeys.selectedItem` config value defined above.
 It can be any unique identifier.
+If no custom component is registered for the configured key, the pattern falls back to the default component registered as `pat-contentbrowser.SelectedItem`.
 
 ```javascript
 ...
@@ -133,4 +134,27 @@ register_selecteditem_component();
 ```
 
 Note: this needs the `svelte-loader` plugin in your webpack.config.js ... see mockups `webpack.config.js` for more info.
+
+Your add-on bundle also has to share the Svelte runtime via module federation, so that your component runs on the same runtime instance as the Plone bundle.
+Add the same `svelte` and `svelte/` shared entries as in mockups `webpack.config.js` to your module federation config:
+
+```javascript
+mf_config({
+    name: package_json.name,
+    remote_entry: config.entry["mybundle.min"],
+    dependencies: {
+        ...package_json.dependencies,
+    },
+    shared: {
+        svelte: {
+            singleton: true,
+            requiredVersion: package_json.dependencies["svelte"],
+        },
+        "svelte/": {
+            singleton: true,
+            requiredVersion: package_json.dependencies["svelte"],
+        },
+    },
+});
+```
 

--- a/src/pat/contentbrowser/src/ContentBrowser.svelte
+++ b/src/pat/contentbrowser/src/ContentBrowser.svelte
@@ -1,7 +1,6 @@
 <script>
     import utils from "@patternslib/patternslib/src/core/utils";
     import { getContext } from "svelte";
-    import * as animateScroll from "svelte-scrollto";
     import { fly } from "svelte/transition";
     import _t from "../../../core/i18n-wrapper";
     import Upload from "../../upload/upload";
@@ -17,12 +16,6 @@
     } from "./utils";
     import Favorites from "./Favorites.svelte";
     import RecentlyUsed from "./RecentlyUsed.svelte";
-
-    animateScroll.setGlobalOptions({
-        scrollX: true,
-        container: ".levelColumns",
-        duration: 500,
-    });
 
     // get context stores
     const currentPath = getContext("currentPath");
@@ -389,9 +382,9 @@
     function scrollToRight() {
         const scrollContainer = document.querySelector(".levelColumns");
         if (scrollContainer) {
-            animateScroll.scrollTo({
-                // element: ".levelColumn:last-child",
-                x: scrollContainer.scrollWidth + 100,
+            scrollContainer.scrollTo({
+                left: scrollContainer.scrollWidth + 100,
+                behavior: "smooth",
             });
         }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,6 +148,25 @@ module.exports = () => {
                     requiredVersion: package_json.dependencies["jquery"],
                     eager: true,
                 },
+                // Share the Svelte runtime with remote (add-on) bundles.
+                // Svelte keeps its reactivity state (effect tree, etc.) in
+                // module-level variables, so host and remotes must use the
+                // very same runtime instance — otherwise a Svelte component
+                // registered by an add-on (e.g. via @plone/registry for
+                // pat-contentbrowser's ``componentRegistryKeys``) cannot be
+                // mounted by this bundle.
+                svelte: {
+                    singleton: true,
+                    requiredVersion: package_json.dependencies["svelte"],
+                },
+                // Prefix share ("svelte/"): compiled Svelte components do not
+                // import "svelte" itself but subpaths like
+                // "svelte/internal/client", which an exact-match share entry
+                // does not cover.
+                "svelte/": {
+                    singleton: true,
+                    requiredVersion: package_json.dependencies["svelte"],
+                },
             },
         })
     );


### PR DESCRIPTION
commit 2cd08c5a9c0b3c8ec0f89bd01d45606cfdf5f462: During preparing the training here https://github.com/collective/blicca.staticresourceoverride/blob/main/TRAINING.md I came across this one. Currently the runtime has to be "bridged" in your addon if you like to override components. With this we share the runtime from mockup and addons can easily use it. If merged, this is not necessary anymore: https://github.com/collective/blicca.staticresourceoverride/blob/main/resources/contentbrowser/mount-bridge.js 

commit 4f60a421c331acfff4970e7c426a9783844f19a1: remove obsolete dependency and use native "smooth" scrolling

commit 3f73bcb404aed39c83ed2584422d43ce48fde2fe: fix wrong documented registry key