### PR TITLE
feat(pat-contentbrowser): Initialize patterns on selected items.

### DIFF
--- a/src/pat/contentbrowser/src/SelectedItems.svelte
+++ b/src/pat/contentbrowser/src/SelectedItems.svelte
@@ -4,6 +4,7 @@
     import Sortable from "sortablejs";
     import _t from "../../../core/i18n-wrapper";
     import events from "@patternslib/patternslib/src/core/events";
+    import registry from "@patternslib/patternslib/src/core/registry";
     import plone_registry from "@plone/registry";
 
     let ref = $state();
@@ -109,6 +110,7 @@
             target: node,
             props: props,
         });
+        registry.scan(node);
     }
 
     $effect(() => {


### PR DESCRIPTION
Do a registry scan on the selected items template, so that customizations can use Patterns in their SelectedItems.svelte templates.

