### PR TITLE
Add Option to translate column to columnDef

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2320,8 +2320,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.34:
-    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+  baseline-browser-mapping@2.11.11:
+    resolution: {integrity: sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4747,8 +4747,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.2.7:
-    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+  react-is@19.2.8:
+    resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -8521,7 +8521,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.34: {}
+  baseline-browser-mapping@2.11.11: {}
 
   basic-ftp@5.3.1: {}
 
@@ -8599,7 +8599,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.34
+      baseline-browser-mapping: 2.11.11
       caniuse-lite: 1.0.30001790
       electron-to-chromium: 1.5.368
       node-releases: 2.0.47
@@ -11016,7 +11016,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.7
+      react-is-19: react-is@19.2.8
 
   prismjs@1.30.0: {}
 
@@ -11082,7 +11082,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.2.7: {}
+  react-is@19.2.8: {}
 
   react@19.2.4: {}
 

--- a/src/pat/filemanager/src/components/ColumnCell.svelte
+++ b/src/pat/filemanager/src/components/ColumnCell.svelte
@@ -29,8 +29,8 @@
 
     function displayValue(value) {
         if (value == null) return "";
-        if (column.valueI18n === "plone") return _tp(String(value));
-        if (column.valueI18n === "patternslib") return _t(String(value));
+        if (column.translationDomain === "plone") return _tp(String(value));
+        if (column.translationDomain === "widgets") return _t(String(value));
         return value;
     }
 

--- a/src/pat/filemanager/src/components/ColumnCell.svelte
+++ b/src/pat/filemanager/src/components/ColumnCell.svelte
@@ -27,6 +27,13 @@
     // raw-content object URL. Folderish titles drill in-app (onTitleClick).
     const openUrl = $derived(contents.config.viewUrl(item));
 
+    function displayValue(value) {
+        if (value == null) return "";
+        if (column.valueI18n === "plone") return _tp(String(value));
+        if (column.valueI18n === "patternslib") return _t(String(value));
+        return value;
+    }
+
     // Folderish titles drill into the folder in-app; everything else keeps the
     // plain link so the object opens normally.
     function onTitleClick(event) {
@@ -72,7 +79,7 @@
     {formatDate(value)}
 {:else if column.type === "state"}
     {#if value}
-        <span class="filemanager-state state-{value}">{_tp(value)}</span>
+        <span class="filemanager-state state-{value}">{displayValue(value)}</span>
     {/if}
 {:else if column.type === "tags"}
     {#each tags as tag (tag)}
@@ -81,5 +88,5 @@
 {:else if column.key === "getObjSize"}
     {formatSize(value)}
 {:else}
-    {value ?? ""}
+    {displayValue(value)}
 {/if}

--- a/src/pat/filemanager/src/stores/ConfigStore.svelte.ts
+++ b/src/pat/filemanager/src/stores/ConfigStore.svelte.ts
@@ -14,7 +14,7 @@ export interface ColumnDef {
     /** catalog index to sort on; omit for non-sortable columns */
     sortIndex?: string;
     /** translation domain for catalog values; omit for user-authored/raw values */
-    valueI18n?: "patternslib" | "plone";
+    translationDomain?: "widgets" | "plone";
     type: ColumnType;
 }
 
@@ -25,14 +25,14 @@ export const COLUMN_DEFS: Record<string, ColumnDef> = {
         key: "portal_type",
         label: "Type",
         sortIndex: "portal_type",
-        valueI18n: "plone",
+        translationDomain: "plone",
         type: "text",
     },
     review_state: {
         key: "review_state",
         label: "State",
         sortIndex: "review_state",
-        valueI18n: "plone",
+        translationDomain: "plone",
         type: "state",
     },
     ModificationDate: { key: "ModificationDate", label: "Modified", sortIndex: "modified", type: "date" },

--- a/src/pat/filemanager/src/stores/ConfigStore.svelte.ts
+++ b/src/pat/filemanager/src/stores/ConfigStore.svelte.ts
@@ -13,14 +13,28 @@ export interface ColumnDef {
     field?: string;
     /** catalog index to sort on; omit for non-sortable columns */
     sortIndex?: string;
+    /** translation domain for catalog values; omit for user-authored/raw values */
+    valueI18n?: "patternslib" | "plone";
     type: ColumnType;
 }
 
 export const COLUMN_DEFS: Record<string, ColumnDef> = {
     image: { key: "image", label: "Preview", field: "image_scales", type: "image" },
     Title: { key: "Title", label: "Title", sortIndex: "sortable_title", type: "title" },
-    portal_type: { key: "portal_type", label: "Type", sortIndex: "portal_type", type: "text" },
-    review_state: { key: "review_state", label: "State", sortIndex: "review_state", type: "state" },
+    portal_type: {
+        key: "portal_type",
+        label: "Type",
+        sortIndex: "portal_type",
+        valueI18n: "plone",
+        type: "text",
+    },
+    review_state: {
+        key: "review_state",
+        label: "State",
+        sortIndex: "review_state",
+        valueI18n: "plone",
+        type: "state",
+    },
     ModificationDate: { key: "ModificationDate", label: "Modified", sortIndex: "modified", type: "date" },
     CreationDate: { key: "CreationDate", label: "Created", sortIndex: "created", type: "date" },
     EffectiveDate: { key: "EffectiveDate", label: "Published", sortIndex: "effective", type: "date" },

--- a/src/pat/filemanager/src/stores/ContentsStore.test.ts
+++ b/src/pat/filemanager/src/stores/ContentsStore.test.ts
@@ -721,9 +721,9 @@ describe("ConfigStore", () => {
     it("resolves a column definition by key", () => {
         const config = new ConfigStore({ contextUrl: "http://nohost/plone" });
         expect(config.column("ModificationDate").type).toBe("date");
-        expect(config.column("portal_type").valueI18n).toBe("plone");
-        expect(config.column("review_state").valueI18n).toBe("plone");
-        expect(config.column("Title").valueI18n).toBeUndefined();
+        expect(config.column("portal_type").translationDomain).toBe("plone");
+        expect(config.column("review_state").translationDomain).toBe("plone");
+        expect(config.column("Title").translationDomain).toBeUndefined();
         expect(config.column("unknown")).toEqual({
             key: "unknown",
             label: "unknown",

--- a/src/pat/filemanager/src/stores/ContentsStore.test.ts
+++ b/src/pat/filemanager/src/stores/ContentsStore.test.ts
@@ -721,6 +721,9 @@ describe("ConfigStore", () => {
     it("resolves a column definition by key", () => {
         const config = new ConfigStore({ contextUrl: "http://nohost/plone" });
         expect(config.column("ModificationDate").type).toBe("date");
+        expect(config.column("portal_type").valueI18n).toBe("plone");
+        expect(config.column("review_state").valueI18n).toBe("plone");
+        expect(config.column("Title").valueI18n).toBeUndefined();
         expect(config.column("unknown")).toEqual({
             key: "unknown",
             label: "unknown",


### PR DESCRIPTION
I added an option in columnDef in the pat-filemanager that allows to enable translation for columns.

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization. 
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits. (I did not, because I could find nothing in the docs about how to create changelog entries in JS projects)

-----

Closes #1621