### PR TITLE
deploy docs only on push to master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         make docs
     - name: Deploy docs
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         publish_dir: ./_site


### PR DESCRIPTION
The deploy step also ran on pull_request events and published the PR build to gh_docs_deploy. Since the branch got protected, the push is rejected and every PR fails the docs job. Skip the deploy for PR builds; they only need to verify that the docs build.

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

