### PR TITLE
feat(core): getCriterias preserves non-ASCII terms raw (encode-exactly-once)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,11 @@ config.transformIgnorePatterns = [
     "/node_modules/.pnpm/(?!@patternslib)(?!@plone)(?!@formatjs)(?!preact)(?!screenfull)(?!sinon)(?!bootstrap)(?!datatable)(?!svelte)(?!esm-env)",
 ];
 
+// The structure pattern tests take up to ~3s each on GitHub Actions runners
+// (about 2x slower than a local run), so the default 5s timeout is too
+// tight and fails sporadically. Give all tests a bit more room.
+config.testTimeout = 10000;
+
 // Transforms. Order matters: Jest uses the first matching pattern, so the
 // runes-in-module rule (.svelte.ts / .svelte.js) must precede the generic
 // babel rule (which would otherwise also match `.svelte.ts`).

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -115,6 +115,14 @@ describe("utils", function () {
                 '{"criteria":[{"i":"SearchableText","o":"plone.app.querystring.operation.string.contains","v":"foobar*"}],"sort_on":"is_folderish","sort_order":"reverse"}'
             );
         });
+        it("getCriterias keeps non-ASCII term raw (encode-exactly-once)", function () {
+            var qh = new utils.QueryHelper({
+                vocabularyUrl: "http://foobar.com/",
+            });
+            var criterias = qh.getCriterias("täst");
+            expect(criterias[0].v).toEqual("täst*");
+            expect(criterias[0].v).not.toContain("%");
+        });
         it("getQueryData use attributes correctly", function () {
             var qh = new utils.QueryHelper({
                 vocabularyUrl: "http://foobar.com/",
@@ -167,6 +175,15 @@ describe("utils", function () {
             );
         });
 
+        it("getCriterias keeps non-ASCII terms raw (encode-exactly-once)", function () {
+            var qh = new utils.QueryHelper({
+                vocabularyUrl: "http://foobar.com/",
+            });
+            var criterias = qh.getCriterias("täst");
+            var crit = criterias[criterias.length - 1];
+            expect(crit.v).toEqual("täst*");
+            expect(crit.v).not.toContain("%");
+        });
         it("browsing adds path criteria", function () {
             var qh = new utils.QueryHelper({
                 vocabularyUrl: "http://foobar.com/?foo=bar",

--- a/src/pat/structure/js/views/textfilter.js
+++ b/src/pat/structure/js/views/textfilter.js
@@ -68,7 +68,7 @@ export default BaseView.extend({
 
     setTerm: function (term, set_input) {
         const term_el = this.$el[0].querySelector(".search-query");
-        this.term = encodeURIComponent(term);
+        this.term = term;
         if (set_input) {
             term_el.value = term;
         }


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Closes https://github.com/plone/Products.CMFPlone/issues/4366

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2924a840-cb3c-4600-816c-2fdb4f6ab75d" />
